### PR TITLE
fix: dark mode email body rendering

### DIFF
--- a/gui/durian/Utilities/DarkModeTransform.swift
+++ b/gui/durian/Utilities/DarkModeTransform.swift
@@ -1,0 +1,146 @@
+//
+//  DarkModeTransform.swift
+//  Durian
+//
+//  CIELAB dark mode color transform for HTML emails.
+//  Injected via evaluateJavaScript after page load in WKWebView.
+//
+
+import Foundation
+
+enum DarkModeTransform {
+    /// JavaScript that walks the DOM and transforms colors for dark mode.
+    /// Uses CIELAB L* manipulation for perceptually accurate color transformation.
+    static let js = """
+    (function() {
+        const DARK_BG = [42, 42, 44];
+        const MIN_CONTRAST = 4.5;
+
+        function toLinear(c) {
+            c = c / 255;
+            return c <= 0.04045 ? c / 12.92 : Math.pow((c + 0.055) / 1.055, 2.4);
+        }
+
+        function toSRGB(c) {
+            c = Math.max(0, Math.min(1, c));
+            return c <= 0.0031308 ? Math.round(c * 12.92 * 255) : Math.round((1.055 * Math.pow(c, 1/2.4) - 0.055) * 255);
+        }
+
+        function luminance(r, g, b) {
+            return 0.2126 * toLinear(r) + 0.7152 * toLinear(g) + 0.0722 * toLinear(b);
+        }
+
+        function contrast(l1, l2) {
+            const lighter = Math.max(l1, l2);
+            const darker = Math.min(l1, l2);
+            return (lighter + 0.05) / (darker + 0.05);
+        }
+
+        function rgbToLab(r, g, b) {
+            let lr = toLinear(r), lg = toLinear(g), lb = toLinear(b);
+            let x = (0.4124564 * lr + 0.3575761 * lg + 0.1804375 * lb) / 0.95047;
+            let y = (0.2126729 * lr + 0.7151522 * lg + 0.0721750 * lb) / 1.0;
+            let z = (0.0193339 * lr + 0.1191920 * lg + 0.9503041 * lb) / 1.08883;
+            const f = (t) => t > 0.008856 ? Math.pow(t, 1/3) : (903.3 * t + 16) / 116;
+            x = f(x); y = f(y); z = f(z);
+            return [116 * y - 16, 500 * (x - y), 200 * (y - z)];
+        }
+
+        function labToRgb(L, a, b) {
+            let y = (L + 16) / 116;
+            let x = a / 500 + y;
+            let z = y - b / 200;
+            const finv = (t) => t > 0.206897 ? t * t * t : (116 * t - 16) / 903.3;
+            x = finv(x) * 0.95047; y = finv(y) * 1.0; z = finv(z) * 1.08883;
+            let lr =  3.2404542 * x - 1.5371385 * y - 0.4985314 * z;
+            let lg = -0.9692660 * x + 1.8760108 * y + 0.0415560 * z;
+            let lb =  0.0556434 * x - 0.2040259 * y + 1.0572252 * z;
+            return [toSRGB(lr), toSRGB(lg), toSRGB(lb)];
+        }
+
+        function fixContrast(r, g, b, bgL) {
+            const lab = rgbToLab(r, g, b);
+            const baseLValue = rgbToLab(DARK_BG[0], DARK_BG[1], DARK_BG[2])[0];
+            let newL = lab[0] * ((100 - baseLValue) / 100) + baseLValue;
+            const floor = 50 + baseLValue;
+            const ceiling = 50;
+            const mid = (floor + ceiling) / 2;
+            if (bgL > mid) {
+                newL = Math.min(newL, 2 * mid - newL);
+                newL = ((newL - baseLValue) * (ceiling - baseLValue)) / (mid - baseLValue) + baseLValue;
+            } else {
+                newL = Math.max(newL, 2 * mid - newL);
+                newL = 100 - ((100 - newL) * (100 - floor)) / (100 - mid);
+            }
+            return labToRgb(newL, lab[1], lab[2]);
+        }
+
+        function parseColor(str) {
+            if (!str || str === 'transparent' || str === 'rgba(0, 0, 0, 0)') return null;
+            const m = str.match(/rgba?\\((\\d+),\\s*(\\d+),\\s*(\\d+)/);
+            if (m) return [+m[1], +m[2], +m[3]];
+            return null;
+        }
+
+        const darkBgLum = luminance(DARK_BG[0], DARK_BG[1], DARK_BG[2]);
+
+        // Check html element
+        const htmlBg = parseColor(window.getComputedStyle(document.documentElement).backgroundColor);
+        if (htmlBg && luminance(htmlBg[0], htmlBg[1], htmlBg[2]) > 0.3) {
+            document.documentElement.style.setProperty('background-color', 'transparent', 'important');
+        }
+
+        // Check body
+        const bodyBg = parseColor(window.getComputedStyle(document.body).backgroundColor);
+        if (bodyBg && luminance(bodyBg[0], bodyBg[1], bodyBg[2]) > 0.3) {
+            document.body.style.setProperty('background-color', 'transparent', 'important');
+        }
+
+        const els = document.body.querySelectorAll('*');
+        for (const el of els) {
+            const tag = el.tagName;
+            if (tag === 'IMG' || tag === 'VIDEO' || tag === 'IFRAME' || tag === 'SVG') continue;
+
+            const style = window.getComputedStyle(el);
+
+            const bg = parseColor(style.backgroundColor);
+            if (bg) {
+                const bgLum = luminance(bg[0], bg[1], bg[2]);
+                if (bgLum > 0.3) {
+                    // Light backgrounds → transparent (let dark card show through)
+                    el.style.setProperty('background-color', 'transparent', 'important');
+                } else if (bgLum > 0.15) {
+                    // Medium-light backgrounds → darken via CIELAB
+                    const newBg = fixContrast(bg[0], bg[1], bg[2], darkBgLum);
+                    el.style.setProperty('background-color', 'rgb(' + newBg.join(',') + ')', 'important');
+                }
+            }
+
+            const fg = parseColor(style.color);
+            if (fg) {
+                const fgLum = luminance(fg[0], fg[1], fg[2]);
+                if (fgLum < 0.4) {
+                    const newFg = fixContrast(fg[0], fg[1], fg[2], darkBgLum);
+                    const newFgLum = luminance(newFg[0], newFg[1], newFg[2]);
+                    if (contrast(newFgLum, darkBgLum) >= MIN_CONTRAST) {
+                        el.style.setProperty('color', 'rgb(' + newFg.join(',') + ')', 'important');
+                    } else {
+                        el.style.setProperty('color', '#e5e5e5', 'important');
+                    }
+                }
+            }
+        }
+
+        const links = document.querySelectorAll('a');
+        for (const a of links) {
+            const fg = parseColor(window.getComputedStyle(a).color);
+            if (fg) {
+                const fgLum = luminance(fg[0], fg[1], fg[2]);
+                if (fgLum < 0.3) {
+                    a.style.setProperty('color', '#6ba3f7', 'important');
+                }
+            }
+        }
+    })();
+    """
+}

