### PR TITLE
feat(swift-keymaps): thread view navigation with context switching

### DIFF
--- a/docs/keymaps-example.toml
+++ b/docs/keymaps-example.toml
@@ -235,3 +235,47 @@ context = "compose_normal"
 description = "Exit insert mode"
 
 # To use "jj" instead, change key = "jj" or add another entry.
+
+# ── Thread View (context = "thread") ─────────────────────────────────
+# Active when thread/detail view is focused (enter with "l", exit with "h").
+
+[[keymaps]]
+action = "enter_thread"
+key = "l"
+description = "Enter thread view"
+
+[[keymaps]]
+action = "scroll_down"
+key = "j"
+context = "thread"
+description = "Scroll down"
+
+[[keymaps]]
+action = "scroll_up"
+key = "k"
+context = "thread"
+description = "Scroll up"
+
+[[keymaps]]
+action = "next_message"
+key = "n"
+context = "thread"
+description = "Next message in thread"
+
+[[keymaps]]
+action = "prev_message"
+key = "N"
+context = "thread"
+description = "Previous message in thread"
+
+[[keymaps]]
+action = "close_detail"
+key = "h"
+context = "thread"
+description = "Back to email list"
+
+[[keymaps]]
+action = "reply"
+key = "r"
+context = "thread"
+description = "Reply to email"

--- a/gui/durian/ContentView.swift
+++ b/gui/durian/ContentView.swift
@@ -13,6 +13,8 @@ import Combine
 extension Notification.Name {
     static let popupSelectNext = Notification.Name("popupSelectNext")
     static let popupSelectPrev = Notification.Name("popupSelectPrev")
+    static let threadScrollDown = Notification.Name("threadScrollDown")
+    static let threadScrollUp = Notification.Name("threadScrollUp")
 }
 
 enum DetailViewMode: Equatable {
@@ -40,6 +42,8 @@ struct ContentView: View {
     @State private var isSearchMode = false
     @State private var searchResults: [MailMessage] = []
     @State private var lastSearchQuery = ""
+    @State private var focusedMessageIndex: Int = 0
+    @State private var isThreadFocused: Bool = false
 
     var body: some View {
         ZStack {
@@ -406,7 +410,9 @@ struct ContentView: View {
                         },
                         onRemoveTag: { tag in
                             Task { await accountManager.removeTag(id: email.id, tag: tag) }
-                        }
+                        },
+                        focusedMessageIndex: $focusedMessageIndex,
+                        isThreadFocused: isThreadFocused
                     )
                     .id(email.id)  // Force new View instance on email change to reset @State
                     
@@ -507,6 +513,15 @@ struct ContentView: View {
         }
     }
     
+    /// Number of thread messages for the currently focused email
+    private var currentThreadMessageCount: Int {
+        guard let emailId = cursorEmailId,
+              let email = accountManager.mailMessages.first(where: { $0.id == emailId })
+                          ?? searchResults.first(where: { $0.id == emailId }),
+              let messages = email.threadMessages else { return 1 }
+        return max(messages.count, 1)
+    }
+
     // MARK: - Display Emails (Search Mode vs Normal)
 
     private var displayEmails: [MailMessage] {
@@ -1031,6 +1046,62 @@ struct ContentView: View {
                 } else {
                     detailMode = .empty
                 }
+            }
+        }
+
+        // ═══════════════════════════════════════════════════════════
+        // THREAD CONTEXT HANDLERS
+        // ═══════════════════════════════════════════════════════════
+
+        // l - Enter thread view
+        keymapHandler.registerSimpleHandler(for: .enterThread) { [self] in
+            await MainActor.run {
+                guard cursorEmailId != nil else { return }
+                focusedMessageIndex = 0
+                isThreadFocused = true
+                keymapHandler.engine.setContext(.thread)
+            }
+        }
+
+        // j/k in thread - scroll
+        keymapHandler.registerSimpleHandler(for: .scrollDown, context: .thread) {
+            NotificationCenter.default.post(name: .threadScrollDown, object: nil)
+        }
+
+        keymapHandler.registerSimpleHandler(for: .scrollUp, context: .thread) {
+            NotificationCenter.default.post(name: .threadScrollUp, object: nil)
+        }
+
+        // n/N in thread - navigate messages
+        keymapHandler.registerSimpleHandler(for: .nextMessage, context: .thread) { [self] in
+            await MainActor.run {
+                let count = currentThreadMessageCount
+                if focusedMessageIndex < count - 1 {
+                    focusedMessageIndex += 1
+                }
+            }
+        }
+
+        keymapHandler.registerSimpleHandler(for: .prevMessage, context: .thread) { [self] in
+            await MainActor.run {
+                if focusedMessageIndex > 0 {
+                    focusedMessageIndex -= 1
+                }
+            }
+        }
+
+        // h/Escape in thread - back to list
+        keymapHandler.registerSimpleHandler(for: .closeDetail, context: .thread) { [self] in
+            await MainActor.run {
+                isThreadFocused = false
+                keymapHandler.engine.setContext(.list)
+            }
+        }
+
+        // r in thread - reply
+        keymapHandler.registerSimpleHandler(for: .reply, context: .thread) { [self] in
+            await MainActor.run {
+                replyToSelected()
             }
         }
 

