### PR TITLE
fix(go-sync): update UID on mailbox move dedup

### DIFF
--- a/cli/internal/imap/sync.go
+++ b/cli/internal/imap/sync.go
@@ -601,8 +601,8 @@ func (s *Syncer) syncMailbox(mailboxName string) MailboxResult {
 						}
 					}
 
-					// Update mailbox to reflect the message's current server folder
-					if err := s.store.UpdateMailbox(messageID, s.accountName(), mailboxName); err != nil {
+					// Update mailbox and UID to reflect the message's current server folder
+					if err := s.store.UpdateMailbox(messageID, s.accountName(), mailboxName, uid); err != nil {
 						slog.Debug("Failed to update mailbox", "module", "SYNC", "message_id", messageID, "err", err)
 					}
 

--- a/cli/internal/store/messages.go
+++ b/cli/internal/store/messages.go
@@ -98,11 +98,11 @@ func (d *DB) UpdateBody(messageID, bodyText, bodyHTML string) error {
 	return nil
 }
 
-// UpdateMailbox sets the mailbox for a message identified by message_id and account.
-func (d *DB) UpdateMailbox(messageID, account, mailbox string) error {
+// UpdateMailbox sets the mailbox and UID for a message identified by message_id and account.
+func (d *DB) UpdateMailbox(messageID, account, mailbox string, uid uint32) error {
 	_, err := d.db.Exec(
-		"UPDATE messages SET mailbox = ? WHERE message_id = ? AND account = ?",
-		mailbox, messageID, account)
+		"UPDATE messages SET mailbox = ?, uid = ? WHERE message_id = ? AND account = ?",
+		mailbox, uid, messageID, account)
 	if err != nil {
 		return fmt.Errorf("update mailbox: %w", err)
 	}


### PR DESCRIPTION
## Summary
- After moving a message between mailboxes, the UID changes but the DB kept the old one
- Attachment downloads failed with "no message found for UID" because the old UID doesn't exist in the new mailbox
- `UpdateMailbox` now updates both mailbox name and UID during deduplication

## Test plan
- [x] Full re-sync after state reset — 18k messages deduplicated with correct UIDs
- [x] Move a message (archive), sync, verify attachment download works
- [ ] `bazel test //cli/...` passes