### PR TITLE
fix(ci): release build with -c opt + ci=true

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,7 +33,7 @@ jobs:
 
       - name: Build GUI
         run: |
-          bazel build --define ci=true //gui:Durian
+          bazel build -c opt --define ci=true //gui:Durian
           cp bazel-bin/gui/Durian.zip dist/Durian-${{ steps.version.outputs.version }}.zip
 
       - name: Package

--- a/gui/BUILD.bazel
+++ b/gui/BUILD.bazel
@@ -8,7 +8,10 @@ config_setting(
 
 config_setting(
     name = "ci",
-    values = {"define": "ci=true"},
+    values = {
+        "define": "ci=true",
+        "compilation_mode": "opt",
+    },
 )
 
 # Full app library (includes @main entry point) — used by macos_application


### PR DESCRIPTION
Fixes Durian.app vs DurianNightly.app in release ZIP and ambiguous select.