### PR TITLE
feat: vim text objects, search, indent, bracket matching

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,7 @@ durian sync --debug                   # debug output on stderr
 
 - [OAuth Setup](docs/OAUTH_SETUP.md) — Gmail & Microsoft 365
 - [Password Setup](docs/PASSWORD_SETUP.md) — IMAP/SMTP with password auth
+- [Vim Compose](docs/vim-compose.md) — Vim keybindings in the compose editor
 
 ## Contributing
 

--- a/docs/vim-compose.md
+++ b/docs/vim-compose.md
@@ -1,0 +1,128 @@
+# Vim Mode — Compose Editor
+
+The compose editor supports vim-style modal editing. Toggle with `Escape` (insert → normal) and configurable exit sequences (e.g. `jk`).
+
+## Modes
+
+| Mode | Description |
+|------|-------------|
+| Insert | Normal typing, like a regular editor |
+| Normal | Navigation and editing commands |
+| Visual | Character-wise selection (`v`) |
+| Visual Line | Line-wise selection (`V`) |
+
+## Navigation
+
+| Key | Action |
+|-----|--------|
+| `h` `j` `k` `l` | Left, down, up, right |
+| `w` | Next word |
+| `b` | Previous word |
+| `e` | End of word |
+| `0` | Beginning of line |
+| `$` | End of line |
+| `gg` | Top of document |
+| `G` | Bottom of document |
+| `%` | Jump to matching bracket |
+| `f`/`F` + char | Find char forward/backward |
+| `t`/`T` + char | Find char (till) forward/backward |
+| `;` `,` | Repeat last find / reverse |
+
+All navigation commands support count prefixes (e.g. `5j` moves down 5 lines).
+
+## Operators
+
+| Key | Action |
+|-----|--------|
+| `d` + motion | Delete |
+| `c` + motion | Change (delete + insert mode) |
+| `y` + motion | Yank (copy) |
+| `dd` | Delete line |
+| `cc` | Change line |
+| `yy` | Yank line |
+| `D` | Delete to end of line |
+| `C` | Change to end of line |
+
+## Text Objects
+
+Operators can be combined with text objects: `d`/`c`/`y` + `i`/`a` + object.
+
+| Key | Object |
+|-----|--------|
+| `iw` / `aw` | Inner/around word |
+| `iW` / `aW` | Inner/around WORD (whitespace-delimited) |
+| `i"` / `a"` | Inner/around double quotes |
+| `i'` / `a'` | Inner/around single quotes |
+| `` i` `` / `` a` `` | Inner/around backticks |
+| `i(` / `a(` | Inner/around parentheses |
+| `i{` / `a{` | Inner/around curly braces |
+| `i[` / `a[` | Inner/around square brackets |
+| `i<` / `a<` | Inner/around angle brackets |
+
+Examples: `ciw` (change word), `di"` (delete inside quotes), `ya(` (yank around parens).
+
+## Editing
+
+| Key | Action |
+|-----|--------|
+| `x` | Delete character under cursor |
+| `X` | Delete character before cursor |
+| `r` + char | Replace character |
+| `~` | Toggle case |
+| `J` | Join lines |
+| `>>` | Indent line |
+| `<<` | Outdent line |
+| `u` | Undo |
+| `Ctrl+r` | Redo |
+| `.` | Repeat last action |
+
+## Insert Mode Entry
+
+| Key | Action |
+|-----|--------|
+| `i` | Insert before cursor |
+| `a` | Insert after cursor |
+| `I` | Insert at beginning of line |
+| `A` | Insert at end of line |
+| `o` | Open line below |
+| `O` | Open line above |
+
+## Visual Mode
+
+| Key | Action |
+|-----|--------|
+| `v` | Toggle character-wise visual |
+| `V` | Toggle line-wise visual |
+| `d` / `c` / `y` | Operate on selection |
+| `i`/`a` + object | Select text object |
+
+## Search
+
+| Key | Action |
+|-----|--------|
+| `/` | Open search bar |
+| `Enter` | Search and close bar |
+| `n` | Next match |
+| `N` | Previous match |
+
+## Clipboard
+
+| Key | Action |
+|-----|--------|
+| `p` | Paste after cursor (line-aware) |
+| `P` | Paste before cursor (line-aware) |
+
+Yank and delete operations copy to the system clipboard.
+
+## Configuration
+
+Exit sequences for insert → normal mode are configured in `keymaps.toml`:
+
+```toml
+[[keymaps]]
+action = "exit_insert"
+key = "jk"
+context = "compose_normal"
+enabled = true
+sequence = true
+```

