### PR TITLE
feat: account-scoped tag picker

### DIFF
--- a/cli/internal/handler/http.go
+++ b/cli/internal/handler/http.go
@@ -77,8 +77,14 @@ func (h *Handler) ShowThreadHandler(w http.ResponseWriter, r *http.Request) {
 }
 
 func (h *Handler) ListTagsHandler(w http.ResponseWriter, r *http.Request) {
-	response := h.ListTags()
-	writeJSON(w, response)
+	account := r.URL.Query().Get("account")
+	if account != "" {
+		response := h.ListTagsForAccounts(strings.Split(account, ","))
+		writeJSON(w, response)
+	} else {
+		response := h.ListTags()
+		writeJSON(w, response)
+	}
 }
 
 func (h *Handler) ShowMessageBodyHandler(w http.ResponseWriter, r *http.Request) {

--- a/cli/internal/handler/tags.go
+++ b/cli/internal/handler/tags.go
@@ -10,3 +10,12 @@ func (h *Handler) ListTags() protocol.Response {
 	}
 	return protocol.SuccessWithTags(tags)
 }
+
+// ListTagsForAccounts returns tags scoped to specific accounts.
+func (h *Handler) ListTagsForAccounts(accounts []string) protocol.Response {
+	tags, err := h.store.ListTags(accounts...)
+	if err != nil {
+		return protocol.Fail(protocol.ErrBackendError, err)
+	}
+	return protocol.SuccessWithTags(tags)
+}

--- a/cli/internal/store/tags.go
+++ b/cli/internal/store/tags.go
@@ -1,6 +1,10 @@
 package store
 
-import "fmt"
+import (
+	"database/sql"
+	"fmt"
+	"strings"
+)
 
 // AddTag adds a tag to a message. No-op if the tag already exists.
 func (d *DB) AddTag(messageDBID int64, tag string) error {
@@ -100,8 +104,23 @@ func (d *DB) GetMessageTags(messageDBID int64) ([]string, error) {
 }
 
 // ListTags returns all distinct tags in the database.
-func (d *DB) ListTags() ([]string, error) {
-	rows, err := d.db.Query("SELECT DISTINCT tag FROM tags ORDER BY tag")
+// When accounts are provided, only tags from those accounts are included.
+func (d *DB) ListTags(accounts ...string) ([]string, error) {
+	var rows *sql.Rows
+	var err error
+	if len(accounts) > 0 {
+		placeholders := make([]string, len(accounts))
+		params := make([]interface{}, len(accounts))
+		for i, a := range accounts {
+			placeholders[i] = "?"
+			params[i] = a
+		}
+		rows, err = d.db.Query(
+			"SELECT DISTINCT t.tag FROM tags t JOIN messages m ON m.id = t.message_id WHERE m.account IN ("+
+				strings.Join(placeholders, ",")+") ORDER BY t.tag", params...)
+	} else {
+		rows, err = d.db.Query("SELECT DISTINCT tag FROM tags ORDER BY tag")
+	}
 	if err != nil {
 		return nil, fmt.Errorf("list tags: %w", err)
 	}

--- a/gui/durian/Managers/AccountManager.swift
+++ b/gui/durian/Managers/AccountManager.swift
@@ -204,6 +204,10 @@ class AccountManager: ObservableObject {
 
     func fetchAllTags() async -> [String] {
         guard let backend = emailBackend else { return [] }
+        let profile = ProfileManager.shared.currentProfile
+        if let profile, !profile.isAll {
+            return await backend.fetchTags(accounts: profile.accounts)
+        }
         return await backend.fetchAllTags()
     }
 

--- a/gui/durian/Network/EmailBackend.swift
+++ b/gui/durian/Network/EmailBackend.swift
@@ -513,6 +513,13 @@ class EmailBackend: ObservableObject {
         return response?.tags ?? []
     }
 
+    func fetchTags(accounts: [String]) async -> [String] {
+        let param = accounts.joined(separator: ",")
+        let encoded = param.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? param
+        let response: DurianResponse? = await request(endpoint: "/tags?account=\(encoded)")
+        return response?.tags ?? []
+    }
+
     /// Fetch the full (unstripped) body of a single message for reply quoting.
     /// Unlike thread bodies, this preserves the quoted conversation chain.
     func fetchOriginalBody(messageId: String) async -> MessageBodyResponse? {

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -35,13 +35,102 @@ paths:
   /tags:
     get:
       summary: List all known tags
+      parameters:
+        - name: account
+          in: query
+          description: Comma-separated account identifiers to scope tags (omit for all)
+          schema:
+            type: string
       responses:
         '200':
-          description: A list of all tags
+          description: A list of tags
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/TagsResponse'
+  /local-drafts:
+    get:
+      summary: List all local crash-recovery drafts
+      responses:
+        '200':
+          description: All local drafts, newest first
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/LocalDraft'
+  /local-drafts/{id}:
+    put:
+      summary: Save or update a local draft
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                draft_json:
+                  type: object
+                  description: The full EmailDraft JSON blob
+              required:
+                - draft_json
+      responses:
+        '200':
+          description: Draft saved
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    type: boolean
+    get:
+      summary: Get a local draft by ID
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+      responses:
+        '200':
+          description: The draft
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/LocalDraft'
+        '404':
+          description: Draft not found
+    delete:
+      summary: Delete a local draft
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+      responses:
+        '200':
+          description: Draft deleted
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    type: boolean
+        '404':
+          description: Draft not found
   /threads/{thread_id}:
     get:
       summary: Get a specific email thread
@@ -494,6 +583,21 @@ components:
           type: string
         to:
           type: string
+    LocalDraft:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        draft_json:
+          type: object
+          description: The full EmailDraft JSON blob
+        created_at:
+          type: integer
+          format: int64
+        modified_at:
+          type: integer
+          format: int64
     AttachmentInfo:
       type: object
       properties:


### PR DESCRIPTION
## Summary
- Tags in the GUI tag picker are scoped to the current profile's accounts
- `/tags` endpoint accepts optional `?account=` query parameter (comma-separated)
- `openapi.yaml` updated with `/tags` account param and `/local-drafts` endpoints (from #131)

## Test plan
- [x] Account profile: only that account's tags shown in picker
- [x] "All" profile: all tags shown (unchanged behavior)
- [x] All CLI tests pass
- [x] GUI builds