### PR TITLE
test(go): add 19 unit tests for v0.2.0 features

### DIFF
--- a/cli/internal/imap/BUILD.bazel
+++ b/cli/internal/imap/BUILD.bazel
@@ -28,6 +28,7 @@ go_test(
     size = "small",
     srcs = [
         "flags_test.go",
+        "gmail_test.go",
         "rules_test.go",
         "state_test.go",
         "sync_test.go",

--- a/cli/internal/imap/gmail_test.go
+++ b/cli/internal/imap/gmail_test.go
@@ -1,0 +1,153 @@
+package imap
+
+import (
+	"testing"
+
+	imap "github.com/emersion/go-imap"
+)
+
+func TestGmailLabelsToTags_SystemLabels(t *testing.T) {
+	msg := &imap.Message{
+		Items: map[imap.FetchItem]interface{}{
+			"X-GM-LABELS": []interface{}{"\\Inbox", "\\Sent", "\\Starred", "\\Important"},
+		},
+	}
+
+	tags := gmailLabelsToTags(msg)
+	want := map[string]bool{"inbox": true, "sent": true, "flagged": true, "important": true}
+
+	for _, tag := range tags {
+		if !want[tag] {
+			t.Errorf("unexpected tag: %q", tag)
+		}
+		delete(want, tag)
+	}
+	for tag := range want {
+		t.Errorf("missing tag: %q", tag)
+	}
+}
+
+func TestGmailLabelsToTags_UserLabels(t *testing.T) {
+	msg := &imap.Message{
+		Items: map[imap.FetchItem]interface{}{
+			"X-GM-LABELS": []interface{}{"Orders", "Finance Briefing", "blind-sonar"},
+		},
+	}
+
+	tags := gmailLabelsToTags(msg)
+	want := map[string]bool{"orders": true, "finance-briefing": true, "blind-sonar": true}
+
+	for _, tag := range tags {
+		if !want[tag] {
+			t.Errorf("unexpected tag: %q", tag)
+		}
+		delete(want, tag)
+	}
+	for tag := range want {
+		t.Errorf("missing tag: %q", tag)
+	}
+}
+
+func TestGmailLabelsToTags_IgnoredLabels(t *testing.T) {
+	msg := &imap.Message{
+		Items: map[imap.FetchItem]interface{}{
+			"X-GM-LABELS": []interface{}{
+				"CATEGORY_PERSONAL", "CATEGORY_SOCIAL",
+				"CATEGORY_PROMOTIONS", "CATEGORY_UPDATES", "CATEGORY_FORUMS",
+			},
+		},
+	}
+
+	tags := gmailLabelsToTags(msg)
+	if len(tags) != 0 {
+		t.Errorf("expected no tags for categories, got %v", tags)
+	}
+}
+
+func TestGmailLabelsToTags_SpamTrash(t *testing.T) {
+	msg := &imap.Message{
+		Items: map[imap.FetchItem]interface{}{
+			"X-GM-LABELS": []interface{}{"\\Trash", "\\Spam"},
+		},
+	}
+
+	tags := gmailLabelsToTags(msg)
+	want := map[string]bool{"trash": true, "spam": true}
+
+	for _, tag := range tags {
+		if !want[tag] {
+			t.Errorf("unexpected tag: %q", tag)
+		}
+	}
+}
+
+func TestGmailLabelsToTags_NoLabels(t *testing.T) {
+	msg := &imap.Message{
+		Items: map[imap.FetchItem]interface{}{},
+	}
+
+	tags := gmailLabelsToTags(msg)
+	if len(tags) != 0 {
+		t.Errorf("expected no tags, got %v", tags)
+	}
+}
+
+func TestGmailLabelsToTags_NilItems(t *testing.T) {
+	msg := &imap.Message{}
+	tags := gmailLabelsToTags(msg)
+	if len(tags) != 0 {
+		t.Errorf("expected no tags, got %v", tags)
+	}
+}
+
+func TestGmailLabelsToTags_QuotedLabels(t *testing.T) {
+	msg := &imap.Message{
+		Items: map[imap.FetchItem]interface{}{
+			"X-GM-LABELS": []interface{}{`"My Projects"`, `"Work/Important"`},
+		},
+	}
+
+	tags := gmailLabelsToTags(msg)
+	found := make(map[string]bool)
+	for _, tag := range tags {
+		found[tag] = true
+	}
+	if !found["my-projects"] {
+		t.Error("missing tag my-projects")
+	}
+	if !found["work/important"] {
+		t.Error("missing tag work/important")
+	}
+}
+
+func TestGmailLabelsToTags_Mixed(t *testing.T) {
+	msg := &imap.Message{
+		Items: map[imap.FetchItem]interface{}{
+			"X-GM-LABELS": []interface{}{
+				"\\Inbox", "\\Important", "CATEGORY_PERSONAL", "Newsletter",
+			},
+		},
+	}
+
+	tags := gmailLabelsToTags(msg)
+	found := make(map[string]bool)
+	for _, tag := range tags {
+		found[tag] = true
+	}
+
+	if !found["inbox"] {
+		t.Error("missing inbox")
+	}
+	if !found["important"] {
+		t.Error("missing important")
+	}
+	if !found["newsletter"] {
+		t.Error("missing newsletter")
+	}
+	if found["category_personal"] {
+		t.Error("CATEGORY_PERSONAL should be ignored")
+	}
+	if len(tags) != 3 {
+		t.Errorf("expected 3 tags, got %d: %v", len(tags), tags)
+	}
+}

--- a/cli/internal/smtp/smtp_test.go
+++ b/cli/internal/smtp/smtp_test.go
@@ -331,3 +331,68 @@ func TestRecipients(t *testing.T) {
 		t.Errorf("Recipients() length = %d, want 2", len(recipients))
 	}
 }
+
+func TestBuild_MessageIDCached(t *testing.T) {
+	msg := &Message{
+		From:    "sender@example.com",
+		To:      []string{"recipient@example.com"},
+		Subject: "Test",
+		Body:    "Hello",
+	}
+
+	data1, err := msg.Build()
+	if err != nil {
+		t.Fatalf("first Build(): %v", err)
+	}
+	if msg.GeneratedMessageID == "" {
+		t.Fatal("GeneratedMessageID not set after Build()")
+	}
+	firstID := msg.GeneratedMessageID
+
+	data2, err := msg.Build()
+	if err != nil {
+		t.Fatalf("second Build(): %v", err)
+	}
+	if msg.GeneratedMessageID != firstID {
+		t.Errorf("Message-ID changed: %q -> %q", firstID, msg.GeneratedMessageID)
+	}
+
+	// Both builds should contain the same Message-ID header
+	id1 := extractHeader(string(data1), "Message-ID")
+	id2 := extractHeader(string(data2), "Message-ID")
+	if id1 != id2 {
+		t.Errorf("Message-ID header differs: %q vs %q", id1, id2)
+	}
+}
+
+func TestBuild_MessageIDPreset(t *testing.T) {
+	msg := &Message{
+		From:               "sender@example.com",
+		To:                 []string{"recipient@example.com"},
+		Subject:            "Test",
+		Body:               "Hello",
+		GeneratedMessageID: "<preset@example.com>",
+	}
+
+	data, err := msg.Build()
+	if err != nil {
+		t.Fatalf("Build(): %v", err)
+	}
+	if msg.GeneratedMessageID != "<preset@example.com>" {
+		t.Errorf("preset ID was overwritten: %q", msg.GeneratedMessageID)
+	}
+
+	content := string(data)
+	if !strings.Contains(content, "Message-ID: <preset@example.com>") {
+		t.Error("preset Message-ID not in headers")
+	}
+}
+
+func extractHeader(content, name string) string {
+	for _, line := range strings.Split(content, "\r\n") {
+		if strings.HasPrefix(line, name+": ") {
+			return strings.TrimPrefix(line, name+": ")
+		}
+	}
+	return ""
+}

--- a/cli/internal/store/BUILD.bazel
+++ b/cli/internal/store/BUILD.bazel
@@ -24,6 +24,7 @@ go_test(
     srcs = [
         "attachments_test.go",
         "headers_test.go",
+        "local_drafts_test.go",
         "messages_test.go",
         "outbox_test.go",
         "search_test.go",

--- a/cli/internal/store/local_drafts_test.go
+++ b/cli/internal/store/local_drafts_test.go
@@ -1,0 +1,121 @@
+package store
+
+import "testing"
+
+func TestSaveAndGetLocalDraft(t *testing.T) {
+	db := newTestDB(t)
+
+	draft := &LocalDraft{
+		ID:        "aaa-bbb-ccc",
+		DraftJSON: `{"subject":"Hello","to":["bob@x.com"]}`,
+	}
+	if err := db.SaveLocalDraft(draft); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+	if draft.CreatedAt == 0 || draft.ModifiedAt == 0 {
+		t.Fatal("timestamps not set")
+	}
+
+	got, err := db.GetLocalDraft("aaa-bbb-ccc")
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if got.DraftJSON != draft.DraftJSON {
+		t.Errorf("draft_json = %q, want %q", got.DraftJSON, draft.DraftJSON)
+	}
+	if got.CreatedAt != draft.CreatedAt {
+		t.Errorf("created_at = %d, want %d", got.CreatedAt, draft.CreatedAt)
+	}
+}
+
+func TestSaveLocalDraft_Upsert(t *testing.T) {
+	db := newTestDB(t)
+
+	draft := &LocalDraft{ID: "xxx", DraftJSON: `{"v":1}`}
+	if err := db.SaveLocalDraft(draft); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+	originalCreated := draft.CreatedAt
+
+	// Update same ID
+	draft2 := &LocalDraft{ID: "xxx", DraftJSON: `{"v":2}`}
+	if err := db.SaveLocalDraft(draft2); err != nil {
+		t.Fatalf("upsert: %v", err)
+	}
+
+	got, _ := db.GetLocalDraft("xxx")
+	if got.DraftJSON != `{"v":2}` {
+		t.Errorf("draft_json not updated: %q", got.DraftJSON)
+	}
+	if got.CreatedAt != originalCreated {
+		t.Error("created_at should not change on upsert")
+	}
+}
+
+func TestGetLocalDraft_NotFound(t *testing.T) {
+	db := newTestDB(t)
+
+	_, err := db.GetLocalDraft("nonexistent")
+	if err == nil {
+		t.Fatal("expected error for missing draft")
+	}
+}
+
+func TestDeleteLocalDraft(t *testing.T) {
+	db := newTestDB(t)
+
+	db.SaveLocalDraft(&LocalDraft{ID: "del-me", DraftJSON: `{}`})
+
+	if err := db.DeleteLocalDraft("del-me"); err != nil {
+		t.Fatalf("delete: %v", err)
+	}
+
+	_, err := db.GetLocalDraft("del-me")
+	if err == nil {
+		t.Fatal("draft should be deleted")
+	}
+}
+
+func TestDeleteLocalDraft_NotFound(t *testing.T) {
+	db := newTestDB(t)
+
+	err := db.DeleteLocalDraft("nope")
+	if err == nil {
+		t.Fatal("expected error for missing draft")
+	}
+}
+
+func TestListLocalDrafts(t *testing.T) {
+	db := newTestDB(t)
+
+	db.SaveLocalDraft(&LocalDraft{ID: "a", DraftJSON: `{"n":1}`})
+	db.SaveLocalDraft(&LocalDraft{ID: "b", DraftJSON: `{"n":2}`})
+	db.SaveLocalDraft(&LocalDraft{ID: "c", DraftJSON: `{"n":3}`})
+
+	drafts, err := db.ListLocalDrafts()
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	if len(drafts) != 3 {
+		t.Fatalf("got %d drafts, want 3", len(drafts))
+	}
+	ids := make(map[string]bool)
+	for _, d := range drafts {
+		ids[d.ID] = true
+	}
+	if !ids["a"] || !ids["b"] || !ids["c"] {
+		t.Errorf("missing drafts, got %v", ids)
+	}
+}
+
+func TestListLocalDrafts_Empty(t *testing.T) {
+	db := newTestDB(t)
+
+	drafts, err := db.ListLocalDrafts()
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	if len(drafts) != 0 {
+		t.Fatalf("got %d drafts, want 0", len(drafts))
+	}
+}

--- a/cli/internal/store/search_test.go
+++ b/cli/internal/store/search_test.go
@@ -413,3 +413,68 @@ func TestSearch_UnknownField(t *testing.T) {
 		t.Error("expected error for unknown field")
 	}
 }
+
+func TestExtractAccounts(t *testing.T) {
+	tests := []struct {
+		query string
+		want  []string
+	}{
+		{"tag:inbox", nil},
+		{"(tag:sent) AND (path:habric/**)", []string{"habric"}},
+		{"(tag:inbox) AND (path:work/** OR path:gmail/**)", []string{"work", "gmail"}},
+		{"*", nil},
+		{"path:personal/**", []string{"personal"}},
+	}
+	for _, tt := range tests {
+		got := extractAccounts(tt.query)
+		if len(got) != len(tt.want) {
+			t.Errorf("extractAccounts(%q) = %v, want %v", tt.query, got, tt.want)
+			continue
+		}
+		for i := range got {
+			if got[i] != tt.want[i] {
+				t.Errorf("extractAccounts(%q)[%d] = %q, want %q", tt.query, i, got[i], tt.want[i])
+			}
+		}
+	}
+}
+
+func TestGetThreadTags_AccountScoped(t *testing.T) {
+	db := newTestDB(t)
+	now := time.Now().Unix()
+
+	// Insert messages in same thread but different accounts
+	msg1 := &Message{
+		MessageID: "scoped@x", Subject: "Scoped", FromAddr: "a@x",
+		Date: now, CreatedAt: now, FetchedBody: true, Account: "work",
+	}
+	db.InsertMessage(msg1)
+	db.AddTag(msg1.ID, "sent")
+
+	msg2 := &Message{
+		MessageID: "scoped@x", Subject: "Scoped", FromAddr: "a@x",
+		Date: now, CreatedAt: now, FetchedBody: true, Account: "gmail",
+	}
+	db.InsertMessage(msg2)
+	db.AddTag(msg2.ID, "inbox")
+
+	threadID := msg1.ThreadID
+
+	// No filter → both tags
+	all, _ := db.getThreadTags(threadID)
+	if len(all) != 2 {
+		t.Errorf("all tags = %v, want 2", all)
+	}
+
+	// Work only
+	work, _ := db.getThreadTags(threadID, "work")
+	if len(work) != 1 || work[0] != "sent" {
+		t.Errorf("work tags = %v, want [sent]", work)
+	}
+
+	// Gmail only
+	gmail, _ := db.getThreadTags(threadID, "gmail")
+	if len(gmail) != 1 || gmail[0] != "inbox" {
+		t.Errorf("gmail tags = %v, want [inbox]", gmail)
+	}
+}

--- a/cli/internal/store/tags_test.go
+++ b/cli/internal/store/tags_test.go
@@ -320,3 +320,63 @@ func TestModifyTagsByMessageIDAndAccount_NotFound(t *testing.T) {
 		t.Fatalf("expected no-op, got error: %v", err)
 	}
 }
+
+func insertTestMessageForAccount(t *testing.T, db *DB, msgID, account string) int64 {
+	t.Helper()
+	now := time.Now().Unix()
+	msg := &Message{
+		MessageID: msgID, Subject: "Test " + msgID,
+		FromAddr: "a@x", Date: now, CreatedAt: now,
+		FetchedBody: true, Account: account,
+	}
+	if err := db.InsertMessage(msg); err != nil {
+		t.Fatalf("insert %s: %v", msgID, err)
+	}
+	return msg.ID
+}
+
+func TestListTags_AccountScoped(t *testing.T) {
+	db := newTestDB(t)
+
+	id1 := insertTestMessageForAccount(t, db, "m1@x", "work")
+	id2 := insertTestMessageForAccount(t, db, "m2@x", "gmail")
+
+	db.AddTag(id1, "inbox")
+	db.AddTag(id1, "finance")
+	db.AddTag(id2, "inbox")
+	db.AddTag(id2, "newsletter")
+
+	// All tags
+	all, _ := db.ListTags()
+	if len(all) != 3 { // finance, inbox, newsletter
+		t.Errorf("all tags = %v, want 3", all)
+	}
+
+	// Work only
+	work, _ := db.ListTags("work")
+	if len(work) != 2 {
+		t.Fatalf("work tags = %v, want 2", work)
+	}
+	found := make(map[string]bool)
+	for _, tag := range work {
+		found[tag] = true
+	}
+	if !found["inbox"] || !found["finance"] {
+		t.Errorf("work tags = %v, want [finance inbox]", work)
+	}
+	if found["newsletter"] {
+		t.Error("work should not have newsletter tag")
+	}
+
+	// Gmail only
+	gmail, _ := db.ListTags("gmail")
+	if len(gmail) != 2 {
+		t.Fatalf("gmail tags = %v, want 2", gmail)
+	}
+
+	// Both accounts
+	both, _ := db.ListTags("work", "gmail")
+	if len(both) != 3 {
+		t.Errorf("both tags = %v, want 3", both)
+	}
+}


### PR DESCRIPTION
## Summary
Unit tests for features added in v0.2.0 that had no dedicated test coverage.

## New tests (19)
- **Local drafts store** (6): Save, Get, Upsert, Delete, NotFound, List
- **Gmail label mapping** (8): System labels, user labels, CATEGORY_* ignored, \Trash/\Spam, nil/empty, quoted labels, mixed
- **Account-scoped tags** (2): ListTags with account filter, getThreadTags scoped
- **extractAccounts** (1): AST-based account extraction from search queries
- **SMTP Message-ID** (2): Build() caches ID, preset ID preserved

## Test plan
- [x] All 10 CLI test targets pass