--- a/gui/durian/Views/ComposeForm.swift
+++ b/gui/durian/Views/ComposeForm.swift
@@ -8,6 +8,10 @@
 import SwiftUI
 import AppKit
 import Combine
+
+extension Notification.Name {
+    static let vimSearchSubmit = Notification.Name("vimSearchSubmit")
+}
 import UniformTypeIdentifiers
 
 struct ComposeForm: View {
@@ -41,6 +45,8 @@ struct ComposeForm: View {
     @State private var currentFontFamily: String = "Helvetica"
     @State private var currentAlignment: String = "left"
     @State private var vimMode: String = "insert"
+    @State private var showVimSearch: Bool = false
+    @State private var vimSearchText: String = ""
     @FocusState private var focusedField: ComposeField?  // Shared focus state
     
     // Contact suggestion popup state
@@ -155,6 +161,22 @@ struct ComposeForm: View {
             autoSaveCancellable?.cancel()
             removeKeyMonitor()
             currentDraft = nil
+        }
+        .overlay(alignment: .bottomLeading) {
+            if showVimSearch {
+                VimSearchPill(text: $vimSearchText, onSubmit: {
+                    let escaped = vimSearchText
+                        .replacingOccurrences(of: "\\", with: "\\\\")
+                        .replacingOccurrences(of: "'", with: "\\'")
+                    NotificationCenter.default.post(name: .vimSearchSubmit, object: escaped)
+                    showVimSearch = false
+                }, onDismiss: {
+                    showVimSearch = false
+                    NotificationCenter.default.post(name: .vimSearchSubmit, object: "")
+                })
+                .padding(.leading, 20)
+                .padding(.bottom, 48)
+            }
         }
     }
     
@@ -433,6 +455,10 @@ struct ComposeForm: View {
                         },
                         onVimModeChange: { mode in
                             vimMode = mode
+                        },
+                        onSearchRequest: {
+                            vimSearchText = ""
+                            showVimSearch = true
                         },
                         vimInsertExitKeys: KeymapsManager.shared.keymaps.keymaps
                             .filter { $0.context == "compose_normal" && $0.action == "exit_insert" && $0.enabled }
@@ -913,6 +939,42 @@ struct AttachmentChip: View {
         .cornerRadius(8)
         .onTapGesture {
             onClick()
+        }
+    }
+}
+
+// MARK: - Vim Search Pill
+
+struct VimSearchPill: View {
+    @Binding var text: String
+    var onSubmit: () -> Void
+    var onDismiss: () -> Void
+    @FocusState private var isFocused: Bool
+
+    var body: some View {
+        HStack(spacing: 4) {
+            Text("/")
+                .font(.system(size: 12, design: .monospaced))
+                .foregroundColor(Color.Detail.textTertiary)
+            TextField("", text: $text)
+                .font(.system(size: 12, design: .monospaced))
+                .textFieldStyle(.plain)
+                .frame(width: 180)
+                .focused($isFocused)
+                .onSubmit { onSubmit() }
+        }
+        .padding(.horizontal, 10)
+        .padding(.vertical, 5)
+        .background(Color.Detail.cardBackground)
+        .cornerRadius(8)
+        .overlay(
+            RoundedRectangle(cornerRadius: 8)
+                .stroke(Color.Detail.border, lineWidth: 1)
+        )
+        .shadow(color: .black.opacity(0.08), radius: 8, y: 4)
+        .onAppear { isFocused = true }
+        .onChange(of: isFocused) { _, focused in
+            if !focused { onDismiss() }
         }
     }
 }

