### PR TITLE
fix(swift-keymaps): keymaps work when email body has focus

### DIFF
--- a/gui/durian/Keymaps/KeymapHandler.swift
+++ b/gui/durian/Keymaps/KeymapHandler.swift
@@ -247,10 +247,9 @@ class KeymapHandler: ObservableObject {
             return true
         }
 
-        // WKWebView with contentEditable (e.g. EditableWebView in compose)
-        if firstResponder is WKWebView {
-            return true
-        }
+        // WKWebView is not checked here — compose runs in a separate window
+        // and handles its own key events. The main window's read-only email
+        // WebView should not block keymaps.
 
         return false
     }


### PR DESCRIPTION
Read-only email WebView no longer blocks vim keymaps. Only the compose editor blocks them.