--- a/gui/durian/Views/EmailWebView.swift
+++ b/gui/durian/Views/EmailWebView.swift
@@ -22,14 +22,15 @@ struct EmailWebView: NSViewRepresentable {
     func makeNSView(context: Context) -> WKWebView {
         let config = WKWebViewConfiguration()
         
-        // SECURITY: Disable JavaScript completely
-        config.defaultWebpagePreferences.allowsContentJavaScript = false
+        // JavaScript is disabled in HTML via CSP (script-src 'none').
+        // evaluateJavaScript from Swift bypasses CSP for dark mode transform.
         
         // SECURITY: Disable auto-opening windows
         config.preferences.javaScriptCanOpenWindowsAutomatically = false
         
         let webView = WKWebView(frame: .zero, configuration: config)
         webView.navigationDelegate = context.coordinator
+        context.coordinator.parent = self
         return webView
     }
     
@@ -57,30 +58,17 @@ struct EmailWebView: NSViewRepresentable {
                 a { color: #0066cc; }
             """
         case "dark":
-            // Always invert for robust dark mode (handles inline styles)
             themeCSS = """
-                html {
-                    filter: invert(1) hue-rotate(180deg);
-                    background-color: #1e1e1e;
-                }
-                img, video, iframe, [style*="background-image"] {
-                    filter: invert(1) hue-rotate(180deg);
-                }
+                body { background-color: #2a2a2c; }
             """
         default: // "system" - follow system preference via @media query
             themeCSS = """
-                @media (prefers-color-scheme: dark) {
-                    html {
-                        filter: invert(1) hue-rotate(180deg);
-                        background-color: #1e1e1e;
-                    }
-                    img, video, iframe, [style*="background-image"] {
-                        filter: invert(1) hue-rotate(180deg);
-                    }
-                }
                 @media (prefers-color-scheme: light) {
                     body { background-color: #ffffff; color: #000000; }
                     a { color: #0066cc; }
+                }
+                @media (prefers-color-scheme: dark) {
+                    body { background-color: #2a2a2c; }
                 }
             """
         }
@@ -113,8 +101,18 @@ struct EmailWebView: NSViewRepresentable {
     func makeCoordinator() -> Coordinator {
         Coordinator()
     }
-    
+
     class Coordinator: NSObject, WKNavigationDelegate {
+        var parent: EmailWebView?
+
+        func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {
+            let isDark = parent?.theme == "dark" ||
+                (parent?.theme == "system" && NSApp.effectiveAppearance.bestMatch(from: [.aqua, .darkAqua]) == .darkAqua)
+            if isDark {
+                webView.evaluateJavaScript(DarkModeTransform.js)
+            }
+        }
+
         // Links open in default browser (not in WebView)
         func webView(_ webView: WKWebView, decidePolicyFor navigationAction: WKNavigationAction, decisionHandler: @escaping (WKNavigationActionPolicy) -> Void) {
             if navigationAction.navigationType == .linkActivated,

--- a/gui/durian/Views/NonScrollingWebView.swift
+++ b/gui/durian/Views/NonScrollingWebView.swift
@@ -49,9 +49,13 @@ struct NonScrollingWebView: NSViewRepresentable {
         
         // Use custom WebView that passes scroll events to parent
         let webView = ScrollPassthroughWebView(frame: .zero, configuration: config)
+        #if DEBUG
+        webView.isInspectable = true
+        #endif
         webView.navigationDelegate = context.coordinator
         
         // Transparent background (let parent handle background color)
+        webView.setValue(false, forKey: "drawsBackground")
         webView.wantsLayer = true
         webView.layer?.backgroundColor = NSColor.clear.cgColor
         
@@ -96,29 +100,14 @@ struct NonScrollingWebView: NSViewRepresentable {
                 a { color: #0066cc; }
             """
         case "dark":
-            themeCSS = """
-                html {
-                    filter: invert(1) hue-rotate(180deg);
-                    background-color: transparent;
-                }
-                img, video, iframe, [style*="background-image"] {
-                    filter: invert(1) hue-rotate(180deg);
-                }
-            """
+            themeCSS = ""
         default: // "system" - follow system preference via @media query
             themeCSS = """
-                @media (prefers-color-scheme: dark) {
-                    html {
-                        filter: invert(1) hue-rotate(180deg);
-                        background-color: transparent;
-                    }
-                    img, video, iframe, [style*="background-image"] {
-                        filter: invert(1) hue-rotate(180deg);
-                    }
-                }
                 @media (prefers-color-scheme: light) {
                     body { background-color: transparent; color: #000000; }
                     a { color: #0066cc; }
+                }
+                @media (prefers-color-scheme: dark) {
                 }
             """
         }
@@ -165,18 +154,35 @@ struct NonScrollingWebView: NSViewRepresentable {
         func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {
             // Capture email ID at callback time to detect stale callbacks
             let expectedEmailId = loadedForEmailId
-            
-            // Measure content height after page loads
-            webView.evaluateJavaScript("document.body.scrollHeight") { [weak self] result, error in
-                if let height = result as? CGFloat, height > 0 {
-                    DispatchQueue.main.async {
-                        // Only update height if still showing the same email (prevents race conditions)
-                        guard self?.parent?.emailId == expectedEmailId else { return }
-                        self?.parent?.contentHeight = height
+
+            // Apply dark mode color transformation if needed
+            let isDark = parent?.theme == "dark" ||
+                (parent?.theme == "system" && NSApp.effectiveAppearance.bestMatch(from: [.aqua, .darkAqua]) == .darkAqua)
+            if isDark {
+                webView.evaluateJavaScript(DarkModeTransform.js) { _, _ in
+                    // Measure height after dark mode transform (colors may affect layout)
+                    webView.evaluateJavaScript("document.body.scrollHeight") { [weak self] result, _ in
+                        if let height = result as? CGFloat, height > 0 {
+                            DispatchQueue.main.async {
+                                guard self?.parent?.emailId == expectedEmailId else { return }
+                                self?.parent?.contentHeight = height
+                            }
+                        }
+                    }
+                }
+            } else {
+                // Light mode: just measure height
+                webView.evaluateJavaScript("document.body.scrollHeight") { [weak self] result, _ in
+                    if let height = result as? CGFloat, height > 0 {
+                        DispatchQueue.main.async {
+                            guard self?.parent?.emailId == expectedEmailId else { return }
+                            self?.parent?.contentHeight = height
+                        }
                     }
                 }
             }
         }
+
         
         // Links open in default browser
         func webView(_ webView: WKWebView, decidePolicyFor navigationAction: WKNavigationAction, decisionHandler: @escaping (WKNavigationActionPolicy) -> Void) {


### PR DESCRIPTION
## Summary
Replace CSS `filter: invert(1) hue-rotate(180deg)` with a JS DOM walk that transforms colors per-element using CIELAB L* manipulation:

- Dark text → lightened for readability on dark cards
- Light/white backgrounds → transparent (card background shows through)
- Medium backgrounds → darkened via CIELAB
- Images/media untouched
- Dark links → blue fallback
- WCAG AA 4.5:1 contrast enforcement

Also: `drawsBackground = false` on NonScrollingWebView to eliminate WKWebView default white background, and `isInspectable = true` in debug builds.

Closes #110

## Test plan
- [x] Plain text emails render correctly in dark mode
- [x] HTML emails with inline `color: #000` show light text
- [x] Emails with `background-color` in `<style>` blocks (e.g. Hetzner) → transparent
- [x] Newsletter-style emails with table backgrounds (Marketo, Reichelt) → transparent
- [x] Already-dark emails (dark bg + light text) left untouched
- [x] Images not affected
- [x] Light mode unaffected