### PR TITLE
fix(go-smtp,swift-compose): outgoing email formatting fixes

### DIFF
--- a/cli/internal/smtp/mime.go
+++ b/cli/internal/smtp/mime.go
@@ -100,7 +100,7 @@ func (m *Message) Build() ([]byte, error) {
 
 	body := m.Body
 	if m.IsHTML {
-		body = normalizeParagraphs(body)
+		body = `<div style="font-family:-apple-system,BlinkMacSystemFont,sans-serif;font-size:14px">` + normalizeParagraphs(body) + `</div>`
 	}
 
 	if len(m.Attachments) == 0 {

--- a/cli/internal/smtp/smtp_test.go
+++ b/cli/internal/smtp/smtp_test.go
@@ -89,7 +89,7 @@ func TestMessageBuildHTML(t *testing.T) {
 		From:    "sender@example.com",
 		To:      []string{"recipient@example.com"},
 		Subject: "HTML Newsletter",
-		Body:    "<html><body><h1>Hello!</h1><p>This is HTML content.</p></body></html>",
+		Body:    "<b>Hello!</b> Test content here.",
 		IsHTML:  true,
 	}
 
@@ -111,7 +111,7 @@ func TestMessageBuildHTML(t *testing.T) {
 	}
 
 	// Check body present
-	if !strings.Contains(content, "<h1>Hello!</h1>") || !strings.Contains(content, "This is HTML content.") {
+	if !strings.Contains(content, "Hello!") || !strings.Contains(content, "Test content here.") {
 		t.Error("HTML body content not found in message")
 	}
 }

--- a/gui/durian/Views/EditableWebView.swift
+++ b/gui/durian/Views/EditableWebView.swift
@@ -358,9 +358,9 @@ struct EditableWebView: NSViewRepresentable {
                         range.setEndBefore(sig);
                         const container = document.createElement('div');
                         container.appendChild(range.cloneContents());
-                        // Strip trailing <br> (visual separator before signature, not user content)
+                        // Strip trailing empty blocks and <br> (visual separator before signature)
                         let html = container.innerHTML;
-                        html = html.replace(/<br\\s*\\/?>$/i, '');
+                        while (html !== (html = html.replace(/(<div><br\\s*\\/?><\\/div>|<div><\\/div>|<br\\s*\\/?>)\\s*$/i, ''))) {}
                         return html;
                     }
                     return editor.innerHTML;


### PR DESCRIPTION
## Summary
- Wrap outgoing HTML body in `<div style="font-size:14px;font-family:...">` so recipients see the same size as compose editor
- Strip trailing empty `<div><br></div>` / `<div></div>` blocks before signature to prevent double line spacing

## Test plan
- [x] Send HTML email — recipient sees 14px body text, not 16px browser default
- [x] Changing font size in compose for specific text still works (inline style overrides wrapper)
- [x] Spacing between body text and signature is one line, not two or three
- [x] `bazel test //cli/internal/smtp:smtp_test` passes