### PR TITLE
fix: 5 bugs — sync, parser, threading, DNS rebinding

### DIFF
--- a/cli/cmd/durian/serve.go
+++ b/cli/cmd/durian/serve.go
@@ -70,6 +70,17 @@ func runServe(cmd *cobra.Command, args []string) {
 	eventHub := handler.NewEventHub()
 
 	r := mux.NewRouter()
+	r.Use(func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+			host := req.Host
+			if host != "localhost:9723" && host != "127.0.0.1:9723" &&
+				host != "localhost" && host != "127.0.0.1" {
+				http.Error(w, "forbidden", http.StatusForbidden)
+				return
+			}
+			next.ServeHTTP(w, req)
+		})
+	})
 	r.HandleFunc("/api/v1/version", func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		json.NewEncoder(w).Encode(map[string]string{

--- a/cli/internal/imap/sync.go
+++ b/cli/internal/imap/sync.go
@@ -1228,12 +1228,18 @@ func (s *Syncer) storeInsertMessage(mailboxName string, imapMsg *goimap.Message,
 	content := s.parser.Parse(parsed)
 	messageID := strings.Trim(content.MessageID, "<>")
 	if messageID == "" {
-		return nil // Can't store without Message-ID
+		// Generate synthetic Message-ID from UID + account to avoid losing the message
+		messageID = fmt.Sprintf("durian-synthetic-%d-%s@%s", imapMsg.Uid, mailboxName, s.accountName())
+		slog.Warn("Message has no Message-ID, using synthetic ID", "module", "SYNC",
+			"uid", imapMsg.Uid, "mailbox", mailboxName, "synthetic_id", messageID)
 	}
 
 	var dateUnix int64
 	if t, err := mail.ParseDate(content.Date); err == nil {
 		dateUnix = t.Unix()
+	} else {
+		// Fallback to IMAP internal date
+		dateUnix = imapMsg.InternalDate.Unix()
 	}
 
 	storeMsg := &store.Message{

--- a/cli/internal/store/search.go
+++ b/cli/internal/store/search.go
@@ -224,9 +224,12 @@ func lex(query string) []lexToken {
 //	unary    → "NOT" unary | primary
 //	primary  → "(" expr ")" | field:value | bare_word | "*"
 
+const maxParseDepth = 50
+
 type parser struct {
 	tokens []lexToken
 	pos    int
+	depth  int
 }
 
 func (p *parser) peek() lexToken {
@@ -319,8 +322,13 @@ func (p *parser) parsePrimary() (exprNode, error) {
 	tok := p.peek()
 	switch tok.kind {
 	case tokLParen:
+		p.depth++
+		if p.depth > maxParseDepth {
+			return nil, fmt.Errorf("query too deeply nested (max %d levels)", maxParseDepth)
+		}
 		p.next()
 		node, err := p.parseExpr()
+		p.depth--
 		if err != nil {
 			return nil, err
 		}

--- a/cli/internal/store/threads.go
+++ b/cli/internal/store/threads.go
@@ -84,5 +84,19 @@ func resolveThreadID(tx *sql.Tx, messageID, inReplyTo, references string) (strin
 	}
 
 	// No existing thread found — compute a new one
-	return computeThreadID(messageID, inReplyTo, references), nil
+	threadID := computeThreadID(messageID, inReplyTo, references)
+
+	// Check if any existing messages reference this message (child arrived before parent).
+	// If so, adopt their thread ID to keep the conversation together.
+	cleanedID := cleanMessageID(messageID)
+	var existingThreadID string
+	err := tx.QueryRow(
+		"SELECT thread_id FROM messages WHERE in_reply_to LIKE ? OR refs LIKE ? LIMIT 1",
+		"%"+cleanedID+"%", "%"+cleanedID+"%",
+	).Scan(&existingThreadID)
+	if err == nil && existingThreadID != "" {
+		return existingThreadID, nil
+	}
+
+	return threadID, nil
 }

--- a/cli/internal/store/threads_test.go
+++ b/cli/internal/store/threads_test.go
@@ -264,10 +264,11 @@ func TestResolveThreadID_CrossBatchSplit_DifferentRoot(t *testing.T) {
 	child, _ := db.GetByMessageID("child2@x")
 	parent, _ := db.GetByMessageID("parent2@x")
 
-	// child hashed grandparent2@x, parent hashed parent2@x → different thread IDs
-	if child.ThreadID == parent.ThreadID {
-		t.Errorf("expected split threads for cross-batch with different roots, but got same: %q",
-			child.ThreadID)
+	// Parent arrives after child — reverse-lookup finds the child referencing parent,
+	// so parent adopts child's thread ID. Conversation stays together.
+	if child.ThreadID != parent.ThreadID {
+		t.Errorf("expected same thread (parent adopted child's thread), got child=%q parent=%q",
+			child.ThreadID, parent.ThreadID)
 	}
 }
 


### PR DESCRIPTION
Closes #80 #81 #82 #83 #90

| Issue | Fix |
|-------|-----|
| #82 P1 | Synthetic Message-ID for messages without one |
| #80 P2 | IMAP InternalDate fallback for missing Date header |
| #81 P2 | Query parser max depth 50 |
| #83 P2 | Thread merge when parent arrives after child |
| #90 P3 | Host header check against DNS rebinding |