### PR TITLE
feat: instant sent folder visibility

### DIFF
--- a/cli/internal/handler/BUILD.bazel
+++ b/cli/internal/handler/BUILD.bazel
@@ -20,6 +20,7 @@ go_library(
         "//cli/internal/auth",
         "//cli/internal/config",
         "//cli/internal/contacts",
+        "//cli/internal/encoding",
         "//cli/internal/imap",
         "//cli/internal/mail",
         "//cli/internal/protocol",

--- a/cli/internal/handler/outbox.go
+++ b/cli/internal/handler/outbox.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/durian-dev/durian/cli/internal/auth"
 	"github.com/durian-dev/durian/cli/internal/config"
+	"github.com/durian-dev/durian/cli/internal/encoding"
 	imapClient "github.com/durian-dev/durian/cli/internal/imap"
 	"github.com/durian-dev/durian/cli/internal/smtp"
 	"github.com/durian-dev/durian/cli/internal/store"
@@ -278,6 +279,11 @@ func (w *OutboxWorker) sendItem(item *store.OutboxItem) {
 	// Success — delete from outbox
 	slog.Info("Outbox item sent successfully", "module", "OUTBOX", "id", item.ID)
 	w.store.DeleteOutboxItem(item.ID)
+
+	// Save to local SQLite store so Sent folder shows the email immediately
+	// (without waiting for next IMAP sync).
+	w.saveToLocalStore(account, msg, &draft)
+
 	w.broadcastStatus(item.ID, "sent", "", draft.Subject, strings.Join(draft.To, ", "))
 
 	// Append to IMAP Sent folder (best-effort, same logic as send.go)
@@ -302,6 +308,51 @@ func (w *OutboxWorker) findAccount(from string) *config.AccountConfig {
 		}
 	}
 	return nil
+}
+
+// saveToLocalStore inserts the sent email into SQLite so the GUI can show it
+// immediately without waiting for the next IMAP sync. Best-effort: errors are
+// logged but do not affect the send result.
+func (w *OutboxWorker) saveToLocalStore(account *config.AccountConfig, msg *smtp.Message, draft *OutboxDraft) {
+	messageID := strings.Trim(msg.GeneratedMessageID, "<>")
+	if messageID == "" {
+		slog.Warn("No Message-ID available, skipping local store insert", "module", "OUTBOX")
+		return
+	}
+
+	now := time.Now().Unix()
+	fromAddr := account.Email
+	if account.DisplayName != "" {
+		fromAddr = fmt.Sprintf("%s <%s>", account.DisplayName, account.Email)
+	}
+	storeMsg := &store.Message{
+		MessageID:   messageID,
+		Subject:     draft.Subject,
+		FromAddr:    fromAddr,
+		ToAddrs:     strings.Join(draft.To, ", "),
+		CCAddrs:     strings.Join(draft.CC, ", "),
+		InReplyTo:   draft.InReplyTo,
+		Refs:        draft.References,
+		Date:        now,
+		CreatedAt:   now,
+		Flags:       "Seen",
+		FetchedBody: true,
+		Account:     account.AccountIdentifier(),
+	}
+	if draft.IsHTML {
+		storeMsg.BodyHTML = draft.Body
+		storeMsg.BodyText = encoding.HTMLToText(draft.Body)
+	} else {
+		storeMsg.BodyText = draft.Body
+	}
+
+	if err := w.store.InsertMessage(storeMsg); err != nil {
+		slog.Warn("Failed to save sent email to local store", "module", "OUTBOX", "err", err)
+		return
+	}
+	if err := w.store.AddTag(storeMsg.ID, "sent"); err != nil {
+		slog.Warn("Failed to tag sent email", "module", "OUTBOX", "err", err)
+	}
 }
 
 // appendToSent saves a copy to the IMAP Sent folder (skip for providers that auto-save).