--- a/gui/durian/ContentView.swift
+++ b/gui/durian/ContentView.swift
@@ -40,6 +40,7 @@ struct ContentView: View {
     @State private var allTags: [String] = []
     @State private var visualModeAnchor: String? = nil    // Anchor for visual mode range selection
     @State private var isSearchMode = false
+    @State private var bodyFetchTask: Task<Void, Never>?
     @State private var searchResults: [MailMessage] = []
     @State private var lastSearchQuery = ""
     @State private var focusedMessageIndex: Int = 0
@@ -533,26 +534,23 @@ struct ContentView: View {
     private func handleEmailSelection(_ emailId: String) {
         detailMode = .emailDetail(emailId: emailId)
 
-        // Auto-load body if not loaded or previously failed
-        if let email = displayEmails.first(where: { $0.id == emailId }) {
-            switch email.bodyState {
-            case .notLoaded, .failed:
-                Task {
-                    await accountManager.fetchEmailBody(id: emailId)
-                }
-            case .loading, .loaded:
-                break // Already loading or loaded
-            }
+        // Debounce body fetch — cancel previous request during rapid j/k navigation
+        bodyFetchTask?.cancel()
+        bodyFetchTask = Task {
+            try? await Task.sleep(for: .milliseconds(150))
+            guard !Task.isCancelled else { return }
 
-            // Mark as read
-            if !email.isRead {
-                Task {
+            if let email = displayEmails.first(where: { $0.id == emailId }) {
+                switch email.bodyState {
+                case .notLoaded, .failed:
+                    await accountManager.fetchEmailBody(id: emailId)
+                case .loading, .loaded:
+                    break
+                }
+                if !email.isRead {
                     await accountManager.markAsRead(id: emailId)
                 }
-            }
-        } else {
-            // Email not in current folder (e.g. opened from search) — fetch it
-            Task {
+            } else {
                 await accountManager.fetchEmailBody(id: emailId)
             }
         }

--- a/gui/durian/ContentView.swift
+++ b/gui/durian/ContentView.swift
@@ -733,11 +733,11 @@ struct ContentView: View {
         return prevIndex >= 0 ? ids[prevIndex] : nil
     }
 
-    /// Get sorted email IDs (by timestamp, newest first)
+    /// Get sorted email IDs matching visual order (pinned first, then by timestamp)
     private var sortedEmailIds: [String] {
-        displayEmails
-            .sorted { $0.timestamp > $1.timestamp }
-            .map { $0.id }
+        let pinned = displayEmails.filter { $0.isPinned }.sorted { $0.timestamp > $1.timestamp }
+        let unpinned = displayEmails.filter { !$0.isPinned }.sorted { $0.timestamp > $1.timestamp }
+        return (pinned + unpinned).map { $0.id }
     }
     
     /// Get current email index in sorted list (based on cursor position)
@@ -752,7 +752,7 @@ struct ContentView: View {
         guard !sortedEmailIds.isEmpty else { return }
         let clampedIndex = max(0, min(index, sortedEmailIds.count - 1))
         let targetId = sortedEmailIds[clampedIndex]
-        
+
         // Always update cursor position
         cursorEmailId = targetId
         

--- a/gui/durian/Keymaps/KeymapTypes.swift
+++ b/gui/durian/Keymaps/KeymapTypes.swift
@@ -66,6 +66,11 @@ enum KeymapAction: String, CaseIterable {
     case confirmSelection = "confirm_selection"
     case closePopup = "close_popup"
     case exitInsert = "exit_insert"
+    case enterThread = "enter_thread"
+    case nextMessage = "next_message"
+    case prevMessage = "prev_message"
+    case scrollDown = "scroll_down"
+    case scrollUp = "scroll_up"
 
     // Note: supportsCount is now defined in keymaps.toml per-action
     // Use SequenceMatcher.shared.supportsCount(action) to check

--- a/gui/durian/Keymaps/KeymapsManager.swift
+++ b/gui/durian/Keymaps/KeymapsManager.swift
@@ -152,9 +152,19 @@ class KeymapsManager: ObservableObject {
             KeymapEntry(action: "select_prev", key: "p", modifiers: ["ctrl"], description: "Previous tag (Ctrl+p)", enabled: true, sequence: false, supportsCount: false, context: "tag_picker"),
             // Compose normal context
             KeymapEntry(action: "exit_insert", key: "jk", modifiers: [], description: "Exit insert mode (jk)", enabled: true, sequence: true, supportsCount: false, context: "compose_normal"),
+            // List context: enter thread
+            KeymapEntry(action: "enter_thread", key: "l", modifiers: [], description: "Enter thread view (l)", enabled: true, sequence: false, supportsCount: false),
+            // Thread context
+            KeymapEntry(action: "scroll_down", key: "j", modifiers: [], description: "Scroll down in thread", enabled: true, sequence: false, supportsCount: false, context: "thread"),
+            KeymapEntry(action: "scroll_up", key: "k", modifiers: [], description: "Scroll up in thread", enabled: true, sequence: false, supportsCount: false, context: "thread"),
+            KeymapEntry(action: "next_message", key: "n", modifiers: [], description: "Next message in thread", enabled: true, sequence: false, supportsCount: false, context: "thread"),
+            KeymapEntry(action: "prev_message", key: "N", modifiers: [], description: "Previous message in thread", enabled: true, sequence: false, supportsCount: false, context: "thread"),
+            KeymapEntry(action: "close_detail", key: "h", modifiers: [], description: "Back to email list", enabled: true, sequence: false, supportsCount: false, context: "thread"),
+            KeymapEntry(action: "close_detail", key: "Escape", modifiers: [], description: "Back to email list", enabled: true, sequence: false, supportsCount: false, context: "thread"),
+            KeymapEntry(action: "reply", key: "r", modifiers: [], description: "Reply to email", enabled: true, sequence: false, supportsCount: false, context: "thread"),
         ]
     }
-    
+
     private func generateTOML(from config: KeymapConfig) -> String {
         var toml = "# durian Keymaps Configuration\n"
         toml += "# All vim-style keybindings are configurable here\n"
@@ -368,6 +378,28 @@ class KeymapsManager: ObservableObject {
             KeymapEntry(action: "exit_insert", key: "jk", modifiers: [],
                        description: "Exit insert mode (jk)", enabled: true,
                        sequence: true, supportsCount: false, context: "compose_normal"),
+
+            // ═══════════════════════════════════════════════════════════
+            // THREAD CONTEXT
+            // ═══════════════════════════════════════════════════════════
+            KeymapEntry(action: "enter_thread", key: "l", modifiers: [],
+                       description: "Enter thread view (l)", enabled: true,
+                       sequence: false, supportsCount: false),
+            KeymapEntry(action: "next_message", key: "j", modifiers: [],
+                       description: "Next message in thread", enabled: true,
+                       sequence: false, supportsCount: false, context: "thread"),
+            KeymapEntry(action: "prev_message", key: "k", modifiers: [],
+                       description: "Previous message in thread", enabled: true,
+                       sequence: false, supportsCount: false, context: "thread"),
+            KeymapEntry(action: "close_detail", key: "h", modifiers: [],
+                       description: "Back to email list", enabled: true,
+                       sequence: false, supportsCount: false, context: "thread"),
+            KeymapEntry(action: "close_detail", key: "Escape", modifiers: [],
+                       description: "Back to email list", enabled: true,
+                       sequence: false, supportsCount: false, context: "thread"),
+            KeymapEntry(action: "reply", key: "r", modifiers: [],
+                       description: "Reply to email", enabled: true,
+                       sequence: false, supportsCount: false, context: "thread"),
         ]
 
         keymaps = config

--- a/gui/durian/Utilities/ScrollViewFinder.swift
+++ b/gui/durian/Utilities/ScrollViewFinder.swift
@@ -1,0 +1,28 @@
+//
+//  ScrollViewFinder.swift
+//  Durian
+//
+//  Captures a reference to the enclosing NSScrollView for programmatic scrolling.
+//
+
+import SwiftUI
+
+struct ScrollViewFinder: NSViewRepresentable {
+    @Binding var scrollView: NSScrollView?
+
+    func makeNSView(context: Context) -> NSView {
+        let view = NSView()
+        DispatchQueue.main.async {
+            self.scrollView = view.enclosingScrollView
+        }
+        return view
+    }
+
+    func updateNSView(_ nsView: NSView, context: Context) {
+        if scrollView == nil {
+            DispatchQueue.main.async {
+                self.scrollView = nsView.enclosingScrollView
+            }
+        }
+    }
+}

--- a/gui/durian/Views/EmailDetailView.swift
+++ b/gui/durian/Views/EmailDetailView.swift
@@ -23,22 +23,40 @@ struct EmailDetailView: View {
     var currentFolder: String? = nil
     var onAddTag: ((String) -> Void)? = nil
     var onRemoveTag: ((String) -> Void)? = nil
-    
+    @Binding var focusedMessageIndex: Int
+    var isThreadFocused: Bool = false
+
     // MARK: - State
-    
+
     @State private var messageHeights: [String: CGFloat] = [:]  // Use message ID as key
-    
+    @State private var detailScrollView: NSScrollView?
+
     // MARK: - Body
-    
+
     var body: some View {
-        ScrollView {
-            VStack(alignment: .leading, spacing: 16) {
-                headerSection
-                messageCards
+        ScrollViewReader { proxy in
+            ScrollView {
+                VStack(alignment: .leading, spacing: 16) {
+                    ScrollViewFinder(scrollView: $detailScrollView)
+                        .frame(height: 0)
+                    headerSection
+                    messageCards
+                }
+            }
+            .onChange(of: focusedMessageIndex) { _, newIndex in
+                withAnimation(.easeInOut(duration: 0.15)) {
+                    proxy.scrollTo("msg-\(newIndex)", anchor: .top)
+                }
             }
         }
         .overlayScrollbars()
         .background(Color(NSColor.controlBackgroundColor))
+        .onReceive(NotificationCenter.default.publisher(for: .threadScrollDown)) { _ in
+            scrollBy(80)
+        }
+        .onReceive(NotificationCenter.default.publisher(for: .threadScrollUp)) { _ in
+            scrollBy(-80)
+        }
         .onAppear {
             // Auto-load body if not loaded
             switch email.bodyState {
@@ -51,6 +69,7 @@ struct EmailDetailView: View {
         // Reset state when email changes
         .onChange(of: email.id) {
             messageHeights = [:]
+            focusedMessageIndex = 0
         }
     }
     
@@ -71,12 +90,15 @@ struct EmailDetailView: View {
             // Use thread messages from CLI if available
             if let messages = email.threadMessages, !messages.isEmpty {
                 ForEach(Array(messages.enumerated()), id: \.element.id) { index, message in
+                    Color.clear.frame(height: 0)
+                        .id("msg-\(index)")
                     ThreadMessageCardView(
                         message: message,
                         isFirst: index == 0,
                         isLast: index == 0,  // Newest message (first) gets reply button
                         email: email,
                         contentHeight: bindingForMessageId(message.id),
+                        isFocused: isThreadFocused && index == focusedMessageIndex,
                         onReply: onReply,
                         onReplyAll: onReplyAll,
                         onForward: onForward,
@@ -153,6 +175,15 @@ struct EmailDetailView: View {
         .padding(.bottom, 32)
     }
     
+    private func scrollBy(_ delta: CGFloat) {
+        guard let sv = detailScrollView else { return }
+        let current = sv.contentView.bounds.origin
+        let maxY = max(sv.documentView!.frame.height - sv.contentView.bounds.height, 0)
+        let newY = min(max(current.y + delta, 0), maxY)
+        sv.contentView.setBoundsOrigin(NSPoint(x: current.x, y: newY))
+        sv.reflectScrolledClipView(sv.contentView)
+    }
+
     private func bindingForMessageId(_ id: String) -> Binding<CGFloat> {
         Binding(
             get: { messageHeights[id] ?? 100 },
@@ -343,6 +374,7 @@ struct ThreadMessageCardView: View {
     let isLast: Bool
     let email: MailMessage  // Parent email for expanded details
     @Binding var contentHeight: CGFloat
+    var isFocused: Bool = false
     let onReply: () -> Void
     let onReplyAll: () -> Void
     let onForward: () -> Void
@@ -401,6 +433,15 @@ struct ThreadMessageCardView: View {
         .padding(.bottom, 16)
         .background(Color.Detail.cardBackground)
         .cornerRadius(10)
+        .overlay(
+            HStack(spacing: 0) {
+                if isFocused {
+                    Color.accentColor.frame(width: 3)
+                }
+                Spacer()
+            }
+            .clipShape(RoundedRectangle(cornerRadius: 10))
+        )
         .shadow(color: Color.primary.opacity(0.1), radius: 3, x: 0, y: 1)
         .padding(.leading, isOwnMessage() ? 56 : 32)  // Indent own messages (24pt extra)
         .padding(.trailing, 32)


### PR DESCRIPTION
## Summary
- `l` enters thread context, `h`/`Escape` exits back to list
- `j`/`k` scroll the detail view in thread context
- `n`/`N` navigate between thread messages with focused message indicator (blue accent stripe)
- All bindings configurable via `keymaps.toml` with `context = "thread"`
- `ScrollViewFinder` utility captures `NSScrollView` reference for programmatic scrolling

Closes #98

## Test plan
- [x] Select email with thread, press `l` → enters thread context
- [x] `j`/`k` scrolls detail view up/down
- [x] `n`/`N` jumps between messages, blue stripe shows focused message
- [x] `h` or `Escape` exits back to list context
- [x] `r` in thread context replies
- [x] Focus indicator only visible in thread context, not in list
- [x] Old keymaps.toml without thread entries loads correctly (defaults merged)
- [x] `bazel build //gui:durian_lib` and `bazel build //gui:durian_core` compile