### PR TITLE
fix(swift-keymaps): keymaps blocked after compose close

### DIFF
--- a/gui/durian/Keymaps/KeymapHandler.swift
+++ b/gui/durian/Keymaps/KeymapHandler.swift
@@ -28,6 +28,7 @@ class KeymapHandler: ObservableObject {
 
     /// When true, space key is passed through for attachment QuickLook preview.
     var attachmentSelected = false
+    var composeActive = false
     
     // Legacy action handlers (for keymaps.toml defined shortcuts with modifiers)
     private var legacyActionHandlers: [String: () async -> Void] = [:]
@@ -231,25 +232,22 @@ class KeymapHandler: ObservableObject {
     /// Check if a text input field is currently focused
     /// This prevents vim keymaps from interfering with typing in search, compose, etc.
     private func isTextInputFocused() -> Bool {
-        guard let keyWindow = NSApp.keyWindow else { return false }
-
-        // Only process keymaps in the main window (first window).
-        // Compose and other secondary windows handle their own input.
-        if keyWindow != NSApp.windows.first {
+        // Compose window active — all keys go to compose (JS vim engine handles them)
+        if composeActive {
             return true
         }
 
-        guard let firstResponder = keyWindow.firstResponder else {
+        guard let responder = NSApp.keyWindow?.firstResponder else {
             return false
         }
 
         // NSTextView is the editor for TextField, TextEditor, etc.
-        if firstResponder is NSTextView {
+        if responder is NSTextView {
             return true
         }
 
         // Directly editable NSTextField
-        if let textField = firstResponder as? NSTextField,
+        if let textField = responder as? NSTextField,
            textField.isEditable {
             return true
         }

--- a/gui/durian/Views/ComposeWindow.swift
+++ b/gui/durian/Views/ComposeWindow.swift
@@ -213,6 +213,8 @@ struct ComposeWindow: View {
         }
         } // ZStack
         .background(WindowCloseGuard(allowClose: $allowClose, onCloseAttempt: { handleDismiss() }))
+        .onAppear { KeymapHandler.shared.composeActive = true }
+        .onDisappear { KeymapHandler.shared.composeActive = false }
     }
     
     // MARK: - Actions


### PR DESCRIPTION
## Summary
- Vim keymaps stopped working after opening and closing a compose window
- Root cause: `NSApp.windows.first` is not a stable reference to the main window
- Fix: removed window comparison, use responder-type check + explicit `composeActive` flag

## Test plan
- [x] Open compose, type in body — no delay, vim engine works
- [x] Close/send compose — `j`/`k`/`dd`/`gg` work immediately in email list
- [x] Search field — typing works, vim keys blocked
- [x] Email body WebView focused — vim keys still work