### PR TITLE
fix(go-smtp): normalize paragraph margins in outgoing HTML

### DIFF
--- a/cli/internal/smtp/mime.go
+++ b/cli/internal/smtp/mime.go
@@ -98,12 +98,17 @@ func (m *Message) Build() ([]byte, error) {
 		contentType = "text/html"
 	}
 
+	body := m.Body
+	if m.IsHTML {
+		body = normalizeParagraphs(body)
+	}
+
 	if len(m.Attachments) == 0 {
 		// Simple message (plain text or HTML)
 		fmt.Fprintf(&buf, "Content-Type: %s; charset=UTF-8\r\n", contentType)
 		fmt.Fprintf(&buf, "Content-Transfer-Encoding: quoted-printable\r\n")
 		fmt.Fprintf(&buf, "\r\n")
-		buf.WriteString(toQuotedPrintable(m.Body))
+		buf.WriteString(toQuotedPrintable(body))
 	} else {
 		// Multipart message with attachments
 		boundary := generateBoundary()
@@ -115,7 +120,7 @@ func (m *Message) Build() ([]byte, error) {
 		fmt.Fprintf(&buf, "Content-Type: %s; charset=UTF-8\r\n", contentType)
 		fmt.Fprintf(&buf, "Content-Transfer-Encoding: quoted-printable\r\n")
 		fmt.Fprintf(&buf, "\r\n")
-		buf.WriteString(toQuotedPrintable(m.Body))
+		buf.WriteString(toQuotedPrintable(body))
 		fmt.Fprintf(&buf, "\r\n")
 
 		// Attachment parts
@@ -217,6 +222,18 @@ func toQuotedPrintable(s string) string {
 	}
 
 	return buf.String()
+}
+
+// normalizeParagraphs adds margin:0 to <p> tags so recipient email clients
+// don't add extra spacing. Matches the compose editor's margin-reset style.
+func normalizeParagraphs(html string) string {
+	// <p> → <p style="margin:0">
+	result := strings.ReplaceAll(html, "<p>", `<p style="margin:0">`)
+	// <p style="..."> → inject margin:0 at start of existing style
+	result = strings.ReplaceAll(result, `<p style="`, `<p style="margin:0; `)
+	// Clean up double margin:0 from the two replacements above
+	result = strings.ReplaceAll(result, "margin:0; margin:0", "margin:0")
+	return result
 }
 
 // ensureAngleBrackets wraps a Message-ID in <> if not already present.

--- a/cli/internal/smtp/smtp_test.go
+++ b/cli/internal/smtp/smtp_test.go
@@ -111,7 +111,7 @@ func TestMessageBuildHTML(t *testing.T) {
 	}
 
 	// Check body present
-	if !strings.Contains(content, "<h1>Hello!</h1>") || !strings.Contains(content, "<p>This is HTML content.</p>") {
+	if !strings.Contains(content, "<h1>Hello!</h1>") || !strings.Contains(content, "This is HTML content.") {
 		t.Error("HTML body content not found in message")
 	}
 }


### PR DESCRIPTION
## Summary
- Adds `margin:0` to all `<p>` tags in outgoing HTML emails
- Compose editor uses CSS reset (`* { margin: 0 }`) but recipient email clients apply default `<p>` margins (~1em), making spacing look double
- This ensures WYSIWYG: what you see in compose is what the recipient sees

## Test plan
- [ ] Send an HTML email with multiple paragraphs (Enter between them)
- [ ] Verify recipient sees same spacing as compose view (no extra gaps)
- [ ] Verify Shift+Enter line breaks still work as expected
- [ ] `bazel test //cli/internal/smtp:smtp_test` passes