### PR TITLE
feat(go-handler,swift-email): dock badge and sidebar unread counts

### DIFF
--- a/cli/cmd/durian/serve.go
+++ b/cli/cmd/durian/serve.go
@@ -70,6 +70,7 @@ func runServe(cmd *cobra.Command, args []string) {
 
 	r := mux.NewRouter()
 	r.HandleFunc("/api/v1/search", h.SearchHandler).Methods("GET")
+	r.HandleFunc("/api/v1/search/count", h.SearchCountHandler).Methods("GET")
 	r.HandleFunc("/api/v1/tags", h.ListTagsHandler).Methods("GET")
 	r.HandleFunc("/api/v1/threads/{thread_id}", h.ShowThreadHandler).Methods("GET")
 	r.HandleFunc("/api/v1/threads/{thread_id}/tags", h.TagThreadHandler).Methods("POST")

--- a/cli/internal/handler/http.go
+++ b/cli/internal/handler/http.go
@@ -50,6 +50,25 @@ func (h *Handler) SearchHandler(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, response)
 }
 
+// SearchCountHandler handles GET /api/v1/search/count?query=...
+// Returns {"count": N} for the number of matching threads.
+func (h *Handler) SearchCountHandler(w http.ResponseWriter, r *http.Request) {
+	query := r.URL.Query().Get("query")
+	if query == "" {
+		http.Error(w, "Missing required 'query' parameter", http.StatusBadRequest)
+		return
+	}
+
+	count, err := h.store.SearchCount(query)
+	if err != nil {
+		slog.Error("Search count failed", "module", "HANDLER", "query", query, "err", err)
+		http.Error(w, "internal error", http.StatusInternalServerError)
+		return
+	}
+
+	writeJSON(w, map[string]int{"count": count})
+}
+
 func (h *Handler) ShowThreadHandler(w http.ResponseWriter, r *http.Request) {
 	vars := mux.Vars(r)
 	threadID := vars["thread_id"]

--- a/cli/internal/handler/http_test.go
+++ b/cli/internal/handler/http_test.go
@@ -19,6 +19,7 @@ import (
 func newTestRouter(h *Handler, hub *EventHub) *mux.Router {
 	r := mux.NewRouter()
 	r.HandleFunc("/api/v1/search", h.SearchHandler).Methods("GET")
+	r.HandleFunc("/api/v1/search/count", h.SearchCountHandler).Methods("GET")
 	r.HandleFunc("/api/v1/tags", h.ListTagsHandler).Methods("GET")
 	r.HandleFunc("/api/v1/threads/{thread_id}", h.ShowThreadHandler).Methods("GET")
 	r.HandleFunc("/api/v1/threads/{thread_id}/tags", h.TagThreadHandler).Methods("POST")
@@ -108,6 +109,41 @@ func TestSearchHandler_InvalidLimit(t *testing.T) {
 	r := newTestRouter(h, nil)
 
 	req := httptest.NewRequest("GET", "/api/v1/search?query=test&limit=abc", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("status = %d, want 400", w.Code)
+	}
+}
+
+func TestSearchCountHandler_OK(t *testing.T) {
+	db := newTestStore(t)
+	seedStoreData(t, db)
+	h := New(db, nil)
+	r := newTestRouter(h, nil)
+
+	req := httptest.NewRequest("GET", "/api/v1/search/count?query=tag:inbox", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", w.Code)
+	}
+
+	var resp map[string]int
+	json.NewDecoder(w.Body).Decode(&resp)
+	if resp["count"] == 0 {
+		t.Error("expected non-zero count for tag:inbox")
+	}
+}
+
+func TestSearchCountHandler_MissingQuery(t *testing.T) {
+	db := newTestStore(t)
+	h := New(db, nil)
+	r := newTestRouter(h, nil)
+
+	req := httptest.NewRequest("GET", "/api/v1/search/count", nil)
 	w := httptest.NewRecorder()
 	r.ServeHTTP(w, req)
 

--- a/cli/internal/store/search.go
+++ b/cli/internal/store/search.go
@@ -6,6 +6,25 @@ import (
 	"time"
 )
 
+// SearchCount returns the number of threads matching a query.
+func (d *DB) SearchCount(query string) (int, error) {
+	where, params, err := parseQuery(query)
+	if err != nil {
+		return 0, fmt.Errorf("parse query: %w", err)
+	}
+
+	q := "SELECT COUNT(DISTINCT m.thread_id) FROM messages m"
+	if where != "" {
+		q += " WHERE " + where
+	}
+
+	var count int
+	if err := d.db.QueryRow(q, params...).Scan(&count); err != nil {
+		return 0, fmt.Errorf("search count: %w", err)
+	}
+	return count, nil
+}
+
 // Search finds threads matching a search query string.
 // Results are grouped by thread and ordered by most recent message date descending.
 func (d *DB) Search(query string, limit int) ([]SearchResult, error) {

--- a/gui/durian/ContentView.swift
+++ b/gui/durian/ContentView.swift
@@ -209,8 +209,21 @@ struct ContentView: View {
                 List(selection: $selectedTagID) {
                     Section("Tags") {
                         ForEach(accountManager.mailFolders) { folder in
-                            Label(folder.displayName, systemImage: folder.icon)
-                                .tag(folder.name)
+                            Label {
+                                HStack {
+                                    Text(folder.displayName)
+                                    Spacer()
+                                    if let count = accountManager.folderUnreadCounts[folder.name], count > 0 {
+                                        Text("\(count)")
+                                            .font(.caption2)
+                                            .fontWeight(.medium)
+                                            .foregroundStyle(.secondary)
+                                    }
+                                }
+                            } icon: {
+                                Image(systemName: folder.icon)
+                            }
+                            .tag(folder.name)
                         }
                     }
                 }
@@ -559,18 +572,22 @@ struct ContentView: View {
         visualModeAnchor = nil
         keymapHandler.engine.exitVisualMode()
         advanceCursor(to: next)
-        Task { await accountManager.deleteMessages(ids: ids) }
+        Task {
+            await accountManager.deleteMessages(ids: ids)
+            await accountManager.refreshFolderCounts()
+        }
     }
-    
+
     private func togglePin() {
         guard let emailId = markedEmails.first else { return }
         Task { await accountManager.togglePin(id: emailId) }
     }
-    
+
     private func toggleRead() {
         guard !markedEmails.isEmpty else { return }
         Task {
             await accountManager.toggleReadForMessages(ids: markedEmails)
+            await accountManager.refreshFolderCounts()
             await MainActor.run {
                 // Exit visual mode after batch action
                 if keymapHandler.engine.isVisualMode {
@@ -889,6 +906,7 @@ struct ContentView: View {
                     for id in ids {
                         await accountManager.modifyTags(id: id, add: ["archive"], remove: ["inbox"])
                     }
+                    await accountManager.refreshFolderCounts()
                 }
             }
         }

--- a/gui/durian/DurianApp.swift
+++ b/gui/durian/DurianApp.swift
@@ -59,7 +59,7 @@ struct DurianApp: App {
     }
 
     private func requestNotificationPermission() {
-        UNUserNotificationCenter.current().requestAuthorization(options: [.alert, .sound]) { granted, error in
+        UNUserNotificationCenter.current().requestAuthorization(options: [.alert, .sound, .badge]) { granted, error in
             if granted {
                 Log.info("NOTIFICATIONS", "Permission granted")
             } else if let error = error {

--- a/gui/durian/Managers/AccountManager.swift
+++ b/gui/durian/Managers/AccountManager.swift
@@ -22,6 +22,9 @@ class AccountManager: ObservableObject {
 
     /// Set by notification click handler; ContentView observes and navigates to this thread
     @Published var pendingNotificationThreadId: String?
+
+    /// Unread thread counts per folder name (for sidebar badges)
+    @Published var folderUnreadCounts: [String: Int] = [:]
     
     private var cancellables = Set<AnyCancellable>()
     
@@ -60,6 +63,30 @@ class AccountManager: ObservableObject {
         loadingProgress = backend.loadingProgress
     }
     
+    // MARK: - Folder Unread Counts & Dock Badge
+
+    /// Refresh unread counts for all sidebar folders and update dock badge.
+    func refreshFolderCounts() async {
+        guard let backend = emailBackend else { return }
+
+        var counts: [String: Int] = [:]
+        for folder in mailFolders {
+            let folderQuery = ProfileManager.shared.buildQuery(folderName: folder.displayName)
+            let unreadQuery = "(\(folderQuery)) AND tag:unread"
+            let count = await backend.searchCount(query: unreadQuery)
+            Log.debug("COUNTS", "\(folder.name): \(count) unread (query: \(unreadQuery))")
+            if count > 0 {
+                counts[folder.name] = count
+            }
+        }
+        folderUnreadCounts = counts
+
+        // Update dock badge with total inbox unread
+        let inboxCount = counts["inbox"] ?? 0
+        Log.debug("COUNTS", "Dock badge: \(inboxCount)")
+        NSApp.dockTile.badgeLabel = inboxCount > 0 ? "\(inboxCount)" : nil
+    }
+
     // MARK: - Connection
     
     func connectToAllAccounts() async {
@@ -70,6 +97,7 @@ class AccountManager: ObservableObject {
         }
         await backend.connect()
         syncFromBackend()
+        await refreshFolderCounts()
     }
     
     // MARK: - Folder/Tag Selection
@@ -80,6 +108,7 @@ class AccountManager: ObservableObject {
         mailMessages.removeAll()
         await backend.selectFolder(tag)
         syncFromBackend()
+        await refreshFolderCounts()
     }
     
     // MARK: - Profile Switching

--- a/gui/durian/Managers/SyncManager.swift
+++ b/gui/durian/Managers/SyncManager.swift
@@ -413,6 +413,7 @@ class SyncManager: ObservableObject {
             Task { @MainActor in
                 guard let backend = AccountManager.shared.emailBackend else { return }
                 await backend.reload()
+                await AccountManager.shared.refreshFolderCounts()
                 self?.lastSyncTime = Date()
             }
         }

--- a/gui/durian/Network/EmailBackend.swift
+++ b/gui/durian/Network/EmailBackend.swift
@@ -285,6 +285,14 @@ class EmailBackend: ObservableObject {
         }
     }
 
+    /// Returns the number of threads matching a query.
+    func searchCount(query: String) async -> Int {
+        struct CountResponse: Decodable { let count: Int }
+        let encoded = query.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? query
+        let response: CountResponse? = await request(endpoint: "/search/count?query=\(encoded)")
+        return response?.count ?? 0
+    }
+
     private func performRequest<T: Decodable>(endpoint: String, method: String, bodyData: Data?) async -> T? {
         guard let url = URL(string: "\(baseURL)\(endpoint)") else {
             Log.error("BACKEND", "Invalid URL")

--- a/gui/durian/SettingsManager.swift
+++ b/gui/durian/SettingsManager.swift
@@ -78,16 +78,16 @@ struct AppSettings: Codable {
     var notificationsEnabled: Bool = true
     var theme: String = "system"
     var loadRemoteImages: Bool = false  // Security: block tracking pixels by default
-    
+
     enum CodingKeys: String, CodingKey {
         case notificationsEnabled = "notifications_enabled"
         case theme
         case loadRemoteImages = "load_remote_images"
     }
-    
+
     // Default initializer
     init() {}
-    
+
     // Custom decoder that handles missing keys gracefully
     init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)


### PR DESCRIPTION
## Summary
- **Backend:** new `GET /api/v1/search/count?query=...` endpoint (thread count without full results)
- **Dock badge:** inbox unread count via `NSApp.dockTile.badgeLabel` (added `.badge` to notification permissions)
- **Sidebar:** unread thread counts per folder
- Counts refresh on: folder selection, connect, SSE new_mail, archive, delete, toggle read

## Test
- Toggle read (u) → sidebar count + dock badge update
- Archive (a) / delete (dd) → counts decrease
- New mail arrives → counts increase via SSE