### PR TITLE
feat(swift-keymaps): count multiplier and gg/G in thread view

### DIFF
--- a/docs/keymaps-example.toml
+++ b/docs/keymaps-example.toml
@@ -248,25 +248,45 @@ description = "Enter thread view"
 action = "scroll_down"
 key = "j"
 context = "thread"
-description = "Scroll down"
+supports_count = true
+description = "Scroll down (3j = 3x)"
 
 [[keymaps]]
 action = "scroll_up"
 key = "k"
 context = "thread"
-description = "Scroll up"
+supports_count = true
+description = "Scroll up (3k = 3x)"
+
+[[keymaps]]
+action = "page_down"
+key = "d"
+modifiers = ["ctrl"]
+context = "thread"
+supports_count = true
+description = "Half-page down in thread"
+
+[[keymaps]]
+action = "page_up"
+key = "u"
+modifiers = ["ctrl"]
+context = "thread"
+supports_count = true
+description = "Half-page up in thread"
 
 [[keymaps]]
 action = "next_message"
 key = "n"
 context = "thread"
-description = "Next message in thread"
+supports_count = true
+description = "Next message in thread (3n = jump 3)"
 
 [[keymaps]]
 action = "prev_message"
 key = "N"
 context = "thread"
-description = "Previous message in thread"
+supports_count = true
+description = "Previous message in thread (3N = jump 3)"
 
 [[keymaps]]
 action = "close_detail"

--- a/gui/durian/ContentView.swift
+++ b/gui/durian/ContentView.swift
@@ -15,6 +15,8 @@ extension Notification.Name {
     static let popupSelectPrev = Notification.Name("popupSelectPrev")
     static let threadScrollDown = Notification.Name("threadScrollDown")
     static let threadScrollUp = Notification.Name("threadScrollUp")
+    static let threadScrollToTop = Notification.Name("threadScrollToTop")
+    static let threadScrollToBottom = Notification.Name("threadScrollToBottom")
 }
 
 enum DetailViewMode: Equatable {
@@ -1061,30 +1063,64 @@ struct ContentView: View {
             }
         }
 
