### PR TITLE
fix(swift): selection bugs and batch sync optimization

### DIFF
--- a/gui/durian/ContentView.swift
+++ b/gui/durian/ContentView.swift
@@ -177,11 +177,12 @@ struct ContentView: View {
                         Task {
                             for id in ids {
                                 if isAdding {
-                                    await accountManager.addTag(id: id, tag: tag)
+                                    await accountManager.modifyTagsWithoutSync(id: id, add: [tag], remove: [])
                                 } else {
-                                    await accountManager.removeTag(id: id, tag: tag)
+                                    await accountManager.modifyTagsWithoutSync(id: id, add: [], remove: [tag])
                                 }
                             }
+                            await accountManager.syncAndRefresh()
                             allTags = await accountManager.fetchAllTags()
                         }
                     }
@@ -609,6 +610,11 @@ struct ContentView: View {
 
     private func togglePin() {
         guard let emailId = markedEmails.first else { return }
+        if keymapHandler.engine.isVisualMode {
+            keymapHandler.engine.exitVisualMode()
+            visualModeAnchor = nil
+            markedEmails = [emailId]
+        }
         Task { await accountManager.togglePin(id: emailId) }
     }
 
@@ -929,14 +935,16 @@ struct ContentView: View {
                 let ids = markedEmails
                 guard !ids.isEmpty else { return [] }
                 let next = nextEmailId(after: ids)
+                visualModeAnchor = nil
+                keymapHandler.engine.exitVisualMode()
                 accountManager.removeLocally(ids: ids)
                 advanceCursor(to: next)
                 return ids
             }
             for id in ids {
-                await accountManager.modifyTags(id: id, add: ["archive"], remove: ["inbox"])
+                await accountManager.modifyTagsWithoutSync(id: id, add: ["archive"], remove: ["inbox"])
             }
-            await accountManager.refreshFolderCounts()
+            await accountManager.syncAndRefresh()
         }
 
         // Delete: dd - works with multi-selection
@@ -951,8 +959,8 @@ struct ContentView: View {
                 advanceCursor(to: next)
                 return ids
             }
-            await accountManager.deleteMessages(ids: ids)
-            await accountManager.refreshFolderCounts()
+            await accountManager.deleteMessagesWithoutSync(ids: ids)
+            await accountManager.syncAndRefresh()
         }
         
         // ═══════════════════════════════════════════════════════════
@@ -1036,9 +1044,9 @@ struct ContentView: View {
         // Escape - Exit visual mode (clears selection, keeps cursor)
         keymapHandler.registerSimpleHandler(for: .exitVisualMode) { [self] in
             await MainActor.run {
-                if keymapHandler.engine.visualModeType != .none {
+                // Always clean up visual mode state (engine may have already exited)
+                if visualModeAnchor != nil || keymapHandler.engine.visualModeType != .none {
                     keymapHandler.engine.exitVisualMode()
-                    // Clear all marks, keep only cursor
                     if let cursor = cursorEmailId {
                         markedEmails = [cursor]
                     }

--- a/gui/durian/Managers/AccountManager.swift
+++ b/gui/durian/Managers/AccountManager.swift
@@ -192,6 +192,11 @@ class AccountManager: ObservableObject {
     }
 
     func modifyTags(id: String, add: [String], remove: [String]) async {
+        await modifyTagsWithoutSync(id: id, add: add, remove: remove)
+        syncFromBackend()
+    }
+
+    func modifyTagsWithoutSync(id: String, add: [String], remove: [String]) async {
         guard let backend = emailBackend else { return }
         do {
             try await backend.modifyTags(id: id, add: add, remove: remove)
@@ -199,7 +204,12 @@ class AccountManager: ObservableObject {
             Log.error("BACKEND", "Failed to modify tags: \(error)")
             BannerManager.shared.showWarning(title: "Tag Failed", message: "Could not modify tags.")
         }
+    }
+
+    /// Sync once and refresh folder counts — call after batch operations
+    func syncAndRefresh() async {
         syncFromBackend()
+        await refreshFolderCounts()
     }
 
     func fetchAllTags() async -> [String] {
@@ -241,6 +251,11 @@ class AccountManager: ObservableObject {
     // MARK: - Batch Operations (Multi-Selection)
 
     func deleteMessages(ids: Set<String>) async {
+        await deleteMessagesWithoutSync(ids: ids)
+        syncFromBackend()
+    }
+
+    func deleteMessagesWithoutSync(ids: Set<String>) async {
         guard let backend = emailBackend else { return }
         var failCount = 0
         for id in ids {
@@ -250,7 +265,6 @@ class AccountManager: ObservableObject {
         if failCount > 0 {
             BannerManager.shared.showWarning(title: "Delete Failed", message: "Could not delete \(failCount) message(s).")
         }
-        syncFromBackend()
     }
 
     func toggleReadForMessages(ids: Set<String>) async {


### PR DESCRIPTION
## Summary
- Archive handler now cleans up visual mode state (was missing, unlike delete handler)
- Batch operations (archive/delete/tag) sync once after all mutations instead of per-email (N→1 syncs)
- Visual mode exit reliably cleans up even when engine clears state before handler runs
- togglePin exits visual mode and cleans up anchor
- Tag picker uses batch sync pattern for multi-email operations

## Context
Multi-select + archive/delete caused cursor to jump to top of list. Visual mode exit was inconsistent — sometimes selection state persisted. Root cause: repeated `syncFromBackend()` calls during batch loops caused list rebuilds mid-operation.

## Test plan
- [x] `bazel build //gui:Durian` + `bazel test //gui:ci_model_test`
- [x] Select 3+ emails with V-mode, press `a` — cursor stays near selection, not top
- [x] Select emails, press `dd` — same behavior
- [x] Enter V-mode, press Escape — selection clears cleanly
- [x] Pin email in V-mode — exits visual mode correctly
- [x] Tag picker on multi-select — no repeated list flickering