### PR TITLE
refactor: store local drafts in SQLite, instant draft visibility

### DIFF
--- a/cli/cmd/durian/draft.go
+++ b/cli/cmd/durian/draft.go
@@ -4,11 +4,15 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"log/slog"
 	"os"
+	"strings"
+	"time"
 
 	"github.com/durian-dev/durian/cli/internal/config"
 	"github.com/durian-dev/durian/cli/internal/draft"
 	"github.com/durian-dev/durian/cli/internal/smtp"
+	"github.com/durian-dev/durian/cli/internal/store"
 	"github.com/spf13/cobra"
 )
 
@@ -193,6 +197,9 @@ func runDraftSave(cmd *cobra.Command, args []string) error {
 		return outputDraftError(fmt.Sprintf("failed to save draft: %v", err))
 	}
 
+	// Save to local SQLite store so Drafts folder shows it immediately
+	saveDraftToLocalStore(account, result.MessageID, msg)
+
 	// Output success
 	resp := draftResponse{
 		OK:        true,
@@ -230,6 +237,54 @@ func runDraftDelete(cmd *cobra.Command, args []string) error {
 	// Output success
 	resp := draftResponse{OK: true}
 	return outputJSON(resp)
+}
+
+// saveDraftToLocalStore inserts the draft into SQLite so the Drafts folder
+// shows it immediately without waiting for the next IMAP sync.
+func saveDraftToLocalStore(account *config.AccountConfig, messageID string, msg *smtp.Message) {
+	messageID = strings.Trim(messageID, "<>")
+	if messageID == "" {
+		return
+	}
+
+	db, err := store.Open(store.DefaultDBPath())
+	if err != nil {
+		slog.Debug("Could not open store for draft insert", "module", "DRAFT", "err", err)
+		return
+	}
+	defer db.Close()
+
+	now := time.Now().Unix()
+	fromAddr := account.Email
+	if account.DisplayName != "" {
+		fromAddr = fmt.Sprintf("%s <%s>", account.DisplayName, account.Email)
+	}
+
+	storeMsg := &store.Message{
+		MessageID:   messageID,
+		Subject:     msg.Subject,
+		FromAddr:    fromAddr,
+		ToAddrs:     strings.Join(msg.To, ", "),
+		CCAddrs:     strings.Join(msg.CC, ", "),
+		InReplyTo:   msg.InReplyTo,
+		Refs:        msg.References,
+		Date:        now,
+		CreatedAt:   now,
+		Flags:       "Draft,Seen",
+		FetchedBody: true,
+		Account:     account.AccountIdentifier(),
+	}
+	if msg.IsHTML {
+		storeMsg.BodyHTML = msg.Body
+	} else {
+		storeMsg.BodyText = msg.Body
+	}
+
+	if err := db.InsertMessage(storeMsg); err != nil {
+		slog.Debug("Failed to save draft to local store", "module", "DRAFT", "err", err)
+		return
+	}
+	_ = db.AddTag(storeMsg.ID, "draft")
 }
 
 func outputDraftError(message string) error {

--- a/cli/cmd/durian/serve.go
+++ b/cli/cmd/durian/serve.go
@@ -105,6 +105,12 @@ func runServe(cmd *cobra.Command, args []string) {
 	r.HandleFunc("/api/v1/outbox", h.ListOutboxHandler).Methods("GET")
 	r.HandleFunc("/api/v1/outbox/{id}", h.DeleteOutboxHandler).Methods("DELETE")
 
+	// Local draft routes (crash-recovery, not IMAP)
+	r.HandleFunc("/api/v1/local-drafts", h.ListLocalDraftsHandler).Methods("GET")
+	r.HandleFunc("/api/v1/local-drafts/{id}", h.SaveLocalDraftHandler).Methods("PUT")
+	r.HandleFunc("/api/v1/local-drafts/{id}", h.GetLocalDraftHandler).Methods("GET")
+	r.HandleFunc("/api/v1/local-drafts/{id}", h.DeleteLocalDraftHandler).Methods("DELETE")
+
 	// Start IMAP IDLE watchers if accounts are configured
 	watcherCtx, watcherCancel := context.WithCancel(context.Background())
 	defer watcherCancel()

--- a/cli/internal/handler/BUILD.bazel
+++ b/cli/internal/handler/BUILD.bazel
@@ -4,6 +4,7 @@ go_library(
     name = "handler",
     srcs = [
         "contacts.go",
+        "drafts.go",
         "events.go",
         "handler.go",
         "http.go",

--- a/cli/internal/handler/drafts.go
+++ b/cli/internal/handler/drafts.go
@@ -1,0 +1,97 @@
+package handler
+
+import (
+	"encoding/json"
+	"log/slog"
+	"net/http"
+
+	"github.com/gorilla/mux"
+
+	"github.com/durian-dev/durian/cli/internal/store"
+)
+
+// SaveLocalDraftHandler handles PUT /api/v1/local-drafts/{id}.
+func (h *Handler) SaveLocalDraftHandler(w http.ResponseWriter, r *http.Request) {
+	id := mux.Vars(r)["id"]
+	if id == "" {
+		http.Error(w, "Missing draft ID", http.StatusBadRequest)
+		return
+	}
+
+	var body struct {
+		DraftJSON json.RawMessage `json:"draft_json"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		http.Error(w, "Invalid request body", http.StatusBadRequest)
+		return
+	}
+
+	draft := &store.LocalDraft{
+		ID:        id,
+		DraftJSON: string(body.DraftJSON),
+	}
+	if err := h.store.SaveLocalDraft(draft); err != nil {
+		slog.Error("Failed to save local draft", "module", "DRAFTS", "id", id, "err", err)
+		http.Error(w, "Failed to save draft", http.StatusInternalServerError)
+		return
+	}
+
+	writeJSON(w, map[string]any{"ok": true})
+}
+
+// GetLocalDraftHandler handles GET /api/v1/local-drafts/{id}.
+func (h *Handler) GetLocalDraftHandler(w http.ResponseWriter, r *http.Request) {
+	id := mux.Vars(r)["id"]
+	draft, err := h.store.GetLocalDraft(id)
+	if err != nil {
+		http.Error(w, "Draft not found", http.StatusNotFound)
+		return
+	}
+
+	writeJSON(w, map[string]any{
+		"id":          draft.ID,
+		"draft_json":  json.RawMessage(draft.DraftJSON),
+		"created_at":  draft.CreatedAt,
+		"modified_at": draft.ModifiedAt,
+	})
+}
+
+// DeleteLocalDraftHandler handles DELETE /api/v1/local-drafts/{id}.
+func (h *Handler) DeleteLocalDraftHandler(w http.ResponseWriter, r *http.Request) {
+	id := mux.Vars(r)["id"]
+	if err := h.store.DeleteLocalDraft(id); err != nil {
+		http.Error(w, "Draft not found", http.StatusNotFound)
+		return
+	}
+
+	writeJSON(w, map[string]any{"ok": true})
+}
+
+// ListLocalDraftsHandler handles GET /api/v1/local-drafts.
+func (h *Handler) ListLocalDraftsHandler(w http.ResponseWriter, r *http.Request) {
+	drafts, err := h.store.ListLocalDrafts()
+	if err != nil {
+		slog.Error("Failed to list local drafts", "module", "DRAFTS", "err", err)
+		http.Error(w, "Failed to list drafts", http.StatusInternalServerError)
+		return
+	}
+
+	type entry struct {
+		ID         string          `json:"id"`
+		DraftJSON  json.RawMessage `json:"draft_json"`
+		CreatedAt  int64           `json:"created_at"`
+		ModifiedAt int64           `json:"modified_at"`
+	}
+
+	entries := make([]entry, 0, len(drafts))
+	for _, d := range drafts {
+		entries = append(entries, entry{
+			ID:         d.ID,
+			DraftJSON:  json.RawMessage(d.DraftJSON),
+			CreatedAt:  d.CreatedAt,
+			ModifiedAt: d.ModifiedAt,
+		})
+	}
+
+	writeJSON(w, entries)
+}

--- a/cli/internal/store/BUILD.bazel
+++ b/cli/internal/store/BUILD.bazel
@@ -5,6 +5,7 @@ go_library(
     srcs = [
         "attachments.go",
         "headers.go",
+        "local_drafts.go",
         "messages.go",
         "outbox.go",
         "search.go",

--- a/cli/internal/store/local_drafts.go
+++ b/cli/internal/store/local_drafts.go
@@ -1,0 +1,80 @@
+package store
+
+import (
+	"fmt"
+	"time"
+)
+
+// LocalDraft represents a locally-saved draft for crash recovery.
+type LocalDraft struct {
+	ID         string
+	DraftJSON  string
+	CreatedAt  int64
+	ModifiedAt int64
+}
+
+// SaveLocalDraft upserts a local draft by ID.
+func (d *DB) SaveLocalDraft(draft *LocalDraft) error {
+	now := time.Now().Unix()
+	if draft.CreatedAt == 0 {
+		draft.CreatedAt = now
+	}
+	draft.ModifiedAt = now
+
+	_, err := d.db.Exec(`
+		INSERT INTO local_drafts (id, draft_json, created_at, modified_at)
+		VALUES (?, ?, ?, ?)
+		ON CONFLICT(id) DO UPDATE SET
+			draft_json = excluded.draft_json,
+			modified_at = excluded.modified_at`,
+		draft.ID, draft.DraftJSON, draft.CreatedAt, draft.ModifiedAt)
+	if err != nil {
+		return fmt.Errorf("save local draft: %w", err)
+	}
+	return nil
+}
+
+// GetLocalDraft retrieves a local draft by ID.
+func (d *DB) GetLocalDraft(id string) (*LocalDraft, error) {
+	draft := &LocalDraft{}
+	err := d.db.QueryRow(
+		"SELECT id, draft_json, created_at, modified_at FROM local_drafts WHERE id = ?", id,
+	).Scan(&draft.ID, &draft.DraftJSON, &draft.CreatedAt, &draft.ModifiedAt)
+	if err != nil {
+		return nil, fmt.Errorf("get local draft: %w", err)
+	}
+	return draft, nil
+}
+
+// DeleteLocalDraft removes a local draft by ID.
+func (d *DB) DeleteLocalDraft(id string) error {
+	result, err := d.db.Exec("DELETE FROM local_drafts WHERE id = ?", id)
+	if err != nil {
+		return fmt.Errorf("delete local draft: %w", err)
+	}
+	rows, _ := result.RowsAffected()
+	if rows == 0 {
+		return fmt.Errorf("local draft not found: %s", id)
+	}
+	return nil
+}
+
+// ListLocalDrafts returns all local drafts, newest first.
+func (d *DB) ListLocalDrafts() ([]*LocalDraft, error) {
+	rows, err := d.db.Query(
+		"SELECT id, draft_json, created_at, modified_at FROM local_drafts ORDER BY modified_at DESC")
+	if err != nil {
+		return nil, fmt.Errorf("list local drafts: %w", err)
+	}
+	defer rows.Close()
+
+	var drafts []*LocalDraft
+	for rows.Next() {
+		draft := &LocalDraft{}
+		if err := rows.Scan(&draft.ID, &draft.DraftJSON, &draft.CreatedAt, &draft.ModifiedAt); err != nil {
+			return nil, fmt.Errorf("scan local draft: %w", err)
+		}
+		drafts = append(drafts, draft)
+	}
+	return drafts, rows.Err()
+}

--- a/cli/internal/store/store.go
+++ b/cli/internal/store/store.go
@@ -319,6 +319,24 @@ func (d *DB) migrate() error {
 				return fmt.Errorf("migrate v5→v6: %w", err)
 			}
 		}
+		version = 6
+	}
+
+	if version < 7 {
+		migrations := []string{
+			`CREATE TABLE IF NOT EXISTS local_drafts (
+				id TEXT PRIMARY KEY,
+				draft_json TEXT NOT NULL,
+				created_at INTEGER NOT NULL,
+				modified_at INTEGER NOT NULL
+			)`,
+			"UPDATE schema_version SET version = 7 WHERE rowid = 1",
+		}
+		for _, stmt := range migrations {
+			if _, err := d.db.Exec(stmt); err != nil {
+				return fmt.Errorf("migrate v6→v7: %w", err)
+			}
+		}
 	}
 
 	return nil

--- a/cli/internal/store/store_test.go
+++ b/cli/internal/store/store_test.go
@@ -24,8 +24,8 @@ func TestOpenAndInit(t *testing.T) {
 	if err != nil {
 		t.Fatalf("read version: %v", err)
 	}
-	if version != 6 {
-		t.Errorf("version = %d, want 6", version)
+	if version != 7 {
+		t.Errorf("version = %d, want 7", version)
 	}
 }
 

--- a/gui/durian/Models/EmailComposition.swift
+++ b/gui/durian/Models/EmailComposition.swift
@@ -628,102 +628,110 @@ extension EmailDraft {
 
 class DraftManager {
     static let shared = DraftManager()
-    
-    private let draftsDirectory: URL
-    
-    private init() {
-        let homeURL = FileManager.default.homeDirectoryForCurrentUser
-        draftsDirectory = homeURL.appendingPathComponent(".config/durian/drafts")
-        createDraftsDirectoryIfNeeded()
-    }
-    
-    private func createDraftsDirectoryIfNeeded() {
-        if !FileManager.default.fileExists(atPath: draftsDirectory.path) {
-            do {
-                try FileManager.default.createDirectory(at: draftsDirectory, withIntermediateDirectories: true)
-                Log.debug("DRAFTING", "Created drafts directory at: \(draftsDirectory.path)")
-            } catch {
-                Log.error("DRAFTING", "Failed to create drafts directory: \(error)")
-            }
-        }
-    }
-    
-    func saveDraft(_ draft: EmailDraft) {
-        let fileURL = draftsDirectory.appendingPathComponent("\(draft.id.uuidString).json")
 
+    private let baseURL = URL(string: "http://localhost:9723/api/v1/local-drafts")!
+    private let encoder: JSONEncoder = {
+        let e = JSONEncoder()
+        e.dateEncodingStrategy = .iso8601
+        return e
+    }()
+    private let decoder: JSONDecoder = {
+        let d = JSONDecoder()
+        d.dateDecodingStrategy = .iso8601
+        return d
+    }()
+
+    private init() {}
+
+    func saveDraft(_ draft: EmailDraft) {
         var cleaned = draft
         cleaned.to = Self.filterValidAddresses(draft.to)
         cleaned.cc = Self.filterValidAddresses(draft.cc)
         cleaned.bcc = Self.filterValidAddresses(draft.bcc)
 
         do {
-            let encoder = JSONEncoder()
-            encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
-            encoder.dateEncodingStrategy = .iso8601
-            let data = try encoder.encode(cleaned)
-            try data.write(to: fileURL)
-            Log.debug("DRAFTING", "Draft saved: \(fileURL.lastPathComponent)")
+            let draftData = try encoder.encode(cleaned)
+            let body = try JSONSerialization.data(withJSONObject: [
+                "draft_json": try JSONSerialization.jsonObject(with: draftData)
+            ])
+
+            var request = URLRequest(url: baseURL.appendingPathComponent(draft.id.uuidString))
+            request.httpMethod = "PUT"
+            request.addValue("application/json", forHTTPHeaderField: "Content-Type")
+            request.httpBody = body
+            request.timeoutInterval = 5
+
+            URLSession.shared.dataTask(with: request) { _, response, error in
+                if let error {
+                    Log.error("DRAFTING", "Failed to save draft: \(error)")
+                    return
+                }
+                if let http = response as? HTTPURLResponse, http.statusCode == 200 {
+                    Log.debug("DRAFTING", "Draft saved: \(draft.id.uuidString)")
+                }
+            }.resume()
         } catch {
-            Log.error("DRAFTING", "Failed to save draft: \(error)")
-            Task { @MainActor in
-                BannerManager.shared.showWarning(title: "Draft Not Saved", message: "Could not save draft to disk.")
-            }
+            Log.error("DRAFTING", "Failed to encode draft: \(error)")
         }
     }
-    
+
     func loadDraft(id: UUID) -> EmailDraft? {
-        let fileURL = draftsDirectory.appendingPathComponent("\(id.uuidString).json")
+        let semaphore = DispatchSemaphore(value: 0)
+        var result: EmailDraft?
 
-        guard FileManager.default.fileExists(atPath: fileURL.path) else {
-            return nil
-        }
+        let url = baseURL.appendingPathComponent(id.uuidString)
+        URLSession.shared.dataTask(with: url) { [decoder] data, response, _ in
+            defer { semaphore.signal() }
+            guard let data,
+                  let http = response as? HTTPURLResponse, http.statusCode == 200 else { return }
 
-        do {
-            let data = try Data(contentsOf: fileURL)
-            let decoder = JSONDecoder()
-            decoder.dateDecodingStrategy = .iso8601
-            var draft = try decoder.decode(EmailDraft.self, from: data)
-            draft.to = Self.filterValidAddresses(draft.to)
-            draft.cc = Self.filterValidAddresses(draft.cc)
-            draft.bcc = Self.filterValidAddresses(draft.bcc)
-            return draft
-        } catch {
-            Log.error("DRAFTING", "Failed to load draft: \(error)")
-            return nil
-        }
-    }
-    
-    func deleteDraft(id: UUID) {
-        let fileURL = draftsDirectory.appendingPathComponent("\(id.uuidString).json")
-        
-        do {
-            try FileManager.default.removeItem(at: fileURL)
-            Log.debug("DRAFTING", "Draft deleted: \(fileURL.lastPathComponent)")
-        } catch {
-            Log.error("DRAFTING", "Failed to delete draft: \(error)")
-        }
-    }
-    
-    func loadAllDrafts() -> [EmailDraft] {
-        var drafts: [EmailDraft] = []
-        
-        guard let files = try? FileManager.default.contentsOfDirectory(at: draftsDirectory, includingPropertiesForKeys: nil) else {
-            return drafts
-        }
-        
-        for fileURL in files where fileURL.pathExtension == "json" {
-            do {
-                let data = try Data(contentsOf: fileURL)
-                let decoder = JSONDecoder()
-                decoder.dateDecodingStrategy = .iso8601
-                let draft = try decoder.decode(EmailDraft.self, from: data)
-                drafts.append(draft)
-            } catch {
-                Log.error("DRAFTING", "Failed to load draft from \(fileURL.lastPathComponent): \(error)")
+            struct Wrapper: Decodable {
+                let draft_json: EmailDraft
             }
-        }
-        
-        return drafts.sorted { $0.modifiedAt > $1.modifiedAt }
+            if let wrapper = try? decoder.decode(Wrapper.self, from: data) {
+                var draft = wrapper.draft_json
+                draft.to = Self.filterValidAddresses(draft.to)
+                draft.cc = Self.filterValidAddresses(draft.cc)
+                draft.bcc = Self.filterValidAddresses(draft.bcc)
+                result = draft
+            }
+        }.resume()
+        semaphore.wait()
+        return result
+    }
+
+    func deleteDraft(id: UUID) {
+        var request = URLRequest(url: baseURL.appendingPathComponent(id.uuidString))
+        request.httpMethod = "DELETE"
+        request.timeoutInterval = 5
+
+        URLSession.shared.dataTask(with: request) { _, _, error in
+            if let error {
+                Log.error("DRAFTING", "Failed to delete draft: \(error)")
+                return
+            }
+            Log.debug("DRAFTING", "Draft deleted: \(id.uuidString)")
+        }.resume()
+    }
+
+    func loadAllDrafts() -> [EmailDraft] {
+        let semaphore = DispatchSemaphore(value: 0)
+        var result: [EmailDraft] = []
+
+        URLSession.shared.dataTask(with: baseURL) { [decoder] data, response, _ in
+            defer { semaphore.signal() }
+            guard let data,
+                  let http = response as? HTTPURLResponse, http.statusCode == 200 else { return }
+
+            struct Entry: Decodable {
+                let draft_json: EmailDraft
+            }
+            if let entries = try? decoder.decode([Entry].self, from: data) {
+                result = entries.map(\.draft_json)
+            }
+        }.resume()
+        semaphore.wait()
+        return result
     }
 
     /// Filter out addresses that don't contain a valid email (must have @)

--- a/gui/durian/Network/EmailBackend.swift
+++ b/gui/durian/Network/EmailBackend.swift
@@ -716,7 +716,7 @@ class EmailBackend: ObservableObject {
     }
 
     func deleteMessage(id: String) async throws {
-        try await tag(query: "thread:\(id)", tags: "+trash -inbox -unread")
+        try await tag(query: "thread:\(id)", tags: "+trash -inbox -unread -draft")
         emails.removeAll { $0.id == id }
         await reload()
     }


### PR DESCRIPTION
## Summary
- **Go**: New `local_drafts` SQLite table (schema v7) with CRUD API endpoints for crash-recovery drafts
- **Go**: `draft save` inserts into local store with `draft` tag after IMAP append — Drafts folder shows draft immediately
- **Swift**: `DraftManager` migrated from JSON file I/O to HTTP API calls
- **Swift**: `dd` on drafts now also removes `draft` tag (`-draft`) so drafts move to Trash on IMAP

## Test plan
- [x] Compose + close window → draft appears in Drafts folder immediately
- [x] Draft visible in Outlook after IMAP append
- [x] Auto-save writes to SQLite (verified via `sqlite3`)
- [x] `dd` on draft removes from Drafts folder
- [x] All CLI tests pass
- [x] GUI builds

Closes #123