--- a/cli/internal/smtp/mime.go
+++ b/cli/internal/smtp/mime.go
@@ -27,6 +27,9 @@ type Message struct {
 	InReplyTo  string // Message-ID of the message being replied to
 	References string // Space-separated list of Message-IDs in the thread
 	Attachments []Attachment
+	// GeneratedMessageID is populated by Build() on first call and reused on
+	// subsequent calls so that SMTP send and IMAP append share the same ID.
+	GeneratedMessageID string
 }
 
 // Attachment represents a file attachment
@@ -60,16 +63,20 @@ func LoadAttachment(path string) (*Attachment, error) {
 func (m *Message) Build() ([]byte, error) {
 	var buf bytes.Buffer
 
-	// Generate Message-ID using sender's domain
-	domain := "localhost"
-	if at := strings.LastIndex(m.From, "@"); at != -1 {
-		d := strings.TrimSpace(m.From[at+1:])
-		d = strings.TrimRight(d, ">")
-		if d != "" {
-			domain = d
+	// Generate Message-ID using sender's domain (reuse on subsequent calls)
+	messageID := m.GeneratedMessageID
+	if messageID == "" {
+		domain := "localhost"
+		if at := strings.LastIndex(m.From, "@"); at != -1 {
+			d := strings.TrimSpace(m.From[at+1:])
+			d = strings.TrimRight(d, ">")
+			if d != "" {
+				domain = d
+			}
 		}
+		messageID = fmt.Sprintf("<%s@%s>", uuid.New().String(), domain)
+		m.GeneratedMessageID = messageID
 	}
-	messageID := fmt.Sprintf("<%s@%s>", uuid.New().String(), domain)
 
 	// Format date per RFC 5322
 	date := time.Now().Format("Mon, 02 Jan 2006 15:04:05 -0700")

--- a/gui/durian/Views/EmailRowView.swift
+++ b/gui/durian/Views/EmailRowView.swift
@@ -260,10 +260,14 @@ struct EmailRowView: View {
         }
         // All authors are own → sent message. Show recipients instead.
         if let to = email.to, !to.isEmpty {
-            let recipients = Self.parseAddressList(to)
-                .filter { !Self.isOwn($0) }
-            if !recipients.isEmpty {
-                return recipients.map { Self.participant(from: $0) }
+            let allRecipients = Self.parseAddressList(to)
+            let externalRecipients = allRecipients.filter { !Self.isOwn($0) }
+            if !externalRecipients.isEmpty {
+                return externalRecipients.map { Self.participant(from: $0) }
+            }
+            // All recipients are also own (sent to self) — show them anyway
+            if !allRecipients.isEmpty {
+                return allRecipients.map { Self.participant(from: $0) }
             }
         }
         return authors.map { Participant(name: Self.extractName(from: $0), email: $0) }


### PR DESCRIPTION
## Summary
- **Go**: Save sent emails to local SQLite immediately after SMTP success, so the GUI Sent folder shows them without waiting for the next IMAP sync
- **Go**: Fix duplicate Message-ID bug — `Build()` now caches the generated ID so SMTP send and IMAP append share the same one
- **Swift**: Fix sent-to-self display — show recipient name in list even when recipient is another own account

## Details

After SMTP delivery, `saveToLocalStore()` inserts the message into the store with a `sent` tag. On next IMAP sync, the UPSERT matches via `UNIQUE(message_id, account)` and updates `uid`/`mailbox` — no duplicates.

Verified with `durian sync h --debug`: 4 sent test emails correctly deduplicated.

## Test plan
- [x] Send new email → appears in Sent folder immediately
- [x] Body preview shows in list (HTML→plaintext via `encoding.HTMLToText`)
- [x] Recipient name shown in list (not sender)
- [x] Sent-to-self shows recipient name
- [x] `durian sync` deduplicates correctly (no duplicate entries)
- [x] All CLI tests pass (`bazel test //cli/...`)
- [x] GUI builds successfully (`bazel build //gui:Durian`)