### PR TITLE
perf: trim search enrichment bodies (95% response size reduction)

### DIFF
--- a/cli/internal/handler/search.go
+++ b/cli/internal/handler/search.go
@@ -47,7 +47,7 @@ func (h *Handler) Search(query string, limit int, enrichLimit int) protocol.Resp
 		if err != nil || len(msgs) == 0 {
 			continue
 		}
-		threads[r.Thread] = h.convertThread(r.Thread, msgs)
+		threads[r.Thread] = h.convertThreadLight(r.Thread, msgs)
 	}
 
 	return protocol.SuccessWithResultsAndThreads(mails, threads)

--- a/cli/internal/handler/show.go
+++ b/cli/internal/handler/show.go
@@ -120,6 +120,65 @@ func (h *Handler) convertThread(threadID string, msgs []*store.Message) *internm
 	}
 }
 
+// convertThreadLight creates a lightweight thread for search enrichment.
+// Bodies are trimmed to 200 chars plaintext, no HTML. This reduces search
+// response size by ~95% compared to full thread content.
+func (h *Handler) convertThreadLight(threadID string, msgs []*store.Message) *internmail.ThreadContent {
+	messages := make([]internmail.MessageInfo, 0, len(msgs))
+	var subject string
+
+	for _, msg := range msgs {
+		body := msg.BodyText
+		if len(body) > 200 {
+			body = body[:200]
+		}
+
+		info := internmail.MessageInfo{
+			ID:        msg.MessageID,
+			From:      msg.FromAddr,
+			To:        msg.ToAddrs,
+			CC:        msg.CCAddrs,
+			Date:      time.Unix(msg.Date, 0).Format(time.RFC1123Z),
+			Timestamp: msg.Date,
+			MessageID: msg.MessageID,
+			Body:      body,
+			// HTML omitted — full body loaded on thread click
+		}
+
+		if subject == "" {
+			subject = msg.Subject
+		}
+
+		if tags, err := h.store.GetMessageTags(msg.ID); err == nil {
+			info.Tags = tags
+		}
+		if atts, err := h.store.GetAttachmentsByMessage(msg.ID); err == nil {
+			for _, a := range atts {
+				info.Attachments = append(info.Attachments, internmail.AttachmentInfo{
+					PartID:      a.PartID,
+					Filename:    a.Filename,
+					ContentType: a.ContentType,
+					Size:        a.Size,
+					Disposition: a.Disposition,
+					ContentID:   a.ContentID,
+				})
+			}
+		}
+
+		messages = append(messages, info)
+	}
+
+	sort.Slice(messages, func(i, j int) bool {
+		return messages[i].Timestamp > messages[j].Timestamp
+	})
+
+	return &internmail.ThreadContent{
+		ThreadID: threadID,
+		Subject:  subject,
+		Messages: messages,
+	}
+}
+
 // DownloadAttachment streams a raw attachment part, setting Content-Type and
 // Content-Disposition headers from server-derived metadata.
 func (h *Handler) DownloadAttachment(messageID string, partID int, w http.ResponseWriter) error {


### PR DESCRIPTION
## Summary
Search enrichment trims body text to 200 chars and omits HTML. Full body loaded on thread click.

| Query | Before | After | Reduction |
|---|---|---|---|
| Inbox (30 enriched) | 3.0MB | 175KB | 94% |
| Archive (30 enriched) | 1.9MB | 75KB | 96% |

## Test plan
- [x] All CLI tests pass
- [x] Body preview shows in email list
- [x] Full body loads on thread click
- [x] Manually tested — noticeably faster folder switching