### PR TITLE
fix(swift-mail): prefer preview text cache

### DIFF
--- a/cli/internal/handler/show.go
+++ b/cli/internal/handler/show.go
@@ -128,11 +128,6 @@ func (h *Handler) convertThreadLight(threadID string, msgs []*store.Message) *in
 	var subject string
 
 	for _, msg := range msgs {
-		body := msg.BodyText
-		if len(body) > 200 {
-			body = body[:200]
-		}
-
 		info := internmail.MessageInfo{
 			ID:        msg.MessageID,
 			From:      msg.FromAddr,
@@ -141,8 +136,8 @@ func (h *Handler) convertThreadLight(threadID string, msgs []*store.Message) *in
 			Date:      time.Unix(msg.Date, 0).Format(time.RFC1123Z),
 			Timestamp: msg.Date,
 			MessageID: msg.MessageID,
-			Body:      body,
-			// HTML omitted — full body loaded on thread click
+			Body:      msg.BodyText,
+			// HTML omitted — loaded on thread click via /threads/{id}
 		}
 
 		if subject == "" {

--- a/gui/durian/Models/Mail.swift
+++ b/gui/durian/Models/Mail.swift
@@ -197,6 +197,9 @@ struct MailMessage: Identifiable, Hashable {
     // Thread messages (loaded from CLI show command)
     var threadMessages: [ThreadMessage]?
     
+    // Preview text from search enrichment (separate from bodyState cache)
+    var previewText: String?
+
     // Reply/Forward metadata (loaded with body)
     var messageId: String?
     var inReplyTo: String?
@@ -232,12 +235,19 @@ struct MailMessage: Identifiable, Hashable {
         return tags.split(separator: ",").contains("draft")
     }
 
-    /// Body preview for list view (first ~100 chars, stripped of HTML)
+    /// Body preview for list view (first ~150 chars)
     var bodyPreview: String? {
+        // Prefer enrichment preview (always available, no HTML)
+        if let preview = previewText, !preview.isEmpty {
+            let stripped = preview
+                .replacingOccurrences(of: "\\s+", with: " ", options: .regularExpression)
+                .trimmingCharacters(in: .whitespacesAndNewlines)
+            return String(stripped.prefix(150))
+        }
+        // Fallback to loaded body
         switch bodyState {
         case .loaded(let body, _):
             guard !body.isEmpty else { return nil }
-            // Strip HTML tags and get first 150 chars
             let stripped = body
                 .replacingOccurrences(of: "<[^>]+>", with: "", options: .regularExpression)
                 .replacingOccurrences(of: "\\s+", with: " ", options: .regularExpression)

--- a/gui/durian/Network/EmailBackend.swift
+++ b/gui/durian/Network/EmailBackend.swift
@@ -763,8 +763,16 @@ class EmailBackend: ObservableObject {
         email.incomingAttachments = allAttachments
         email.hasAttachment = !allAttachments.isEmpty
 
-        let combinedBody = thread.messages.map { $0.body }.joined(separator: "\n\n---\n\n")
-        email.bodyState = .loaded(body: combinedBody, attributedBody: nil)
+        // Set preview text from enrichment (lightweight, no HTML).
+        // bodyState stays .notLoaded so full thread is fetched on click.
+        let previewBody = thread.messages.first?.body ?? ""
+        email.previewText = String(previewBody.prefix(200))
+
+        // Only set bodyState if HTML is present (full thread data, not light enrichment)
+        if thread.messages.contains(where: { $0.html != nil && !($0.html?.isEmpty ?? true) }) {
+            let combinedBody = thread.messages.map { $0.body }.joined(separator: "\n\n---\n\n")
+            email.bodyState = .loaded(body: combinedBody, attributedBody: nil)
+        }
         cacheThread(id: email.id, messages: thread.messages)
     }
 
@@ -817,8 +825,12 @@ class EmailBackend: ObservableObject {
                 emails[index].incomingAttachments = allAttachments
                 emails[index].hasAttachment = !allAttachments.isEmpty
 
-                let combinedBody = cached.messages.map { $0.body }.joined(separator: "\n\n---\n\n")
-                emails[index].bodyState = .loaded(body: combinedBody, attributedBody: nil)
+                let previewBody = cached.messages.first?.body ?? ""
+                emails[index].previewText = String(previewBody.prefix(200))
+                if cached.messages.contains(where: { $0.html != nil && !($0.html?.isEmpty ?? true) }) {
+                    let combinedBody = cached.messages.map { $0.body }.joined(separator: "\n\n---\n\n")
+                    emails[index].bodyState = .loaded(body: combinedBody, attributedBody: nil)
+                }
                 restoredCount += 1
             }
         }


### PR DESCRIPTION
## Summary
- Preserve full thread body in CLI light thread data
- Cache lightweight preview text separately from body state
- Avoid eagerly setting body state unless HTML is present

## Testing
- Local build