### PR TITLE
fix: show recipient name in collapsed email card

### DIFF
--- a/gui/durian/Views/EmailDetailView.swift
+++ b/gui/durian/Views/EmailDetailView.swift
@@ -516,17 +516,17 @@ struct ThreadMessageCardView: View {
     @ViewBuilder
     private var recipientsRow: some View {
         HStack(spacing: 4) {
-            // To recipients
-            if let to = message.to, !to.isEmpty {
+            // To recipients (from message, fallback to parent email)
+            if let to = message.to ?? email.to, !to.isEmpty {
                 Text("To:")
                     .foregroundColor(Color.Detail.textTertiary)
                 Text(extractRecipientNames(to).joined(separator: ", "))
                     .foregroundColor(Color.Detail.textSecondary)
                     .lineLimit(1)
             }
-            
+
             // Cc recipients (only if present)
-            if let cc = message.cc, !cc.isEmpty {
+            if let cc = message.cc ?? email.cc, !cc.isEmpty {
                 Text("Cc:")
                     .foregroundColor(Color.Detail.textTertiary)
                 Text(extractRecipientNames(cc).joined(separator: ", "))
@@ -571,7 +571,13 @@ struct ThreadMessageCardView: View {
                 return String(name[..<pipeRange.lowerBound]).trimmingCharacters(in: .whitespaces)
             }
             
-            return name.isEmpty ? nil : name
+            if !name.isEmpty { return name }
+            // Fallback: show local part of email
+            let email = AddressUtils.extractEmail(from: fullPart)
+            if let at = email.firstIndex(of: "@") {
+                return String(email[..<at])
+            }
+            return nil
         }
     }
     


### PR DESCRIPTION
## Summary
- When `extractName` returns empty for addresses like `"email@x.com" <email@x.com>`, fall back to showing the email local part (e.g. `julian`)
- Also added `email.to`/`email.cc` fallback for collapsed recipients row (matching expanded view behavior)

## Test plan
- [x] Emails with `"email" <email>` format now show local part in collapsed card
- [x] Emails with proper display names still work as before