### PR TITLE
fix(swift): reload email list after delete and send

### DIFF
--- a/gui/durian/ContentView.swift
+++ b/gui/durian/ContentView.swift
@@ -600,7 +600,7 @@ struct ContentView: View {
         visualModeAnchor = nil
         keymapHandler.engine.exitVisualMode()
         advanceCursor(to: next)
-        Task {
+        Task { @MainActor in
             await accountManager.deleteMessages(ids: ids)
             await accountManager.refreshFolderCounts()
         }
@@ -924,26 +924,34 @@ struct ContentView: View {
         
         // Archive: a - add archive tag and remove inbox tag (works with multi-selection)
         keymapHandler.registerSimpleHandler(for: .archiveEmail) { [self] in
-            await MainActor.run {
+            let ids = await MainActor.run { () -> Set<String> in
                 let ids = markedEmails
-                guard !ids.isEmpty else { return }
+                guard !ids.isEmpty else { return [] }
                 let next = nextEmailId(after: ids)
                 accountManager.removeLocally(ids: ids)
                 advanceCursor(to: next)
-                Task {
-                    for id in ids {
-                        await accountManager.modifyTags(id: id, add: ["archive"], remove: ["inbox"])
-                    }
-                    await accountManager.refreshFolderCounts()
-                }
+                return ids
             }
+            for id in ids {
+                await accountManager.modifyTags(id: id, add: ["archive"], remove: ["inbox"])
+            }
+            await accountManager.refreshFolderCounts()
         }
 
         // Delete: dd - works with multi-selection
         keymapHandler.registerSimpleHandler(for: .deleteEmail) { [self] in
-            await MainActor.run {
-                deleteSelectedEmails()
+            let ids = await MainActor.run { () -> Set<String> in
+                guard !markedEmails.isEmpty else { return [] }
+                let ids = markedEmails
+                let next = nextEmailId(after: ids)
+                accountManager.removeLocally(ids: ids)
+                visualModeAnchor = nil
+                keymapHandler.engine.exitVisualMode()
+                advanceCursor(to: next)
+                return ids
             }
+            await accountManager.deleteMessages(ids: ids)
+            await accountManager.refreshFolderCounts()
         }
         
         // ═══════════════════════════════════════════════════════════

--- a/gui/durian/Managers/SyncManager.swift
+++ b/gui/durian/Managers/SyncManager.swift
@@ -491,6 +491,11 @@ class SyncManager: ObservableObject {
                 let subject = event.subject ?? "Email"
                 BannerManager.shared.showSuccess(title: "Sent Successfully", message: "\(subject) has been delivered.")
             }
+            // Refresh email list so Sent folder shows the new message
+            Task {
+                await AccountManager.shared.emailBackend?.reload()
+                await AccountManager.shared.refreshFolderCounts()
+            }
         case "failed":
             let detail = event.error ?? "Unknown error"
             let subject = event.subject ?? "Email"

--- a/gui/durian/Network/EmailBackend.swift
+++ b/gui/durian/Network/EmailBackend.swift
@@ -718,6 +718,7 @@ class EmailBackend: ObservableObject {
     func deleteMessage(id: String) async throws {
         try await tag(query: "thread:\(id)", tags: "+deleted -inbox -unread")
         emails.removeAll { $0.id == id }
+        await reload()
     }
     
     func reload() async {


### PR DESCRIPTION
## Summary
- `deleteMessage` now calls `reload()` after tag mutation
- Archive/delete handlers `await` tag writes sequentially (no fire-and-forget Task)
- Outbox "sent" SSE event triggers `reload()` + `refreshFolderCounts()`

Prevents stale folder views when switching folders after archive/delete/send.

## Test plan
- [x] Archive email, switch to Archive folder — message appears immediately
- [x] Delete email, switch to Trash — message appears immediately
- [ ] Send email, switch to Sent — message appears after delivery