### PR TITLE
chore: sync server API versioning + Linux CLI release binaries

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,6 +31,16 @@ jobs:
           bazel build //cli/cmd/durian --platforms=@rules_go//go/toolchain:darwin_amd64
           cp bazel-bin/cli/cmd/durian/durian_/durian dist/durian-darwin-amd64
 
+      - name: Build CLI (linux-amd64)
+        run: |
+          bazel build //cli/cmd/durian --platforms=@rules_go//go/toolchain:linux_amd64
+          cp bazel-bin/cli/cmd/durian/durian_/durian dist/durian-linux-amd64
+
+      - name: Build CLI (linux-arm64)
+        run: |
+          bazel build //cli/cmd/durian --platforms=@rules_go//go/toolchain:linux_arm64
+          cp bazel-bin/cli/cmd/durian/durian_/durian dist/durian-linux-arm64
+
       - name: Build Sync Server (linux-amd64)
         run: |
           bazel build //sync:durian-sync --platforms=@rules_go//go/toolchain:linux_amd64
@@ -56,6 +66,8 @@ jobs:
           cd dist
           tar -czf durian-${{ steps.version.outputs.version }}-darwin-arm64.tar.gz durian-darwin-arm64
           tar -czf durian-${{ steps.version.outputs.version }}-darwin-amd64.tar.gz durian-darwin-amd64
+          tar -czf durian-${{ steps.version.outputs.version }}-linux-amd64.tar.gz durian-linux-amd64
+          tar -czf durian-${{ steps.version.outputs.version }}-linux-arm64.tar.gz durian-linux-arm64
           tar -czf durian-sync-${{ steps.version.outputs.version }}-linux-amd64.tar.gz durian-sync-linux-amd64
           tar -czf durian-sync-${{ steps.version.outputs.version }}-linux-arm64.tar.gz durian-sync-linux-arm64
           shasum -a 256 *.tar.gz *.zip > checksums.txt
@@ -66,6 +78,8 @@ jobs:
           gh release create "${{ github.ref_name }}" \
             dist/durian-${{ steps.version.outputs.version }}-darwin-arm64.tar.gz \
             dist/durian-${{ steps.version.outputs.version }}-darwin-amd64.tar.gz \
+            dist/durian-${{ steps.version.outputs.version }}-linux-amd64.tar.gz \
+            dist/durian-${{ steps.version.outputs.version }}-linux-arm64.tar.gz \
             dist/durian-sync-${{ steps.version.outputs.version }}-linux-amd64.tar.gz \
             dist/durian-sync-${{ steps.version.outputs.version }}-linux-arm64.tar.gz \
             dist/Durian-${{ steps.version.outputs.version }}.zip \

--- a/README.md
+++ b/README.md
@@ -43,7 +43,15 @@ brew install --cask durian      # GUI
 
 ### Linux
 
-CLI only — build from source (see below).
+Pre-built CLI binaries (amd64/arm64) are available in each [GitHub release](https://github.com/julion2/Durian/releases):
+
+```bash
+# Download latest release (example for amd64)
+curl -sSL https://github.com/julion2/Durian/releases/latest/download/durian-linux-amd64.tar.gz | tar -xz
+sudo mv durian-linux-amd64 /usr/local/bin/durian
+```
+
+Or build from source (see below).
 
 ## Build from Source
 

--- a/cli/internal/tagsync/client.go
+++ b/cli/internal/tagsync/client.go
@@ -66,7 +66,7 @@ func (c *Client) Push(changes []TagChange) error {
 		return fmt.Errorf("marshal: %w", err)
 	}
 
-	req, err := http.NewRequest("POST", c.url+"/sync", bytes.NewReader(body))
+	req, err := http.NewRequest("POST", c.url+"/v1/sync", bytes.NewReader(body))
 	if err != nil {
 		return fmt.Errorf("request: %w", err)
 	}

--- a/docs/TAG_SYNC.md
+++ b/docs/TAG_SYNC.md
@@ -110,8 +110,8 @@ api_key = "your-secret"
 | Method | Endpoint | Description |
 |--------|----------|-------------|
 | `GET` | `/health` | Health check |
-| `POST` | `/sync` | Push tag changes |
-| `GET` | `/sync?since=<ts>&client_id=<id>` | Pull changes since timestamp |
+| `POST` | `/v1/sync` | Push tag changes |
+| `GET` | `/v1/sync?since=<ts>&client_id=<id>` | Pull changes since timestamp |
 
 ### Push payload
 

--- a/sync/main.go
+++ b/sync/main.go
@@ -73,7 +73,7 @@ func main() {
 		log.Fatalf("Failed to init database: %v", err)
 	}
 
-	http.HandleFunc("/sync", authMiddleware(handleSync))
+	http.HandleFunc("/v1/sync", authMiddleware(handleSync))
 	http.HandleFunc("/health", handleHealth)
 
 	addr := fmt.Sprintf(":%d", *port)

--- a/sync/main_test.go
+++ b/sync/main_test.go
@@ -51,7 +51,7 @@ func TestAuthMiddleware_ValidKey(t *testing.T) {
 		w.WriteHeader(200)
 	})
 
-	req := httptest.NewRequest("GET", "/sync", nil)
+	req := httptest.NewRequest("GET", "/v1/sync", nil)
 	req.Header.Set("X-API-Key", "test-key")
 	w := httptest.NewRecorder()
 	handler(w, req)
@@ -67,7 +67,7 @@ func TestAuthMiddleware_InvalidKey(t *testing.T) {
 		w.WriteHeader(200)
 	})
 
-	req := httptest.NewRequest("GET", "/sync", nil)
+	req := httptest.NewRequest("GET", "/v1/sync", nil)
 	req.Header.Set("X-API-Key", "wrong-key")
 	w := httptest.NewRecorder()
 	handler(w, req)