-        // j/k in thread - scroll
-        keymapHandler.registerSimpleHandler(for: .scrollDown, context: .thread) {
-            NotificationCenter.default.post(name: .threadScrollDown, object: nil)
-        }
-
-        keymapHandler.registerSimpleHandler(for: .scrollUp, context: .thread) {
-            NotificationCenter.default.post(name: .threadScrollUp, object: nil)
-        }
-
-        // n/N in thread - navigate messages
-        keymapHandler.registerSimpleHandler(for: .nextMessage, context: .thread) { [self] in
-            await MainActor.run {
-                let count = currentThreadMessageCount
-                if focusedMessageIndex < count - 1 {
-                    focusedMessageIndex += 1
-                }
+        // j/k in thread - scroll (supports count: 3j = scroll 3x)
+        keymapHandler.registerHandler(for: .scrollDown, context: .thread) { count in
+            for _ in 0..<count {
+                NotificationCenter.default.post(name: .threadScrollDown, object: nil)
             }
         }
 
-        keymapHandler.registerSimpleHandler(for: .prevMessage, context: .thread) { [self] in
+        keymapHandler.registerHandler(for: .scrollUp, context: .thread) { count in
+            for _ in 0..<count {
+                NotificationCenter.default.post(name: .threadScrollUp, object: nil)
+            }
+        }
+
+        // Ctrl+d/u in thread - half-page scroll
+        keymapHandler.registerHandler(for: .pageDown, context: .thread) { count in
+            let steps = 5 * count
+            for _ in 0..<steps {
+                NotificationCenter.default.post(name: .threadScrollDown, object: nil)
+            }
+        }
+
+        keymapHandler.registerHandler(for: .pageUp, context: .thread) { count in
+            let steps = 5 * count
+            for _ in 0..<steps {
+                NotificationCenter.default.post(name: .threadScrollUp, object: nil)
+            }
+        }
+
+        // n/N in thread - navigate messages (supports count: 3n = jump 3)
+        keymapHandler.registerHandler(for: .nextMessage, context: .thread) { [self] count in
             await MainActor.run {
-                if focusedMessageIndex > 0 {
-                    focusedMessageIndex -= 1
+                let max = currentThreadMessageCount - 1
+                focusedMessageIndex = min(focusedMessageIndex + count, max)
+            }
+        }
+
+        keymapHandler.registerHandler(for: .prevMessage, context: .thread) { [self] count in
+            await MainActor.run {
+                guard focusedMessageIndex > 0 else { return }
+                focusedMessageIndex = max(focusedMessageIndex - count, 0)
+            }
+        }
+
+        // gg/G in thread - first/last message
+        keymapHandler.registerSimpleHandler(for: .firstEmail, context: .thread) { [self] in
+            await MainActor.run {
+                guard focusedMessageIndex > 0 else { return }
+                focusedMessageIndex = 0
+            }
+        }
+
+        keymapHandler.registerSimpleHandler(for: .lastEmail, context: .thread) { [self] in
+            await MainActor.run {
+                let last = max(currentThreadMessageCount - 1, 0)
+                if focusedMessageIndex == last {
+                    NotificationCenter.default.post(name: .threadScrollToBottom, object: nil)
                 }
+                focusedMessageIndex = last
             }
         }
 

--- a/gui/durian/Keymaps/KeymapsManager.swift
+++ b/gui/durian/Keymaps/KeymapsManager.swift
@@ -155,10 +155,14 @@ class KeymapsManager: ObservableObject {
             // List context: enter thread
             KeymapEntry(action: "enter_thread", key: "l", modifiers: [], description: "Enter thread view (l)", enabled: true, sequence: false, supportsCount: false),
             // Thread context
-            KeymapEntry(action: "scroll_down", key: "j", modifiers: [], description: "Scroll down in thread", enabled: true, sequence: false, supportsCount: false, context: "thread"),
-            KeymapEntry(action: "scroll_up", key: "k", modifiers: [], description: "Scroll up in thread", enabled: true, sequence: false, supportsCount: false, context: "thread"),
-            KeymapEntry(action: "next_message", key: "n", modifiers: [], description: "Next message in thread", enabled: true, sequence: false, supportsCount: false, context: "thread"),
-            KeymapEntry(action: "prev_message", key: "N", modifiers: [], description: "Previous message in thread", enabled: true, sequence: false, supportsCount: false, context: "thread"),
+            KeymapEntry(action: "scroll_down", key: "j", modifiers: [], description: "Scroll down in thread", enabled: true, sequence: false, supportsCount: true, context: "thread"),
+            KeymapEntry(action: "scroll_up", key: "k", modifiers: [], description: "Scroll up in thread", enabled: true, sequence: false, supportsCount: true, context: "thread"),
+            KeymapEntry(action: "page_down", key: "d", modifiers: ["ctrl"], description: "Half-page down in thread", enabled: true, sequence: false, supportsCount: true, context: "thread"),
+            KeymapEntry(action: "page_up", key: "u", modifiers: ["ctrl"], description: "Half-page up in thread", enabled: true, sequence: false, supportsCount: true, context: "thread"),
+            KeymapEntry(action: "next_message", key: "n", modifiers: [], description: "Next message in thread", enabled: true, sequence: false, supportsCount: true, context: "thread"),
+            KeymapEntry(action: "prev_message", key: "N", modifiers: [], description: "Previous message in thread", enabled: true, sequence: false, supportsCount: true, context: "thread"),
+            KeymapEntry(action: "first_email", key: "gg", modifiers: [], description: "First message in thread", enabled: true, sequence: true, supportsCount: false, context: "thread"),
+            KeymapEntry(action: "last_email", key: "G", modifiers: [], description: "Last message in thread", enabled: true, sequence: false, supportsCount: false, context: "thread"),
             KeymapEntry(action: "close_detail", key: "h", modifiers: [], description: "Back to email list", enabled: true, sequence: false, supportsCount: false, context: "thread"),
             KeymapEntry(action: "close_detail", key: "Escape", modifiers: [], description: "Back to email list", enabled: true, sequence: false, supportsCount: false, context: "thread"),
             KeymapEntry(action: "reply", key: "r", modifiers: [], description: "Reply to email", enabled: true, sequence: false, supportsCount: false, context: "thread"),

--- a/gui/durian/Views/EmailDetailView.swift
+++ b/gui/durian/Views/EmailDetailView.swift
@@ -39,13 +39,18 @@ struct EmailDetailView: View {
                 VStack(alignment: .leading, spacing: 16) {
                     ScrollViewFinder(scrollView: $detailScrollView)
                         .frame(height: 0)
+                        .id("thread-top")
                     headerSection
                     messageCards
                 }
             }
             .onChange(of: focusedMessageIndex) { _, newIndex in
                 withAnimation(.easeInOut(duration: 0.15)) {
-                    proxy.scrollTo("msg-\(newIndex)", anchor: .top)
+                    if newIndex == 0 {
+                        proxy.scrollTo("thread-top", anchor: .top)
+                    } else {
+                        proxy.scrollTo("msg-\(newIndex)", anchor: .top)
+                    }
                 }
             }
         }
@@ -56,6 +61,17 @@ struct EmailDetailView: View {
         }
         .onReceive(NotificationCenter.default.publisher(for: .threadScrollUp)) { _ in
             scrollBy(-80)
+        }
+        .onReceive(NotificationCenter.default.publisher(for: .threadScrollToTop)) { _ in
+            guard let sv = detailScrollView else { return }
+            sv.contentView.setBoundsOrigin(.zero)
+            sv.reflectScrolledClipView(sv.contentView)
+        }
+        .onReceive(NotificationCenter.default.publisher(for: .threadScrollToBottom)) { _ in
+            guard let sv = detailScrollView else { return }
+            let maxY = max(sv.documentView!.frame.height - sv.contentView.bounds.height, 0)
+            sv.contentView.setBoundsOrigin(NSPoint(x: 0, y: maxY))
+            sv.reflectScrolledClipView(sv.contentView)
         }
         .onAppear {
             // Auto-load body if not loaded


### PR DESCRIPTION
## Summary
- `3j`/`3k` scroll multiplier in thread detail view
- `Ctrl+d`/`Ctrl+u` half-page scroll in thread context
- `3n`/`3N` message navigation with count
- `gg`/`G` jump to first/last message in thread
- Index 0 scrolls to top including header, not just first message anchor
- Fix: repeated N/gg at top no longer causes scroll bounce

## Test plan
- [ ] `3j` scrolls 3× in thread view
- [ ] `Ctrl+d`/`Ctrl+u` scrolls half-page in thread
- [ ] `3n` jumps 3 messages forward
- [ ] `gg` goes to first message with header visible
- [ ] `G` goes to last message
- [ ] Pressing `N`/`gg` when already at top does nothing (no bounce)