### PR TITLE
perf(swift-keymaps): reduce keymap latency

### DIFF
--- a/gui/durian/Keymaps/KeyBuffer.swift
+++ b/gui/durian/Keymaps/KeyBuffer.swift
@@ -46,6 +46,10 @@ class KeyBuffer: ObservableObject {
     func append(_ event: KeyEvent) {
         buffer.append(event)
         updateDisplayString()
+    }
+
+    /// Start the sequence timeout (call only for partial matches)
+    func startTimeout() {
         resetTimeout()
     }
     
@@ -136,7 +140,6 @@ class KeyBuffer: ObservableObject {
     }
     
     private func handleTimeout() {
-        Log.debug("KEYBUFFER", "Timeout - clearing buffer '\(asString)'")
         clear()
         onTimeout?()
     }

--- a/gui/durian/Keymaps/KeySequenceEngine.swift
+++ b/gui/durian/Keymaps/KeySequenceEngine.swift
@@ -146,53 +146,40 @@ class KeySequenceEngine: ObservableObject {
     // MARK: - Private
     
     private func processKey(key: String, modifiers: Set<KeyModifier>) -> Bool {
-        // Create key event
         let keyEvent = KeyEvent(key: key, modifiers: modifiers)
-        
-        Log.debug("KEYSEQ", "Key pressed: '\(key)' modifiers: \(modifiers) normalized: '\(keyEvent.normalized)'")
-        
+
         // Add to buffer
         buffer.append(keyEvent)
-        currentSequence = buffer.displayString
-        
-        Log.debug("KEYSEQ", "Buffer = '\(buffer.asString)' (count: \(buffer.count))")
-        
+
         // Try to match
-        let result = matcher.match(buffer: buffer.asString)
-        
+        let bufferStr = buffer.asString
+        let result = matcher.match(buffer: bufferStr)
+
         switch result {
         case .match(let action, let count):
-            Log.debug("KEYSEQ", "Match! action=\(action.rawValue) count=\(count)")
             executeAction(action, count: count)
             buffer.clear()
             currentSequence = ""
             isWaitingForMore = false
             return true
-            
+
         case .partial:
-            Log.debug("KEYSEQ", "Partial match, waiting for more...")
+            currentSequence = buffer.displayString
             isWaitingForMore = true
+            buffer.startTimeout()
             return true
-            
+
         case .noMatch:
-            Log.debug("KEYSEQ", "No match, clearing buffer")
             buffer.clear()
             currentSequence = ""
             isWaitingForMore = false
             return false
         }
     }
-    
+
     private func executeAction(_ action: KeymapAction, count: Int) {
-        guard let handler = actionHandlers[action] else {
-            Log.debug("KEYSEQ", "No handler registered for \(action.rawValue)")
-            return
-        }
-        
-        Task {
-            // Pass count to handler - handler is responsible for repeating if needed
-            await handler(count)
-        }
+        guard let handler = actionHandlers[action] else { return }
+        Task { await handler(count) }
     }
     
     private func getModifiers(from event: NSEvent) -> Set<KeyModifier> {

--- a/gui/durian/Keymaps/KeymapHandler.swift
+++ b/gui/durian/Keymaps/KeymapHandler.swift
@@ -163,23 +163,16 @@ class KeymapHandler: ObservableObject {
         
         guard isAppInForeground,
               keymapsManager.keymaps.globalSettings.keymapsEnabled else {
-            Log.debug("KEYMAPS", "Event ignored - app not in foreground or keymaps disabled")
             return false
         }
-        
-        let key = event.charactersIgnoringModifiers ?? ""
-        Log.debug("KEYMAPS", "Received key event: '\(key)' keyCode: \(event.keyCode)")
-        
+
         // First, check for legacy keymaps with modifiers (Cmd+r, etc.)
         if handleLegacyKeymap(event) {
-            Log.debug("KEYMAPS", "Handled by legacy keymap")
             return true
         }
-        
+
         // Then delegate to sequence engine
-        let consumed = sequenceEngine.handleKeyEvent(event)
-        Log.debug("KEYMAPS", "Sequence engine returned: \(consumed)")
-        return consumed
+        return sequenceEngine.handleKeyEvent(event)
     }
     
     /// Handle keymaps.toml defined shortcuts with modifiers

--- a/gui/durian/Views/SearchPopupView.swift
+++ b/gui/durian/Views/SearchPopupView.swift
@@ -73,16 +73,26 @@ struct SearchPopupView: View {
             }
         }
         .onKeyPress(.upArrow) {
-            if selectedIndex > 0 {
-                selectedIndex -= 1
-            }
+            if selectedIndex > 0 { selectedIndex -= 1 }
             return .handled
         }
         .onKeyPress(.downArrow) {
-            if selectedIndex < searchManager.results.count - 1 {
-                selectedIndex += 1
-            }
+            if selectedIndex < searchManager.results.count - 1 { selectedIndex += 1 }
             return .handled
+        }
+        .onKeyPress { press in
+            if press.modifiers.contains(.control) {
+                switch press.key {
+                case "j", KeyEquivalent("n"):
+                    if selectedIndex < searchManager.results.count - 1 { selectedIndex += 1 }
+                    return .handled
+                case "k", KeyEquivalent("p"):
+                    if selectedIndex > 0 { selectedIndex -= 1 }
+                    return .handled
+                default: break
+                }
+            }
+            return .ignored
         }
         .onKeyPress(.escape) {
             close()

--- a/gui/durian/Views/TagPickerView.swift
+++ b/gui/durian/Views/TagPickerView.swift
@@ -75,16 +75,26 @@ struct TagPickerView: View {
             selectedIndex = 0
         }
         .onKeyPress(.upArrow) {
-            if selectedIndex > 0 {
-                selectedIndex -= 1
-            }
+            if selectedIndex > 0 { selectedIndex -= 1 }
             return .handled
         }
         .onKeyPress(.downArrow) {
-            if selectedIndex < displayItems.count - 1 {
-                selectedIndex += 1
-            }
+            if selectedIndex < displayItems.count - 1 { selectedIndex += 1 }
             return .handled
+        }
+        .onKeyPress { press in
+            if press.modifiers.contains(.control) {
+                switch press.key {
+                case "j", KeyEquivalent("n"):
+                    if selectedIndex < displayItems.count - 1 { selectedIndex += 1 }
+                    return .handled
+                case "k", KeyEquivalent("p"):
+                    if selectedIndex > 0 { selectedIndex -= 1 }
+                    return .handled
+                default: break
+                }
+            }
+            return .ignored
         }
         .onKeyPress(.escape) {
             close()


### PR DESCRIPTION
Removes debug logging from hot path, only starts sequence timeout for
partial matches, reduces string allocations. Should feel noticeably
snappier.

Closes #95

Note: Search and TagPicker already have arrow-key navigation.
Thread-view keyboard nav tracked in #98.