### PR TITLE
fix(swift): restrict remote images to HTTPS only

### DIFF
--- a/gui/durian/Views/EmailWebView.swift
+++ b/gui/durian/Views/EmailWebView.swift
@@ -43,7 +43,7 @@ struct EmailWebView: NSViewRepresentable {
         // Dynamic CSP based on loadRemoteImages setting
         let csp: String
         if loadRemoteImages {
-            csp = "default-src 'none'; style-src 'unsafe-inline'; img-src data: cid: https: http:;"
+            csp = "default-src 'none'; style-src 'unsafe-inline'; img-src data: cid: https:; font-src https: data:;"
         } else {
             csp = "default-src 'none'; style-src 'unsafe-inline'; img-src data: cid:;"
         }

--- a/gui/durian/Views/NonScrollingWebView.swift
+++ b/gui/durian/Views/NonScrollingWebView.swift
@@ -86,7 +86,7 @@ struct NonScrollingWebView: NSViewRepresentable {
         // so height measurement still works while inline <script> tags are blocked.
         let csp: String
         if loadRemoteImages {
-            csp = "default-src 'none'; style-src 'unsafe-inline'; img-src data: cid: https: http:;"
+            csp = "default-src 'none'; style-src 'unsafe-inline'; img-src data: cid: https:; font-src https: data:;"
         } else {
             csp = "default-src 'none'; style-src 'unsafe-inline'; img-src data: cid:;"
         }


### PR DESCRIPTION
## Summary
- Remove `http:` from CSP `img-src` — only `https:` allowed when remote images enabled
- Add `font-src https: data:` for emails with custom web fonts

Closes #141

## Test plan
- [ ] `bazel build //gui:Durian`
- [ ] Open email with remote images — HTTPS images load, HTTP blocked
- [ ] Newsletter with web fonts renders correctly