--- a/gui/durian/Views/EditableWebView.swift
+++ b/gui/durian/Views/EditableWebView.swift
@@ -769,11 +769,13 @@ struct EditableWebView: NSViewRepresentable {
                                 return;
                             }
 
-                            // Line ops: dd, cc, yy, gg
+                            // Line ops: dd, cc, yy, gg, >>, <<
                             if (combo === 'dd') { this.deleteLine(pn); this.recordAction(['dd']); return; }
                             if (combo === 'cc') { this.changeLine(pn); return; }
                             if (combo === 'yy') { this.yankLine(pn); return; }
                             if (combo === 'gg') { this.goToTop(); return; }
+                            if (combo === '>>') { this.indentLine(pn); this.recordAction(['>>']); return; }
+                            if (combo === '<<') { this.outdentLine(pn); this.recordAction(['<<']); return; }
 
                             // Text objects: di, ci, yi + next key; da, ca, ya + next key
                             if ((op === 'd' || op === 'c' || op === 'y') && (key === 'i' || key === 'a')) {
@@ -891,6 +893,9 @@ struct EditableWebView: NSViewRepresentable {
                             case 'c': this.pending = 'c'; this.pendingCount = n; break;
                             case 'y': this.pending = 'y'; this.pendingCount = n; break;
                             case 'g': this.pending = 'g'; this.pendingCount = n; break;
+                            case '>': this.pending = '>'; this.pendingCount = n; break;
+                            case '<': this.pending = '<'; this.pendingCount = n; break;
+                            case '%': this.matchBracket(); break;
                             case 'Escape':
                                 if (this.visual) { this.visual = ''; sel.collapseToEnd(); this.notifyMode(); }
                                 this.pending = '';
@@ -938,6 +943,97 @@ struct EditableWebView: NSViewRepresentable {
                         this.register = lines.join('\\n');
                         this.registerIsLine = true;
                         window.webkit.messageHandlers.vimYank.postMessage(this.register);
+                    },
+
+                    indentLine(n) {
+                        const sel = window.getSelection();
+                        if (!sel.rangeCount) return;
+                        const savedOffset = sel.focusOffset;
+                        for (let i = 0; i < n; i++) {
+                            sel.modify('move', 'backward', 'lineboundary');
+                            document.execCommand('insertText', false, '\\t');
+                        }
+                        this.notifyTextChange();
+                    },
+
+                    outdentLine(n) {
+                        const sel = window.getSelection();
+                        if (!sel.rangeCount) return;
+                        for (let i = 0; i < n; i++) {
+                            sel.modify('move', 'backward', 'lineboundary');
+                            // Check leading whitespace via selection
+                            let removed = 0;
+                            while (removed < 4) {
+                                sel.modify('extend', 'forward', 'character');
+                                const ch = sel.toString();
+                                if (ch === ' ') {
+                                    document.execCommand('delete');
+                                    removed++;
+                                } else if (ch === '\\t' && removed === 0) {
+                                    document.execCommand('delete');
+                                    break;
+                                } else {
+                                    sel.collapseToStart();
+                                    break;
+                                }
+                            }
+                        }
+                        this.notifyTextChange();
+                    },
+
+                    matchBracket() {
+                        const ctx = this.getBlockContext();
+                        if (!ctx) return;
+                        const { block, text, pos } = ctx;
+                        const pairs = { '(': ')', ')': '(', '{': '}', '}': '{', '[': ']', ']': '[', '<': '>', '>': '<' };
+                        const opens = new Set(['(', '{', '[', '<']);
+
+                        // Find a bracket at or after cursor on current line
+                        let bracketPos = -1;
+                        for (let i = pos; i < text.length; i++) {
+                            if (text[i] === '\\n') break;
+                            if (pairs[text[i]]) { bracketPos = i; break; }
+                        }
+                        // Also check at cursor
+                        if (bracketPos === -1 && pos < text.length && pairs[text[pos]]) bracketPos = pos;
+                        if (bracketPos === -1) return;
+
+                        const ch = text[bracketPos];
+                        const match = pairs[ch];
+                        const forward = opens.has(ch);
+                        let depth = 0;
+                        let targetPos = -1;
+
+                        if (forward) {
+                            for (let i = bracketPos + 1; i < text.length; i++) {
+                                if (text[i] === ch) depth++;
+                                if (text[i] === match) { if (depth === 0) { targetPos = i; break; } depth--; }
+                            }
+                        } else {
+                            for (let i = bracketPos - 1; i >= 0; i--) {
+                                if (text[i] === ch) depth++;
+                                if (text[i] === match) { if (depth === 0) { targetPos = i; break; } depth--; }
+                            }
+                        }
+                        if (targetPos === -1) return;
+
+                        // Move cursor to matched bracket
+                        const sel = window.getSelection();
+                        const walker = document.createTreeWalker(block, NodeFilter.SHOW_TEXT);
+                        let offset = 0;
+                        while (walker.nextNode()) {
+                            const node = walker.currentNode;
+                            const len = node.textContent.length;
+                            if (offset + len > targetPos) {
+                                const range = document.createRange();
+                                range.setStart(node, targetPos - offset);
+                                range.collapse(true);
+                                sel.removeAllRanges();
+                                sel.addRange(range);
+                                return;
+                            }
+                            offset += len;
+                        }
                     },
 
                     openLineBelow() {

--- a/gui/durian/Views/EditableWebView.swift
+++ b/gui/durian/Views/EditableWebView.swift
@@ -41,6 +41,9 @@ struct EditableWebView: NSViewRepresentable {
         config.userContentController.add(handler, name: "vimPaste")
 
         let webView = ScrollPassthroughWebView(frame: .zero, configuration: config)
+        #if DEBUG
+        webView.isInspectable = true
+        #endif
         webView.navigationDelegate = context.coordinator
         webView.wantsLayer = true
         webView.layer?.backgroundColor = NSColor.clear.cgColor
@@ -536,6 +539,110 @@ struct EditableWebView: NSViewRepresentable {
                         return node;
                     },
 
+                    // Select a text object (iw, aw, i", a", i(, a(, etc.)
+                    // inner=true for 'i' objects, false for 'a' objects
+                    // Get block text and cursor offset within it
+                    getBlockContext() {
+                        const sel = window.getSelection();
+                        if (!sel.rangeCount) return null;
+                        const block = this.getCurrentBlock();
+                        if (!block) return null;
+                        const text = block.textContent;
+                        // Calculate cursor offset within block
+                        const range = document.createRange();
+                        range.setStart(block, 0);
+                        range.setEnd(sel.focusNode, sel.focusOffset);
+                        const pos = range.toString().length;
+                        return { block, text, pos };
+                    },
+
+                    // Set selection by offset within a block element
+                    setBlockSelection(block, start, end) {
+                        const sel = window.getSelection();
+                        const walker = document.createTreeWalker(block, NodeFilter.SHOW_TEXT);
+                        let offset = 0;
+                        let startNode = null, startOff = 0, endNode = null, endOff = 0;
+                        while (walker.nextNode()) {
+                            const node = walker.currentNode;
+                            const len = node.textContent.length;
+                            if (!startNode && offset + len > start) {
+                                startNode = node;
+                                startOff = start - offset;
+                            }
+                            if (!endNode && offset + len >= end) {
+                                endNode = node;
+                                endOff = end - offset;
+                            }
+                            offset += len;
+                            if (startNode && endNode) break;
+                        }
+                        if (!startNode || !endNode) return false;
+                        const range = document.createRange();
+                        range.setStart(startNode, startOff);
+                        range.setEnd(endNode, endOff);
+                        sel.removeAllRanges();
+                        sel.addRange(range);
+                        return true;
+                    },
+
+                    selectTextObject(obj, inner) {
+                        const ctx = this.getBlockContext();
+                        if (!ctx) return false;
+                        const { block, text, pos } = ctx;
+
+                        if (obj === 'w' || obj === 'W') {
+                            const isWord = obj === 'w'
+                                ? (c) => /\\w/.test(c)
+                                : (c) => c !== ' ' && c !== '\\t' && c !== '\\n';
+                            let start = pos, end = pos;
+                            if (pos < text.length && isWord(text[pos])) {
+                                while (start > 0 && isWord(text[start - 1])) start--;
+                                while (end < text.length && isWord(text[end])) end++;
+                            } else {
+                                while (start > 0 && !isWord(text[start - 1])) start--;
+                                while (end < text.length && !isWord(text[end])) end++;
+                            }
+                            if (!inner) {
+                                while (end < text.length && text[end] === ' ') end++;
+                                if (end === pos) { while (start > 0 && text[start - 1] === ' ') start--; }
+                            }
+                            return this.setBlockSelection(block, start, end);
+                        }
+
+                        // Paired delimiters
+                        const pairs = { '(': ')', ')': ')', '{': '}', '}': '}', '[': ']', ']': ']', '<': '>', '>': '>' };
+                        const quotes = ['"', "'", '`'];
+
+                        if (quotes.includes(obj)) {
+                            let start = text.lastIndexOf(obj, pos - 1);
+                            let end = text.indexOf(obj, Math.max(pos, start + 1));
+                            if (start === -1 && pos < text.length && text[pos] === obj) { start = pos; end = text.indexOf(obj, start + 1); }
+                            if (start === -1 || end === -1) return false;
+                            return this.setBlockSelection(block, inner ? start + 1 : start, inner ? end : end + 1);
+                        }
+
+                        if (pairs[obj]) {
+                            const open = [')', '}', ']', '>'].includes(obj) ? Object.keys(pairs).find(k => pairs[k] === obj && k !== obj) : obj;
+                            const close = pairs[open];
+                            let depth = 0, start = -1;
+                            for (let i = pos; i >= 0; i--) {
+                                if (text[i] === close && i !== pos) depth++;
+                                if (text[i] === open) { if (depth === 0) { start = i; break; } depth--; }
+                            }
+                            if (start === -1) return false;
+                            depth = 0;
+                            let endPos = -1;
+                            for (let i = start + 1; i < text.length; i++) {
+                                if (text[i] === open) depth++;
+                                if (text[i] === close) { if (depth === 0) { endPos = i; break; } depth--; }
+                            }
+                            if (endPos === -1) return false;
+                            return this.setBlockSelection(block, inner ? start + 1 : start, inner ? endPos : endPos + 1);
+                        }
+
+                        return false;
+                    },
+
                     // Execute a motion in 'move' or 'extend' mode
                     execMotion(key, n, mode) {
                         const sel = window.getSelection();
@@ -617,6 +724,8 @@ struct EditableWebView: NSViewRepresentable {
 
                     handleNormal(e) {
                         const key = e.key;
+                        // Ignore bare modifier keys (Shift, Control, etc.)
+                        if (['Shift', 'Control', 'Alt', 'Meta', 'CapsLock'].includes(key)) return;
                         if (e.ctrlKey && key === 'r') { document.execCommand('redo'); return; }
 
                         if (/^[1-9]$/.test(key) || (this.count && /^[0-9]$/.test(key))) {
@@ -652,11 +761,39 @@ struct EditableWebView: NSViewRepresentable {
                             }
                             if (op === 'f' || op === 't' || op === 'F' || op === 'T') return;
 
+                            // Visual mode text objects: viw, vi", etc.
+                            if (op === 'visual_obj') {
+                                const inner = this.textObjInner;
+                                delete this.textObjInner;
+                                this.selectTextObject(key, inner);
+                                return;
+                            }
+
                             // Line ops: dd, cc, yy, gg
                             if (combo === 'dd') { this.deleteLine(pn); this.recordAction(['dd']); return; }
                             if (combo === 'cc') { this.changeLine(pn); return; }
                             if (combo === 'yy') { this.yankLine(pn); return; }
                             if (combo === 'gg') { this.goToTop(); return; }
+
+                            // Text objects: di, ci, yi + next key; da, ca, ya + next key
+                            if ((op === 'd' || op === 'c' || op === 'y') && (key === 'i' || key === 'a')) {
+                                this.pending = op;
+                                this.pendingCount = pn;
+                                this.textObjInner = (key === 'i');
+                                return;
+                            }
+
+                            // Resolve text object (e.g. diw, ci", ya()
+                            if ((op === 'd' || op === 'c' || op === 'y') && this.textObjInner !== undefined) {
+                                const inner = this.textObjInner;
+                                delete this.textObjInner;
+                                if (this.selectTextObject(key, inner)) {
+                                    this.applyOperator(op);
+                                    if (op === 'd') this.recordAction([op, inner ? 'i' : 'a', key]);
+                                    return;
+                                }
+                                return;
+                            }
 
                             // Operator + motion (dw, cw, yw, d$, etc.)
                             if ((op === 'd' || op === 'c' || op === 'y') && this.execMotion(key, pn, 'extend')) {
@@ -704,8 +841,14 @@ struct EditableWebView: NSViewRepresentable {
                                 this.notifyMode();
                                 break;
                             // Insert mode entries (not in visual)
-                            case 'i': if (!this.visual) this.setMode('insert'); break;
-                            case 'a': if (!this.visual) { if (sel.rangeCount) sel.modify('move','forward','character'); this.setMode('insert'); } break;
+                            case 'i':
+                                if (this.visual) { this.pending = 'visual_obj'; this.textObjInner = true; }
+                                else this.setMode('insert');
+                                break;
+                            case 'a':
+                                if (this.visual) { this.pending = 'visual_obj'; this.textObjInner = false; }
+                                else { if (sel.rangeCount) sel.modify('move','forward','character'); this.setMode('insert'); }
+                                break;
                             case 'I': if (!this.visual) { if (sel.rangeCount) sel.modify('move','backward','lineboundary'); this.setMode('insert'); } break;
                             case 'A': if (!this.visual) { if (sel.rangeCount) sel.modify('move','forward','lineboundary'); this.setMode('insert'); } break;
                             case 'o': if (!this.visual) { this.openLineBelow(); this.setMode('insert'); } break;

--- a/gui/durian/Views/EditableWebView.swift
+++ b/gui/durian/Views/EditableWebView.swift
@@ -23,6 +23,7 @@ struct EditableWebView: NSViewRepresentable {
     @Binding var htmlBody: String
     var onFormatStateChange: ((_ bold: Bool, _ italic: Bool, _ underline: Bool, _ strikethrough: Bool, _ fontSize: Int, _ fontFamily: String, _ alignment: String) -> Void)?
     var onVimModeChange: ((_ mode: String) -> Void)?
+    var onSearchRequest: (() -> Void)?
     var vimInsertExitKeys: [String] = []
 
     func makeNSView(context: Context) -> WKWebView {
@@ -39,6 +40,7 @@ struct EditableWebView: NSViewRepresentable {
         config.userContentController.add(handler, name: "vimModeChanged")
         config.userContentController.add(handler, name: "vimYank")
         config.userContentController.add(handler, name: "vimPaste")
+        config.userContentController.add(handler, name: "vimSearch")
 
         let webView = ScrollPassthroughWebView(frame: .zero, configuration: config)
         #if DEBUG
@@ -896,6 +898,9 @@ struct EditableWebView: NSViewRepresentable {
                             case '>': this.pending = '>'; this.pendingCount = n; break;
                             case '<': this.pending = '<'; this.pendingCount = n; break;
                             case '%': this.matchBracket(); break;
+                            case '/': this.openSearch(); break;
+                            case 'n': this.searchNext(false); break;
+                            case 'N': this.searchNext(true); break;
                             case 'Escape':
                                 if (this.visual) { this.visual = ''; sel.collapseToEnd(); this.notifyMode(); }
                                 this.pending = '';
@@ -1033,6 +1038,49 @@ struct EditableWebView: NSViewRepresentable {
                                 return;
                             }
                             offset += len;
+                        }
+                    },
+
+                    // / search
+                    lastSearch: '',
+
+                    openSearch() {
+                        window.webkit.messageHandlers.vimSearch.postMessage({});
+                    },
+
+                    doSearch(query) {
+                        console.log('[vimsearch] doSearch called:', query);
+                        if (query) {
+                            this.lastSearch = query;
+                            this.searchNext(false);
+                        }
+                        editor.focus();
+                    },
+
+                    searchNext(reverse) {
+                        console.log('[vimsearch] searchNext reverse=' + reverse, 'lastSearch=' + this.lastSearch);
+                        if (!this.lastSearch) return;
+                        const sel = window.getSelection();
+                        // Collapse to end of current selection to search forward
+                        if (!reverse && sel.rangeCount && !sel.isCollapsed) {
+                            sel.collapseToEnd();
+                        } else if (reverse && sel.rangeCount && !sel.isCollapsed) {
+                            sel.collapseToStart();
+                        }
+                        const found = window.find(this.lastSearch, false, reverse, true);
+                        if (!found) {
+                            // Wrap around: move to start/end and try again
+                            const range = document.createRange();
+                            if (reverse) {
+                                range.selectNodeContents(editor);
+                                range.collapse(false);
+                            } else {
+                                range.setStart(editor, 0);
+                                range.collapse(true);
+                            }
+                            sel.removeAllRanges();
+                            sel.addRange(range);
+                            window.find(this.lastSearch, false, reverse, true);
                         }
                     },
 
@@ -1349,6 +1397,24 @@ struct EditableWebView: NSViewRepresentable {
         var lastLoadedSignature: String?
         var initialLoadDone = false
         private var isUpdating = false
+        private var searchObserver: Any?
+
+        override init() {
+            super.init()
+            searchObserver = NotificationCenter.default.addObserver(
+                forName: .vimSearchSubmit, object: nil, queue: .main
+            ) { [weak self] notification in
+                guard let query = notification.object as? String else { return }
+                self?.webView?.window?.makeFirstResponder(self?.webView)
+                self?.webView?.evaluateJavaScript("vim.doSearch('\(query)')")
+            }
+        }
+
+        deinit {
+            if let observer = searchObserver {
+                NotificationCenter.default.removeObserver(observer)
+            }
+        }
 
         func userContentController(_ userContentController: WKUserContentController, didReceive message: WKScriptMessage) {
             switch message.name {
@@ -1405,6 +1471,14 @@ struct EditableWebView: NSViewRepresentable {
                     .replacingOccurrences(of: "\n", with: "\\n")
                     .replacingOccurrences(of: "\r", with: "")
                 webView?.evaluateJavaScript("vim.doPaste('\(escaped)', \(before))")
+            case "vimSearch":
+                DispatchQueue.main.async {
+                    self.parent?.onSearchRequest?()
+                }
+            case "vimSearchFocus":
+                DispatchQueue.main.async {
+                    self.webView?.window?.makeFirstResponder(self.webView)
+                }
             default:
                 break
             }


### PR DESCRIPTION
## Summary
- **Text objects**: `iw/aw`, `iW/aW`, `i"/a"`, `i'/a'`, `` i`/a` ``, `i(/a(`, `i{/a{`, `i[/a[`, `i</a<` — works with `d`, `c`, `y` and visual mode
- **Search**: `/` opens native search pill, Enter searches, `n`/`N` navigate matches
- **Indent**: `>>` indent (tab), `<<` outdent
- **Bracket matching**: `%` jumps to matching bracket
- **Fix**: ignore bare modifier keys (Shift, Control, etc.) in vim normal mode
- **Debug**: enable WKWebView inspection in debug builds
- **Docs**: vim compose keybindings reference

Closes #101

## Test plan
- [x] `diw`, `ciw`, `yiw` — delete/change/yank inner word
- [x] `di"`, `ci(`, `da{` — quotes and brackets
- [x] `viw`, `vi"` — visual mode text objects
- [x] `>>` indent, `<<` outdent
- [x] `%` bracket matching
- [x] `/` search + `n`/`N` navigation
- [x] `.` repeat works with text objects