@@ -83,7 +83,7 @@ func TestAuthMiddleware_MissingKey(t *testing.T) {
 		w.WriteHeader(200)
 	})
 
-	req := httptest.NewRequest("GET", "/sync", nil)
+	req := httptest.NewRequest("GET", "/v1/sync", nil)
 	w := httptest.NewRecorder()
 	handler(w, req)
 
@@ -103,7 +103,7 @@ func TestPostSync(t *testing.T) {
 		},
 	})
 
-	req := httptest.NewRequest("POST", "/sync", bytes.NewReader(body))
+	req := httptest.NewRequest("POST", "/v1/sync", bytes.NewReader(body))
 	w := httptest.NewRecorder()
 	handlePostSync(w, req)
 
@@ -131,7 +131,7 @@ func TestPostSync_InvalidAction(t *testing.T) {
 		},
 	})
 
-	req := httptest.NewRequest("POST", "/sync", bytes.NewReader(body))
+	req := httptest.NewRequest("POST", "/v1/sync", bytes.NewReader(body))
 	w := httptest.NewRecorder()
 	handlePostSync(w, req)
 
@@ -146,7 +146,7 @@ func TestPostSync_EmptyChanges(t *testing.T) {
 	setupTestServer(t)
 
 	body, _ := json.Marshal(SyncRequest{ClientID: "mac1", Changes: []TagChange{}})
-	req := httptest.NewRequest("POST", "/sync", bytes.NewReader(body))
+	req := httptest.NewRequest("POST", "/v1/sync", bytes.NewReader(body))
 	w := httptest.NewRecorder()
 	handlePostSync(w, req)
 
@@ -168,12 +168,12 @@ func TestGetSync_PullAll(t *testing.T) {
 			{MessageID: "b@x", Account: "w", Tag: "sent", Action: "add", Timestamp: 200},
 		},
 	})
-	req := httptest.NewRequest("POST", "/sync", bytes.NewReader(body))
+	req := httptest.NewRequest("POST", "/v1/sync", bytes.NewReader(body))
 	w := httptest.NewRecorder()
 	handlePostSync(w, req)
 
 	// Pull from mac2 — should see both
-	req = httptest.NewRequest("GET", "/sync?since=0&client_id=mac2", nil)
+	req = httptest.NewRequest("GET", "/v1/sync?since=0&client_id=mac2", nil)
 	w = httptest.NewRecorder()
 	handleGetSync(w, req)
 
@@ -193,12 +193,12 @@ func TestGetSync_ExcludesOwnClient(t *testing.T) {
 			{MessageID: "a@x", Account: "w", Tag: "inbox", Action: "add", Timestamp: 100},
 		},
 	})
-	req := httptest.NewRequest("POST", "/sync", bytes.NewReader(body))
+	req := httptest.NewRequest("POST", "/v1/sync", bytes.NewReader(body))
 	w := httptest.NewRecorder()
 	handlePostSync(w, req)
 
 	// Pull from mac1 — should see nothing (own changes excluded)
-	req = httptest.NewRequest("GET", "/sync?since=0&client_id=mac1", nil)
+	req = httptest.NewRequest("GET", "/v1/sync?since=0&client_id=mac1", nil)
 	w = httptest.NewRecorder()
 	handleGetSync(w, req)
 
@@ -219,12 +219,12 @@ func TestGetSync_SinceTimestamp(t *testing.T) {
 			{MessageID: "b@x", Account: "w", Tag: "new", Action: "add", Timestamp: 200},
 		},
 	})
-	req := httptest.NewRequest("POST", "/sync", bytes.NewReader(body))
+	req := httptest.NewRequest("POST", "/v1/sync", bytes.NewReader(body))
 	w := httptest.NewRecorder()
 	handlePostSync(w, req)
 
 	// Pull since=150 — only the second change
-	req = httptest.NewRequest("GET", "/sync?since=150&client_id=mac2", nil)
+	req = httptest.NewRequest("GET", "/v1/sync?since=150&client_id=mac2", nil)
 	w = httptest.NewRecorder()
 	handleGetSync(w, req)
 
@@ -249,11 +249,11 @@ func TestGetSync_DeduplicatesPerMessageTag(t *testing.T) {
 			{MessageID: "a@x", Account: "w", Tag: "inbox", Action: "remove", Timestamp: 200},
 		},
 	})
-	req := httptest.NewRequest("POST", "/sync", bytes.NewReader(body))
+	req := httptest.NewRequest("POST", "/v1/sync", bytes.NewReader(body))
 	w := httptest.NewRecorder()
 	handlePostSync(w, req)
 
-	req = httptest.NewRequest("GET", "/sync?since=0&client_id=mac2", nil)
+	req = httptest.NewRequest("GET", "/v1/sync?since=0&client_id=mac2", nil)
 	w = httptest.NewRecorder()
 	handleGetSync(w, req)
 
@@ -268,7 +268,7 @@ func TestGetSync_DeduplicatesPerMessageTag(t *testing.T) {
 }
 
 func TestSyncMethodNotAllowed(t *testing.T) {
-	req := httptest.NewRequest("PUT", "/sync", nil)
+	req := httptest.NewRequest("PUT", "/v1/sync", nil)
 	w := httptest.NewRecorder()
 	handleSync(w, req)
 


### PR DESCRIPTION
## Summary
- Sync server endpoints under `/v1/sync` (API versioning)
- Release builds CLI for Linux amd64 + arm64 (previously only macOS)
- README updated with Linux binary install instructions

## Test plan
- [x] All CLI + sync server tests pass
- [x] Client URLs updated to `/v1/sync`
- [x] Test paths updated