### PR TITLE
fix: sanitize attachment filename to prevent path traversal

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,10 @@ durian sync --debug                   # debug output on stderr
 - [OAuth Setup](docs/OAUTH_SETUP.md) — Gmail & Microsoft 365
 - [Password Setup](docs/PASSWORD_SETUP.md) — IMAP/SMTP with password auth
 
+## Contributing
+
+Found a bug or have a feature request? [Open an issue](https://github.com/julion2/Durian/issues).
+
 ## License
 
 [MIT](LICENSE)

--- a/cli/cmd/durian/attachment.go
+++ b/cli/cmd/durian/attachment.go
@@ -106,7 +106,11 @@ func runAttachment(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	outPath := filepath.Join(attachOutput, att.Filename)
+	safeFilename := filepath.Base(att.Filename)
+	if safeFilename == "" || safeFilename == "." {
+		safeFilename = "attachment"
+	}
+	outPath := filepath.Join(attachOutput, safeFilename)
 	f, err := os.Create(outPath)
 	if err != nil {
 		return fmt.Errorf("create file: %w", err)


### PR DESCRIPTION
Use filepath.Base() on filename before writing. Prevents directory traversal via malicious IMAP attachment names.