### PR TITLE
test: comprehensive test coverage (unit + integration + contract)

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -11,3 +11,6 @@ build --reuse_sandbox_directories
 # --- Test defaults ---
 test --test_output=errors
 test --test_verbose_timeout_warnings
+
+# Qt tests need offscreen platform on headless Linux (CI, Vagrant)
+test --test_env=QT_QPA_PLATFORM=offscreen

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -71,13 +71,6 @@ jobs:
       - name: Install Qt6
         run: sudo apt-get update && sudo apt-get install -y qt6-base-dev qt6-declarative-dev qt6-tools-dev qt6-tools-dev-tools libgl-dev
 
-      - name: Debug Qt6 paths
-        run: |
-          echo "=== rcc ===" && find /usr -name 'rcc' -type f 2>/dev/null || echo "not found"
-          echo "=== moc ===" && find /usr -name 'moc' -type f 2>/dev/null || echo "not found"
-          echo "=== libQt6Core ===" && find /usr -name 'libQt6Core*' 2>/dev/null | head -5 || echo "not found"
-          echo "=== qt6 dirs ===" && find /usr -type d -name 'qt6' 2>/dev/null || echo "not found"
-
       - name: Mount Bazel cache
         uses: actions/cache@v4
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -71,6 +71,13 @@ jobs:
       - name: Install Qt6
         run: sudo apt-get update && sudo apt-get install -y qt6-base-dev qt6-declarative-dev qt6-tools-dev qt6-tools-dev-tools libgl-dev
 
+      - name: Debug Qt6 paths
+        run: |
+          echo "=== rcc ===" && find /usr -name 'rcc' -type f 2>/dev/null || echo "not found"
+          echo "=== moc ===" && find /usr -name 'moc' -type f 2>/dev/null || echo "not found"
+          echo "=== libQt6Core ===" && find /usr -name 'libQt6Core*' 2>/dev/null | head -5 || echo "not found"
+          echo "=== qt6 dirs ===" && find /usr -type d -name 'qt6' 2>/dev/null || echo "not found"
+
       - name: Mount Bazel cache
         uses: actions/cache@v4
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -44,4 +44,4 @@ jobs:
           restore-keys: bazel-gui-
 
       - name: Test
-        run: bazel test //macos:ci_config_test //macos:ci_profile_test //macos:ci_banner_manager_test //macos:ci_model_test --test_output=errors
+        run: bazel test //macos:ci_config_test //macos:ci_profile_test //macos:ci_banner_manager_test //macos:ci_model_test //macos:ci_sync_manager_test //macos:ci_search_manager_test //macos:ci_outbox_manager_test --test_output=errors

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -82,7 +82,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Install Qt6
-        run: sudo apt-get update && sudo apt-get install -y qt6-base-dev qt6-declarative-dev libgl-dev
+        run: sudo apt-get update && sudo apt-get install -y qt6-base-dev qt6-declarative-dev qt6-tools-dev qt6-tools-dev-tools libgl-dev
 
       - name: Mount Bazel cache
         uses: actions/cache@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -44,4 +44,4 @@ jobs:
           restore-keys: bazel-gui-
 
       - name: Test
-        run: bazel test //macos:ci_config_test //macos:ci_profile_test //macos:ci_banner_manager_test //macos:ci_model_test //macos:ci_sync_manager_test //macos:ci_search_manager_test //macos:ci_outbox_manager_test --test_output=errors
+        run: bazel test //macos:ci_config_test //macos:ci_profile_test //macos:ci_banner_manager_test //macos:ci_model_test //macos:ci_sync_manager_test //macos:ci_search_manager_test //macos:ci_outbox_manager_test //macos:ci_contacts_manager_test //macos:ci_email_sending_test //macos:ci_account_manager_test --test_output=errors

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -69,7 +69,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Install Qt6
-        run: sudo apt-get update && sudo apt-get install -y qt6-base-dev qt6-declarative-dev qt6-tools-dev qt6-tools-dev-tools libgl-dev
+        run: sudo apt-get update && sudo apt-get install -y qt6-base-dev qt6-declarative-dev qt6-tools-dev qt6-tools-dev-tools qt6-webengine-dev libgl-dev
 
       - name: Mount Bazel cache
         uses: actions/cache@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,14 +21,43 @@ jobs:
       - name: Test CLI
         run: bazel test //cli/... --test_output=errors
 
-      - name: Test Sync Server
-        run: bazel test //sync:sync_test --test_output=errors
-
       - name: Build CLI
         run: bazel build //cli/cmd/durian
 
+  sync:
+    name: Sync Server
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Mount Bazel cache
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/bazel-disk
+          key: bazel-sync-${{ hashFiles('MODULE.bazel', 'cli/go.mod', 'cli/go.sum') }}
+          restore-keys: bazel-sync-
+
+      - name: Test Sync Server
+        run: bazel test //sync:sync_test --test_output=errors
+
       - name: Build Sync Server
         run: bazel build //sync:durian-sync
+
+  integration:
+    name: Integration (Contract)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Mount Bazel cache
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/bazel-disk
+          key: bazel-integration-${{ hashFiles('MODULE.bazel', 'cli/go.mod', 'cli/go.sum') }}
+          restore-keys: bazel-integration-
+
+      - name: Test API Contract
+        run: bazel test //integration:integration_test --test_output=all
 
   gui:
     name: GUI (Swift)
@@ -45,3 +74,24 @@ jobs:
 
       - name: Test
         run: bazel test //macos:ci_config_test //macos:ci_profile_test //macos:ci_banner_manager_test //macos:ci_model_test //macos:ci_sync_manager_test //macos:ci_search_manager_test //macos:ci_outbox_manager_test //macos:ci_contacts_manager_test //macos:ci_email_sending_test //macos:ci_account_manager_test --test_output=errors
+
+  linux:
+    name: Linux GUI (Qt)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Qt6
+        run: sudo apt-get update && sudo apt-get install -y qt6-base-dev qt6-declarative-dev libgl-dev
+
+      - name: Mount Bazel cache
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/bazel-disk
+          key: bazel-linux-${{ hashFiles('MODULE.bazel', 'linux/BUILD.bazel') }}
+          restore-keys: bazel-linux-
+
+      - name: Test Linux GUI
+        run: bazel test //linux:icon_map_test //linux:thread_model_test //linux:profile_model_test --repo_env=QTDIR=/usr --test_output=errors
+        env:
+          QT_QPA_PLATFORM: offscreen

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,6 +21,9 @@ jobs:
       - name: Test CLI
         run: bazel test //cli/... --test_output=errors
 
+      - name: Test API Contract
+        run: bazel test //integration:integration_test --test_output=all
+
       - name: Build CLI
         run: bazel build //cli/cmd/durian
 
@@ -42,22 +45,6 @@ jobs:
 
       - name: Build Sync Server
         run: bazel build //sync:durian-sync
-
-  integration:
-    name: Integration (Contract)
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Mount Bazel cache
-        uses: actions/cache@v4
-        with:
-          path: ~/.cache/bazel-disk
-          key: bazel-integration-${{ hashFiles('MODULE.bazel', 'cli/go.mod', 'cli/go.sum') }}
-          restore-keys: bazel-integration-
-
-      - name: Test API Contract
-        run: bazel test //integration:integration_test --test_output=all
 
   gui:
     name: GUI (Swift)

--- a/.gitignore
+++ b/.gitignore
@@ -99,3 +99,6 @@ iOSInjectionProject/
 # Bazel
 /bazel-*
 MODULE.bazel.lock
+
+# Vagrant
+.vagrant/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,7 +7,8 @@ Email client: Go CLI backend + Swift macOS GUI.
 - **CLI:** `bazel build //cli/cmd/durian` → install: `cli/install.sh` (copies to /usr/local/bin)
 - **GUI:** `bazel build //macos:Durian` → dev run: `macos/run.sh` (debug build → `/Applications/DurianNightly.app`) → install: `macos/install.sh` (release build → `/Applications/Durian.app`)
 - **Tests:** `bazel test //cli/...` (CLI) / `bazel test //macos/...` (GUI, requires Xcode 26) / `bazel test //...` (all)
-- **CI Tests (GUI):** `bazel test //macos:ci_config_test //macos:ci_profile_test //macos:ci_banner_manager_test //macos:ci_model_test` (uses `durian_core` target, no Views, works on Xcode 16+)
+- **CI Tests (GUI):** `bazel test //macos:ci_config_test //macos:ci_profile_test //macos:ci_banner_manager_test //macos:ci_model_test //macos:ci_sync_manager_test //macos:ci_search_manager_test //macos:ci_outbox_manager_test` (uses `durian_core` target, no Views, works on Xcode 16+)
+- **Integration Tests:** `bazel test //integration:integration_test` (starts real server, validates API contract via curl+jq)
 - **Logs (GUI/Swift):** `log stream --level debug --predicate 'subsystem == "org.js-lab.durian.nightly"'` (nightly) / `subsystem == "org.js-lab.durian"` (release)
 - **Logs (CLI/Go):** `~/.config/durian/serve.log` (truncated on each `durian serve` start). Default: Info+, with `--debug`: Debug+. Other commands: Error → stderr, with `--debug`: Debug+ → stderr.
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,54 @@
+# Durian Linux Dev VM (Fedora headless on Apple Silicon via QEMU)
+#
+# Usage:
+#   vagrant up        — start VM (first run downloads image + provisions)
+#   vagrant ssh       — SSH into VM
+#   vagrant halt      — stop VM (preserves state)
+#   vagrant destroy   — delete VM entirely
+#
+# Inside the VM:
+#   cd /vagrant       — shared folder = this repo (auto-synced)
+#   bazel build //linux:durian --repo_env=QTDIR=/usr
+#   bazel test //linux:all --repo_env=QTDIR=/usr
+#   bazel test //cli/...
+
+Vagrant.configure("2") do |config|
+  # Fedora 41 ARM64 (matches your Linux laptop)
+  config.vm.box = "generic-a64/fedora39"
+  config.vm.hostname = "durian-dev"
+
+  # QEMU provider for Apple Silicon
+  config.vm.provider "qemu" do |qe|
+    qe.memory = "4096"       # 4GB RAM (headless is fine with this)
+    qe.cpus = 4              # 4 cores
+    qe.arch = "aarch64"      # ARM64 to match host (no emulation overhead)
+  end
+
+  # /vagrant = this repo, auto-mounted via rsync
+  config.vm.synced_folder ".", "/vagrant", type: "rsync",
+    rsync__exclude: [".git/", "bazel-*", ".DS_Store"]
+
+  # Provision: install Bazel + Qt6 dev headers
+  config.vm.provision "shell", inline: <<-SHELL
+    set -e
+
+    # Bazel via Bazelisk
+    if ! command -v bazel &> /dev/null; then
+      echo "Installing Bazelisk..."
+      curl -fsSL https://github.com/bazelbuild/bazelisk/releases/latest/download/bazelisk-linux-arm64 -o /usr/local/bin/bazel
+      chmod +x /usr/local/bin/bazel
+    fi
+
+    # Qt6 dev headers (for Linux GUI build)
+    echo "Installing Qt6 dev packages..."
+    dnf install -y -q qt6-qtbase-devel qt6-qtdeclarative-devel qt6-qtwebengine-devel
+
+    # Go (for CLI build/test)
+    if ! command -v go &> /dev/null; then
+      echo "Installing Go..."
+      dnf install -y -q golang
+    fi
+
+    echo "Done. Run: cd /vagrant && bazel test //cli/... //linux:all --repo_env=QTDIR=/usr"
+  SHELL
+end

--- a/cli/cmd/durian/serve.go
+++ b/cli/cmd/durian/serve.go
@@ -22,6 +22,10 @@ import (
 	"github.com/durian-dev/durian/cli/internal/tagsync"
 )
 
+var servePort int
+var serveDB string
+var serveContactsDB string
+
 var serveCmd = &cobra.Command{
 	Use:   "serve",
 	Short: "Start OpenAPI HTTP server (for GUI integration)",
@@ -31,6 +35,9 @@ This replaces the old JSON protocol server.`,
 }
 
 func init() {
+	serveCmd.Flags().IntVar(&servePort, "port", 9723, "port to listen on")
+	serveCmd.Flags().StringVar(&serveDB, "db", "", "path to email database (default: ~/.config/durian/email.db)")
+	serveCmd.Flags().StringVar(&serveContactsDB, "contacts-db", "", "path to contacts database (default: ~/.config/durian/contacts.db)")
 	rootCmd.AddCommand(serveCmd)
 }
 
@@ -48,7 +55,10 @@ func runServe(cmd *cobra.Command, args []string) {
 
 	// Open contacts database (non-fatal if missing)
 	var contactsDB *contacts.DB
-	contactsDBPath := contacts.DefaultDBPath()
+	contactsDBPath := serveContactsDB
+	if contactsDBPath == "" {
+		contactsDBPath = contacts.DefaultDBPath()
+	}
 	if cdb, err := contacts.Open(contactsDBPath); err != nil {
 		slog.Warn("Could not open contacts database", "module", "SERVE", "path", contactsDBPath, "err", err)
 	} else {
@@ -58,23 +68,36 @@ func runServe(cmd *cobra.Command, args []string) {
 	}
 
 	// Open email store (required for reads)
-	emailDB, err := openEmailDB()
+	dbPath := serveDB
+	if dbPath == "" {
+		dbPath = store.DefaultDBPath()
+	}
+	emailDB, err := store.Open(dbPath)
 	if err != nil {
 		slog.Error("Email store required but unavailable", "module", "SERVE", "err", err)
 		fmt.Fprintln(os.Stderr, "Error: email store unavailable:", err)
 		os.Exit(1)
 	}
+	if err := emailDB.Init(); err != nil {
+		emailDB.Close()
+		slog.Error("Email store init failed", "module", "SERVE", "err", err)
+		fmt.Fprintln(os.Stderr, "Error: email store init failed:", err)
+		os.Exit(1)
+	}
 	defer emailDB.Close()
-	slog.Info("Opened email store", "module", "SERVE", "path", store.DefaultDBPath())
+	slog.Info("Opened email store", "module", "SERVE", "path", dbPath)
 
 	h := handler.New(emailDB, contactsDB)
 	eventHub := handler.NewEventHub()
 
 	r := mux.NewRouter()
+	addr := fmt.Sprintf(":%d", servePort)
+	allowedHost := fmt.Sprintf("localhost:%d", servePort)
+	allowedHostIP := fmt.Sprintf("127.0.0.1:%d", servePort)
 	r.Use(func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 			host := req.Host
-			if host != "localhost:9723" && host != "127.0.0.1:9723" &&
+			if host != allowedHost && host != allowedHostIP &&
 				host != "localhost" && host != "127.0.0.1" {
 				http.Error(w, "forbidden", http.StatusForbidden)
 				return
@@ -157,7 +180,7 @@ func runServe(cmd *cobra.Command, args []string) {
 	}
 
 	server := &http.Server{
-		Addr:    ":9723",
+		Addr:    addr,
 		Handler: r,
 	}
 

--- a/cli/cmd/testseeder/BUILD.bazel
+++ b/cli/cmd/testseeder/BUILD.bazel
@@ -1,0 +1,18 @@
+load("@rules_go//go:def.bzl", "go_binary", "go_library")
+
+go_library(
+    name = "testseeder_lib",
+    srcs = ["main.go"],
+    importpath = "github.com/durian-dev/durian/cli/cmd/testseeder",
+    visibility = ["//visibility:private"],
+    deps = [
+        "//cli/internal/contacts",
+        "//cli/internal/store",
+    ],
+)
+
+go_binary(
+    name = "testseeder",
+    embed = [":testseeder_lib"],
+    visibility = ["//visibility:public"],
+)

--- a/cli/cmd/testseeder/main.go
+++ b/cli/cmd/testseeder/main.go
@@ -1,0 +1,116 @@
+// testseeder creates SQLite databases with test data for integration tests.
+// Usage: testseeder <email-db-path> <contacts-db-path>
+package main
+
+import (
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/durian-dev/durian/cli/internal/contacts"
+	"github.com/durian-dev/durian/cli/internal/store"
+)
+
+func main() {
+	if len(os.Args) != 3 {
+		fmt.Fprintln(os.Stderr, "usage: testseeder <email-db-path> <contacts-db-path>")
+		os.Exit(1)
+	}
+
+	if err := seedEmailDB(os.Args[1]); err != nil {
+		fmt.Fprintf(os.Stderr, "email db: %v\n", err)
+		os.Exit(1)
+	}
+
+	if err := seedContactsDB(os.Args[2]); err != nil {
+		fmt.Fprintf(os.Stderr, "contacts db: %v\n", err)
+		os.Exit(1)
+	}
+
+	fmt.Println("Seeded test databases successfully")
+}
+
+func seedEmailDB(path string) error {
+	db, err := store.Open(path)
+	if err != nil {
+		return fmt.Errorf("open: %w", err)
+	}
+	defer db.Close()
+
+	if err := db.Init(); err != nil {
+		return fmt.Errorf("init: %w", err)
+	}
+
+	now := time.Now().Unix()
+
+	msgs := []*store.Message{
+		{
+			MessageID: "msg1@test", Subject: "Hello World",
+			FromAddr: "alice@example.com", ToAddrs: "bob@example.com",
+			Date: now - 3600, CreatedAt: now, BodyText: "First message body",
+			BodyHTML: "<p>First message body</p>", Mailbox: "INBOX", FetchedBody: true,
+			Account: "test",
+		},
+		{
+			MessageID: "msg2@test", Subject: "Re: Hello World",
+			FromAddr: "bob@example.com", ToAddrs: "alice@example.com",
+			InReplyTo: "<msg1@test>", Refs: "<msg1@test>",
+			Date: now, CreatedAt: now, BodyText: "Reply body",
+			BodyHTML: "<p>Reply body</p>", Mailbox: "INBOX", FetchedBody: true,
+			Account: "test",
+		},
+		{
+			MessageID: "msg3@test", Subject: "Other Thread",
+			FromAddr: "charlie@example.com", ToAddrs: "alice@example.com",
+			Date: now - 7200, CreatedAt: now, BodyText: "Different thread",
+			BodyHTML: "<p>Different thread</p>", Mailbox: "INBOX", FetchedBody: true,
+			Account: "test",
+		},
+	}
+
+	for _, msg := range msgs {
+		if err := db.InsertMessage(msg); err != nil {
+			return fmt.Errorf("insert %s: %w", msg.MessageID, err)
+		}
+	}
+
+	m1, _ := db.GetByMessageID("msg1@test")
+	m2, _ := db.GetByMessageID("msg2@test")
+	m3, _ := db.GetByMessageID("msg3@test")
+
+	db.AddTag(m1.ID, "inbox")
+	db.AddTag(m1.ID, "unread")
+	db.AddTag(m2.ID, "inbox")
+	db.AddTag(m3.ID, "inbox")
+	db.AddTag(m3.ID, "flagged")
+
+	fmt.Printf("  email.db: %d messages at %s\n", len(msgs), path)
+	return nil
+}
+
+func seedContactsDB(path string) error {
+	db, err := contacts.Open(path)
+	if err != nil {
+		return fmt.Errorf("open: %w", err)
+	}
+	defer db.Close()
+
+	if err := db.Init(); err != nil {
+		return fmt.Errorf("init: %w", err)
+	}
+
+	testContacts := []struct{ email, name string }{
+		{"alice@example.com", "Alice Smith"},
+		{"bob@example.com", "Bob Jones"},
+		{"charlie@example.com", "Charlie Brown"},
+	}
+
+	for _, c := range testContacts {
+		if err := db.Add(c.email, c.name, "imported"); err != nil {
+			return fmt.Errorf("add %s: %w", c.email, err)
+		}
+	}
+
+	fmt.Printf("  contacts.db: %d contacts at %s\n", len(testContacts), path)
+	return nil
+}

--- a/cli/internal/auth/BUILD.bazel
+++ b/cli/internal/auth/BUILD.bazel
@@ -1,10 +1,23 @@
-load("@rules_go//go:def.bzl", "go_library")
+load("@rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "auth",
     srcs = ["auth.go"],
     importpath = "github.com/durian-dev/durian/cli/internal/auth",
     visibility = ["//cli:__subpackages__"],
+    deps = [
+        "//cli/internal/config",
+        "//cli/internal/keychain",
+        "//cli/internal/oauth",
+        "//cli/internal/smtp",
+    ],
+)
+
+go_test(
+    name = "auth_test",
+    size = "small",
+    srcs = ["auth_test.go"],
+    embed = [":auth"],
     deps = [
         "//cli/internal/config",
         "//cli/internal/keychain",

--- a/cli/internal/auth/auth.go
+++ b/cli/internal/auth/auth.go
@@ -16,6 +16,12 @@ const (
 	PasswordKeychainService = "durian-password"
 )
 
+// Replaceable function vars for testability.
+var (
+	getKeychainPassword = keychain.GetPassword
+	getValidOAuthToken  = oauth.GetValidToken
+)
+
 // GetSMTPAuth returns the appropriate SMTP auth method for the given account.
 func GetSMTPAuth(account *config.AccountConfig) (smtp.Auth, error) {
 	switch account.SMTP.Auth {
@@ -28,7 +34,7 @@ func GetSMTPAuth(account *config.AccountConfig) (smtp.Auth, error) {
 		// SMTP also requires the SASL user to be the delegator — shared mailboxes
 		// cannot perform SMTP AUTH. MAIL FROM / From: header use account.Email downstream.
 		authEmail := account.GetAuthEmail()
-		token, err := oauth.GetValidToken(authEmail, account.OAuth.ClientID, account.OAuth.ClientSecret, account.OAuth.Tenant)
+		token, err := getValidOAuthToken(authEmail, account.OAuth.ClientID, account.OAuth.ClientSecret, account.OAuth.Tenant)
 		if err != nil {
 			if errors.Is(err, oauth.ErrTokenNotFound) {
 				return nil, fmt.Errorf("not authenticated for %s", authEmail)
@@ -45,7 +51,7 @@ func GetSMTPAuth(account *config.AccountConfig) (smtp.Auth, error) {
 		}, nil
 
 	case "password":
-		password, err := keychain.GetPassword(PasswordKeychainService, account.Email)
+		password, err := getKeychainPassword(PasswordKeychainService, account.Email)
 		if err != nil {
 			if errors.Is(err, keychain.ErrNotFound) {
 				return nil, fmt.Errorf("no password stored for %s", account.Email)

--- a/cli/internal/auth/auth_test.go
+++ b/cli/internal/auth/auth_test.go
@@ -1,0 +1,268 @@
+package auth
+
+import (
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/durian-dev/durian/cli/internal/config"
+	"github.com/durian-dev/durian/cli/internal/keychain"
+	"github.com/durian-dev/durian/cli/internal/oauth"
+	"github.com/durian-dev/durian/cli/internal/smtp"
+)
+
+func restoreFuncs() {
+	getKeychainPassword = keychain.GetPassword
+	getValidOAuthToken = oauth.GetValidToken
+}
+
+// --- Password auth ---
+
+func TestGetSMTPAuth_PasswordSuccess(t *testing.T) {
+	getKeychainPassword = func(service, account string) (string, error) {
+		if service != PasswordKeychainService {
+			t.Errorf("service = %q, want %q", service, PasswordKeychainService)
+		}
+		if account != "user@example.com" {
+			t.Errorf("account = %q, want %q", account, "user@example.com")
+		}
+		return "s3cret", nil
+	}
+	defer restoreFuncs()
+
+	acct := &config.AccountConfig{
+		Email: "user@example.com",
+		SMTP:  config.SMTPConfig{Auth: "password"},
+	}
+	auth, err := GetSMTPAuth(acct)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	pa, ok := auth.(*smtp.PasswordAuth)
+	if !ok {
+		t.Fatalf("got %T, want *smtp.PasswordAuth", auth)
+	}
+	if pa.Username != "user@example.com" {
+		t.Errorf("Username = %q, want %q", pa.Username, "user@example.com")
+	}
+	if pa.Password != "s3cret" {
+		t.Errorf("Password = %q, want %q", pa.Password, "s3cret")
+	}
+}
+
+func TestGetSMTPAuth_PasswordExplicitUsername(t *testing.T) {
+	getKeychainPassword = func(_, _ string) (string, error) { return "pw", nil }
+	defer restoreFuncs()
+
+	acct := &config.AccountConfig{
+		Email: "user@example.com",
+		SMTP:  config.SMTPConfig{Auth: "password"},
+		Auth:  config.AuthConfig{Username: "custom-user"},
+	}
+	auth, err := GetSMTPAuth(acct)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	pa := auth.(*smtp.PasswordAuth)
+	if pa.Username != "custom-user" {
+		t.Errorf("Username = %q, want %q", pa.Username, "custom-user")
+	}
+}
+
+func TestGetSMTPAuth_PasswordFallbackUsername(t *testing.T) {
+	getKeychainPassword = func(_, _ string) (string, error) { return "pw", nil }
+	defer restoreFuncs()
+
+	acct := &config.AccountConfig{
+		Email: "user@example.com",
+		SMTP:  config.SMTPConfig{Auth: "password"},
+		Auth:  config.AuthConfig{}, // empty username
+	}
+	auth, err := GetSMTPAuth(acct)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	pa := auth.(*smtp.PasswordAuth)
+	if pa.Username != "user@example.com" {
+		t.Errorf("Username = %q, want email fallback %q", pa.Username, "user@example.com")
+	}
+}
+
+func TestGetSMTPAuth_PasswordNotFound(t *testing.T) {
+	getKeychainPassword = func(_, _ string) (string, error) { return "", keychain.ErrNotFound }
+	defer restoreFuncs()
+
+	acct := &config.AccountConfig{
+		Email: "user@example.com",
+		SMTP:  config.SMTPConfig{Auth: "password"},
+	}
+	_, err := GetSMTPAuth(acct)
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), "no password stored") {
+		t.Errorf("error = %q, want 'no password stored'", err.Error())
+	}
+}
+
+func TestGetSMTPAuth_PasswordKeychainError(t *testing.T) {
+	getKeychainPassword = func(_, _ string) (string, error) { return "", errors.New("keychain locked") }
+	defer restoreFuncs()
+
+	acct := &config.AccountConfig{
+		Email: "user@example.com",
+		SMTP:  config.SMTPConfig{Auth: "password"},
+	}
+	_, err := GetSMTPAuth(acct)
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), "keychain") {
+		t.Errorf("error = %q, should mention keychain", err.Error())
+	}
+}
+
+// --- OAuth2 auth ---
+
+func TestGetSMTPAuth_OAuth2Success(t *testing.T) {
+	getValidOAuthToken = func(email, clientID, clientSecret, tenant string) (*oauth.Token, error) {
+		if email != "user@example.com" {
+			t.Errorf("email = %q, want %q", email, "user@example.com")
+		}
+		return &oauth.Token{AccessToken: "tok123", Expiry: time.Now().Add(time.Hour)}, nil
+	}
+	defer restoreFuncs()
+
+	acct := &config.AccountConfig{
+		Email: "user@example.com",
+		SMTP:  config.SMTPConfig{Auth: "oauth2"},
+		OAuth: config.OAuthConfig{Provider: "google", ClientID: "cid", ClientSecret: "cs"},
+	}
+	auth, err := GetSMTPAuth(acct)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	oa, ok := auth.(*smtp.OAuth2Auth)
+	if !ok {
+		t.Fatalf("got %T, want *smtp.OAuth2Auth", auth)
+	}
+	if oa.Email != "user@example.com" {
+		t.Errorf("Email = %q, want %q", oa.Email, "user@example.com")
+	}
+	if oa.AccessToken != "tok123" {
+		t.Errorf("AccessToken = %q, want %q", oa.AccessToken, "tok123")
+	}
+}
+
+func TestGetSMTPAuth_OAuth2MissingProvider(t *testing.T) {
+	acct := &config.AccountConfig{
+		Email: "user@example.com",
+		SMTP:  config.SMTPConfig{Auth: "oauth2"},
+		OAuth: config.OAuthConfig{}, // no provider
+	}
+	_, err := GetSMTPAuth(acct)
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), "provider not configured") {
+		t.Errorf("error = %q, want 'provider not configured'", err.Error())
+	}
+}
+
+func TestGetSMTPAuth_OAuth2TokenNotFound(t *testing.T) {
+	getValidOAuthToken = func(_, _, _, _ string) (*oauth.Token, error) { return nil, oauth.ErrTokenNotFound }
+	defer restoreFuncs()
+
+	acct := &config.AccountConfig{
+		Email: "user@example.com",
+		SMTP:  config.SMTPConfig{Auth: "oauth2"},
+		OAuth: config.OAuthConfig{Provider: "google"},
+	}
+	_, err := GetSMTPAuth(acct)
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), "not authenticated") {
+		t.Errorf("error = %q, want 'not authenticated'", err.Error())
+	}
+}
+
+func TestGetSMTPAuth_OAuth2TokenExpired(t *testing.T) {
+	getValidOAuthToken = func(_, _, _, _ string) (*oauth.Token, error) { return nil, oauth.ErrTokenExpired }
+	defer restoreFuncs()
+
+	acct := &config.AccountConfig{
+		Email: "user@example.com",
+		SMTP:  config.SMTPConfig{Auth: "oauth2"},
+		OAuth: config.OAuthConfig{Provider: "microsoft"},
+	}
+	_, err := GetSMTPAuth(acct)
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), "expired") {
+		t.Errorf("error = %q, want 'expired'", err.Error())
+	}
+}
+
+func TestGetSMTPAuth_OAuth2OtherError(t *testing.T) {
+	getValidOAuthToken = func(_, _, _, _ string) (*oauth.Token, error) { return nil, errors.New("network timeout") }
+	defer restoreFuncs()
+
+	acct := &config.AccountConfig{
+		Email: "user@example.com",
+		SMTP:  config.SMTPConfig{Auth: "oauth2"},
+		OAuth: config.OAuthConfig{Provider: "google"},
+	}
+	_, err := GetSMTPAuth(acct)
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), "OAuth token") {
+		t.Errorf("error = %q, should mention OAuth token", err.Error())
+	}
+}
+
+func TestGetSMTPAuth_OAuth2SharedMailbox(t *testing.T) {
+	var calledEmail string
+	getValidOAuthToken = func(email, _, _, _ string) (*oauth.Token, error) {
+		calledEmail = email
+		return &oauth.Token{AccessToken: "delegated-tok", Expiry: time.Now().Add(time.Hour)}, nil
+	}
+	defer restoreFuncs()
+
+	acct := &config.AccountConfig{
+		Email:     "shared@example.com",
+		AuthEmail: "delegator@example.com",
+		SMTP:      config.SMTPConfig{Auth: "oauth2"},
+		OAuth:     config.OAuthConfig{Provider: "microsoft", ClientID: "cid", Tenant: "t"},
+	}
+	auth, err := GetSMTPAuth(acct)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if calledEmail != "delegator@example.com" {
+		t.Errorf("token lookup email = %q, want delegator %q", calledEmail, "delegator@example.com")
+	}
+	oa := auth.(*smtp.OAuth2Auth)
+	if oa.Email != "delegator@example.com" {
+		t.Errorf("OAuth2Auth.Email = %q, want delegator %q", oa.Email, "delegator@example.com")
+	}
+}
+
+// --- Unsupported ---
+
+func TestGetSMTPAuth_UnsupportedMethod(t *testing.T) {
+	acct := &config.AccountConfig{
+		Email: "user@example.com",
+		SMTP:  config.SMTPConfig{Auth: "plain"},
+	}
+	_, err := GetSMTPAuth(acct)
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), "unsupported auth method") {
+		t.Errorf("error = %q, want 'unsupported auth method'", err.Error())
+	}
+}

--- a/cli/internal/contacts/BUILD.bazel
+++ b/cli/internal/contacts/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@rules_go//go:def.bzl", "go_library")
+load("@rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "contacts",
@@ -14,4 +14,11 @@ go_library(
         "@com_github_google_uuid//:uuid",
         "@org_modernc_sqlite//:sqlite",
     ],
+)
+
+go_test(
+    name = "contacts_test",
+    size = "small",
+    srcs = ["db_test.go"],
+    embed = [":contacts"],
 )

--- a/cli/internal/contacts/db_test.go
+++ b/cli/internal/contacts/db_test.go
@@ -1,0 +1,314 @@
+package contacts
+
+import (
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func newTestDB(t *testing.T) *DB {
+	t.Helper()
+	dir := t.TempDir()
+	db, err := Open(filepath.Join(dir, "contacts.db"))
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	if err := db.Init(); err != nil {
+		t.Fatalf("init: %v", err)
+	}
+	t.Cleanup(func() { db.Close() })
+	return db
+}
+
+func TestAddAndSearch(t *testing.T) {
+	db := newTestDB(t)
+
+	if err := db.Add("alice@example.com", "Alice", SourceImported); err != nil {
+		t.Fatalf("add: %v", err)
+	}
+
+	results, err := db.Search("alice", 10)
+	if err != nil {
+		t.Fatalf("search: %v", err)
+	}
+	if len(results) != 1 {
+		t.Fatalf("got %d results, want 1", len(results))
+	}
+	if results[0].Email != "alice@example.com" {
+		t.Errorf("email = %q, want %q", results[0].Email, "alice@example.com")
+	}
+	if results[0].Name != "Alice" {
+		t.Errorf("name = %q, want %q", results[0].Name, "Alice")
+	}
+}
+
+func TestAdd_NormalizesEmail(t *testing.T) {
+	db := newTestDB(t)
+	db.Add("Alice@Example.COM", "Alice", SourceImported)
+
+	results, _ := db.Search("alice", 10)
+	if len(results) != 1 {
+		t.Fatalf("got %d, want 1", len(results))
+	}
+	if results[0].Email != "alice@example.com" {
+		t.Errorf("email = %q, want lowercase", results[0].Email)
+	}
+}
+
+func TestAdd_InvalidEmail(t *testing.T) {
+	db := newTestDB(t)
+	err := db.Add("not-an-email", "Bad", SourceManual)
+	if err == nil {
+		t.Error("expected error for invalid email")
+	}
+}
+
+func TestAdd_UpsertUpdatesName(t *testing.T) {
+	db := newTestDB(t)
+	db.Add("alice@example.com", "", SourceImported)
+	db.Add("alice@example.com", "Alice Smith", SourceImported)
+
+	results, _ := db.Search("alice", 10)
+	if len(results) != 1 {
+		t.Fatalf("got %d, want 1 (upsert should not duplicate)", len(results))
+	}
+	if results[0].Name != "Alice Smith" {
+		t.Errorf("name = %q, want updated name", results[0].Name)
+	}
+}
+
+func TestAdd_UpsertDoesNotClearName(t *testing.T) {
+	db := newTestDB(t)
+	db.Add("alice@example.com", "Alice", SourceImported)
+	db.Add("alice@example.com", "", SourceImported) // empty name should not overwrite
+
+	results, _ := db.Search("alice", 10)
+	if results[0].Name != "Alice" {
+		t.Errorf("name = %q, empty upsert should preserve existing name", results[0].Name)
+	}
+}
+
+func TestFindByExactName(t *testing.T) {
+	db := newTestDB(t)
+	db.Add("alice@example.com", "Alice Smith", SourceImported)
+	db.Add("bob@example.com", "Bob Jones", SourceImported)
+
+	c, err := db.FindByExactName("Alice Smith")
+	if err != nil {
+		t.Fatalf("find: %v", err)
+	}
+	if c == nil {
+		t.Fatal("expected non-nil contact")
+	}
+	if c.Email != "alice@example.com" {
+		t.Errorf("email = %q, want alice", c.Email)
+	}
+}
+
+func TestFindByExactName_CaseInsensitive(t *testing.T) {
+	db := newTestDB(t)
+	db.Add("alice@example.com", "Alice Smith", SourceImported)
+
+	c, _ := db.FindByExactName("alice smith")
+	if c == nil {
+		t.Error("case-insensitive lookup should find contact")
+	}
+}
+
+func TestFindByExactName_NotFound(t *testing.T) {
+	db := newTestDB(t)
+	c, err := db.FindByExactName("Nobody")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if c != nil {
+		t.Error("expected nil for non-existent name")
+	}
+}
+
+func TestList(t *testing.T) {
+	db := newTestDB(t)
+	db.Add("alice@example.com", "Alice", SourceImported)
+	db.Add("bob@example.com", "Bob", SourceImported)
+	db.Add("charlie@example.com", "Charlie", SourceImported)
+
+	results, err := db.List(10)
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	if len(results) != 3 {
+		t.Errorf("got %d, want 3", len(results))
+	}
+}
+
+func TestList_RespectsLimit(t *testing.T) {
+	db := newTestDB(t)
+	db.Add("a@example.com", "A", SourceImported)
+	db.Add("b@example.com", "B", SourceImported)
+	db.Add("c@example.com", "C", SourceImported)
+
+	results, _ := db.List(2)
+	if len(results) != 2 {
+		t.Errorf("got %d, want 2", len(results))
+	}
+}
+
+func TestCount(t *testing.T) {
+	db := newTestDB(t)
+	db.Add("a@example.com", "A", SourceImported)
+	db.Add("b@example.com", "B", SourceImported)
+
+	count, err := db.Count()
+	if err != nil {
+		t.Fatalf("count: %v", err)
+	}
+	if count != 2 {
+		t.Errorf("count = %d, want 2", count)
+	}
+}
+
+func TestIncrementUsage(t *testing.T) {
+	db := newTestDB(t)
+	db.Add("alice@example.com", "Alice", SourceImported)
+
+	db.IncrementUsage("alice@example.com")
+	db.IncrementUsage("alice@example.com")
+
+	results, _ := db.Search("alice", 10)
+	if results[0].UsageCount != 2 {
+		t.Errorf("usage = %d, want 2", results[0].UsageCount)
+	}
+	if results[0].LastUsed.IsZero() {
+		t.Error("last_used should be set after increment")
+	}
+}
+
+func TestDelete(t *testing.T) {
+	db := newTestDB(t)
+	db.Add("alice@example.com", "Alice", SourceImported)
+
+	if err := db.Delete("alice@example.com"); err != nil {
+		t.Fatalf("delete: %v", err)
+	}
+
+	count, _ := db.Count()
+	if count != 0 {
+		t.Errorf("count = %d after delete, want 0", count)
+	}
+}
+
+func TestDelete_NotFound(t *testing.T) {
+	db := newTestDB(t)
+	err := db.Delete("nobody@example.com")
+	if err == nil {
+		t.Error("expected error for non-existent contact")
+	}
+}
+
+func TestAddBatch(t *testing.T) {
+	db := newTestDB(t)
+	contacts := []Contact{
+		{ID: "1", Email: "a@example.com", Name: "A", Source: SourceImported, CreatedAt: time.Now()},
+		{ID: "2", Email: "b@example.com", Name: "B", Source: SourceImported, CreatedAt: time.Now()},
+		{ID: "3", Email: "c@example.com", Name: "C", Source: SourceImported, CreatedAt: time.Now()},
+	}
+
+	added, _, err := db.AddBatch(contacts)
+	if err != nil {
+		t.Fatalf("batch: %v", err)
+	}
+	if added != 3 {
+		t.Errorf("added = %d, want 3", added)
+	}
+
+	count, _ := db.Count()
+	if count != 3 {
+		t.Errorf("count = %d, want 3", count)
+	}
+}
+
+func TestAddBatch_SkipsInvalidEmail(t *testing.T) {
+	db := newTestDB(t)
+	contacts := []Contact{
+		{ID: "1", Email: "good@example.com", Name: "Good", Source: SourceImported, CreatedAt: time.Now()},
+		{ID: "2", Email: "bad-email", Name: "Bad", Source: SourceImported, CreatedAt: time.Now()},
+	}
+
+	added, _, _ := db.AddBatch(contacts)
+	if added != 1 {
+		t.Errorf("added = %d, want 1 (invalid email skipped)", added)
+	}
+}
+
+func TestCleanInvalid(t *testing.T) {
+	db := newTestDB(t)
+	// Directly insert an invalid email via raw SQL to bypass validation
+	db.db.Exec(`INSERT INTO contacts (id, email, name, source) VALUES ('1', 'bad', 'Bad', 'test')`)
+	db.Add("good@example.com", "Good", SourceImported)
+
+	removed, err := db.CleanInvalid()
+	if err != nil {
+		t.Fatalf("clean: %v", err)
+	}
+	if removed != 1 {
+		t.Errorf("removed = %d, want 1", removed)
+	}
+
+	count, _ := db.Count()
+	if count != 1 {
+		t.Errorf("count = %d, want 1 (only valid contact)", count)
+	}
+}
+
+func TestSearch_OrderedByUsage(t *testing.T) {
+	db := newTestDB(t)
+	db.Add("low@example.com", "Low", SourceImported)
+	db.Add("high@example.com", "High", SourceImported)
+
+	// Increment high usage
+	db.IncrementUsage("high@example.com")
+	db.IncrementUsage("high@example.com")
+
+	results, _ := db.List(10)
+	if len(results) < 2 {
+		t.Fatalf("got %d, want 2+", len(results))
+	}
+	if results[0].Email != "high@example.com" {
+		t.Errorf("first result = %q, want high-usage contact first", results[0].Email)
+	}
+}
+
+func TestIsValidEmail(t *testing.T) {
+	tests := []struct {
+		email string
+		valid bool
+	}{
+		{"user@example.com", true},
+		{"user.name+tag@example.co.uk", true},
+		{"user@sub.domain.com", true},
+		{"not-an-email", false},
+		{"@example.com", false},
+		{"user@", false},
+		{"", false},
+		{"user@x.y", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.email, func(t *testing.T) {
+			if got := isValidEmail(tt.email); got != tt.valid {
+				t.Errorf("isValidEmail(%q) = %v, want %v", tt.email, got, tt.valid)
+			}
+		})
+	}
+}
+
+func TestFormatDisplay(t *testing.T) {
+	c := &Contact{Email: "alice@example.com", Name: "Alice"}
+	if got := c.FormatDisplay(); got != "Alice <alice@example.com>" {
+		t.Errorf("FormatDisplay() = %q", got)
+	}
+
+	c2 := &Contact{Email: "bob@example.com"}
+	if got := c2.FormatDisplay(); got != "bob@example.com" {
+		t.Errorf("FormatDisplay() = %q, want email only", got)
+	}
+}

--- a/cli/internal/draft/BUILD.bazel
+++ b/cli/internal/draft/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@rules_go//go:def.bzl", "go_library")
+load("@rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "draft",
@@ -11,4 +11,11 @@ go_library(
         "//cli/internal/smtp",
         "@com_github_emersion_go_imap//:go-imap",
     ],
+)
+
+go_test(
+    name = "draft_test",
+    size = "small",
+    srcs = ["draft_test.go"],
+    embed = [":draft"],
 )

--- a/cli/internal/draft/draft_test.go
+++ b/cli/internal/draft/draft_test.go
@@ -1,0 +1,107 @@
+package draft
+
+import "testing"
+
+func TestExtractMessageID(t *testing.T) {
+	tests := []struct {
+		name string
+		data string
+		want string
+	}{
+		{
+			"standard header",
+			"From: test@example.com\r\nMessage-ID: <abc123@mail.example.com>\r\nSubject: Test\r\n",
+			"abc123@mail.example.com",
+		},
+		{
+			"lowercase header",
+			"From: test@example.com\r\nMessage-Id: <def456@example.com>\r\nSubject: Test\r\n",
+			"def456@example.com",
+		},
+		{
+			"unix line endings",
+			"From: test@example.com\nMessage-ID: <unix@example.com>\nSubject: Test\n",
+			"unix@example.com",
+		},
+		{
+			"no brackets",
+			"Message-ID: plain-id@example.com\r\n",
+			"plain-id@example.com",
+		},
+		{
+			"with whitespace",
+			"Message-ID:   <spaced@example.com>  \r\n",
+			"spaced@example.com",
+		},
+		{
+			"no message id header",
+			"From: test@example.com\r\nSubject: No ID\r\n",
+			"",
+		},
+		{
+			"empty input",
+			"",
+			"",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := extractMessageID([]byte(tt.data))
+			if got != tt.want {
+				t.Errorf("extractMessageID() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestTrimSpace(t *testing.T) {
+	tests := []struct {
+		input, want string
+	}{
+		{"  hello  ", "hello"},
+		{"\thello\t", "hello"},
+		{"hello", "hello"},
+		{"  ", ""},
+		{"", ""},
+	}
+	for _, tt := range tests {
+		if got := trimSpace(tt.input); got != tt.want {
+			t.Errorf("trimSpace(%q) = %q, want %q", tt.input, got, tt.want)
+		}
+	}
+}
+
+func TestTrimBrackets(t *testing.T) {
+	tests := []struct {
+		input, want string
+	}{
+		{"<abc@example.com>", "abc@example.com"},
+		{"no-brackets@example.com", "no-brackets@example.com"},
+		{"<>", ""},
+		{"a", "a"},
+		{"", ""},
+	}
+	for _, tt := range tests {
+		if got := trimBrackets(tt.input); got != tt.want {
+			t.Errorf("trimBrackets(%q) = %q, want %q", tt.input, got, tt.want)
+		}
+	}
+}
+
+func TestIndexOf(t *testing.T) {
+	tests := []struct {
+		s, substr string
+		want      int
+	}{
+		{"hello world", "world", 6},
+		{"hello", "hello", 0},
+		{"hello", "xyz", -1},
+		{"", "a", -1},
+		{"abc", "", 0},
+	}
+	for _, tt := range tests {
+		if got := indexOf(tt.s, tt.substr); got != tt.want {
+			t.Errorf("indexOf(%q, %q) = %d, want %d", tt.s, tt.substr, got, tt.want)
+		}
+	}
+}

--- a/cli/internal/keychain/BUILD.bazel
+++ b/cli/internal/keychain/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@rules_go//go:def.bzl", "go_library")
+load("@rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "keychain",
@@ -9,4 +9,11 @@ go_library(
     ],
     importpath = "github.com/durian-dev/durian/cli/internal/keychain",
     visibility = ["//cli:__subpackages__"],
+)
+
+go_test(
+    name = "keychain_test",
+    size = "small",
+    srcs = ["keychain_darwin_test.go"],
+    embed = [":keychain"],
 )

--- a/cli/internal/keychain/keychain_darwin.go
+++ b/cli/internal/keychain/keychain_darwin.go
@@ -6,9 +6,12 @@ import (
 	"strings"
 )
 
+// commandRunner creates exec.Cmd instances. Tests override this to avoid real keychain access.
+var commandRunner = exec.Command
+
 // GetPassword retrieves a password from the macOS Keychain
 func GetPassword(service, account string) (string, error) {
-	cmd := exec.Command("security", "find-generic-password",
+	cmd := commandRunner("security", "find-generic-password",
 		"-s", service,
 		"-a", account,
 		"-w", // Output only the password
@@ -32,7 +35,7 @@ func GetPassword(service, account string) (string, error) {
 func SetPassword(service, account, password string) error {
 	_ = DeletePassword(service, account)
 
-	cmd := exec.Command("security", "add-generic-password",
+	cmd := commandRunner("security", "add-generic-password",
 		"-s", service,
 		"-a", account,
 		"-w", password,
@@ -48,7 +51,7 @@ func SetPassword(service, account, password string) error {
 
 // DeletePassword removes a password from the macOS Keychain
 func DeletePassword(service, account string) error {
-	cmd := exec.Command("security", "delete-generic-password",
+	cmd := commandRunner("security", "delete-generic-password",
 		"-s", service,
 		"-a", account,
 	)

--- a/cli/internal/keychain/keychain_darwin_test.go
+++ b/cli/internal/keychain/keychain_darwin_test.go
@@ -1,0 +1,159 @@
+package keychain
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"testing"
+)
+
+// TestHelperProcess is not a real test — it is invoked as a subprocess by
+// tests that override commandRunner to simulate security CLI responses.
+func TestHelperProcess(t *testing.T) {
+	if os.Getenv("GO_TEST_HELPER") != "1" {
+		return
+	}
+	switch os.Getenv("GO_TEST_MODE") {
+	case "success":
+		fmt.Fprint(os.Stdout, os.Getenv("GO_TEST_STDOUT"))
+		os.Exit(0)
+	case "exit44":
+		os.Exit(44)
+	case "exit1":
+		fmt.Fprint(os.Stderr, os.Getenv("GO_TEST_STDERR"))
+		os.Exit(1)
+	default:
+		fmt.Fprintln(os.Stderr, "unknown GO_TEST_MODE")
+		os.Exit(2)
+	}
+}
+
+// mockCommand returns a commandRunner replacement that invokes TestHelperProcess
+// with the given mode, stdout, and stderr values.
+func mockCommand(mode, stdout, stderr string) func(string, ...string) *exec.Cmd {
+	return func(name string, args ...string) *exec.Cmd {
+		cmd := exec.Command(os.Args[0], "-test.run=TestHelperProcess")
+		cmd.Env = append(os.Environ(),
+			"GO_TEST_HELPER=1",
+			"GO_TEST_MODE="+mode,
+			"GO_TEST_STDOUT="+stdout,
+			"GO_TEST_STDERR="+stderr,
+		)
+		return cmd
+	}
+}
+
+func restoreCommandRunner() { commandRunner = exec.Command }
+
+// --- GetPassword ---
+
+func TestGetPassword_Success(t *testing.T) {
+	commandRunner = mockCommand("success", "my-secret\n", "")
+	defer restoreCommandRunner()
+
+	pw, err := GetPassword("svc", "acct")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if pw != "my-secret" {
+		t.Errorf("password = %q, want %q", pw, "my-secret")
+	}
+}
+
+func TestGetPassword_NotFound(t *testing.T) {
+	commandRunner = mockCommand("exit44", "", "")
+	defer restoreCommandRunner()
+
+	_, err := GetPassword("svc", "acct")
+	if !errors.Is(err, ErrNotFound) {
+		t.Errorf("err = %v, want ErrNotFound", err)
+	}
+}
+
+func TestGetPassword_ExecError(t *testing.T) {
+	commandRunner = mockCommand("exit1", "", "security: something went wrong")
+	defer restoreCommandRunner()
+
+	_, err := GetPassword("svc", "acct")
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if errors.Is(err, ErrNotFound) {
+		t.Error("should not be ErrNotFound")
+	}
+}
+
+// --- SetPassword ---
+
+func TestSetPassword_Success(t *testing.T) {
+	commandRunner = mockCommand("success", "", "")
+	defer restoreCommandRunner()
+
+	err := SetPassword("svc", "acct", "pw")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestSetPassword_Failure(t *testing.T) {
+	commandRunner = mockCommand("exit1", "", "add failed")
+	defer restoreCommandRunner()
+
+	err := SetPassword("svc", "acct", "pw")
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+}
+
+// --- DeletePassword ---
+
+func TestDeletePassword_Success(t *testing.T) {
+	commandRunner = mockCommand("success", "", "")
+	defer restoreCommandRunner()
+
+	err := DeletePassword("svc", "acct")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestDeletePassword_NotFoundIsNil(t *testing.T) {
+	commandRunner = mockCommand("exit44", "", "")
+	defer restoreCommandRunner()
+
+	err := DeletePassword("svc", "acct")
+	if err != nil {
+		t.Errorf("expected nil for not-found, got: %v", err)
+	}
+}
+
+func TestDeletePassword_OtherError(t *testing.T) {
+	commandRunner = mockCommand("exit1", "", "delete failed")
+	defer restoreCommandRunner()
+
+	err := DeletePassword("svc", "acct")
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+}
+
+// --- Exists ---
+
+func TestExists_Found(t *testing.T) {
+	commandRunner = mockCommand("success", "pw\n", "")
+	defer restoreCommandRunner()
+
+	if !Exists("svc", "acct") {
+		t.Error("Exists() = false, want true")
+	}
+}
+
+func TestExists_NotFound(t *testing.T) {
+	commandRunner = mockCommand("exit44", "", "")
+	defer restoreCommandRunner()
+
+	if Exists("svc", "acct") {
+		t.Error("Exists() = true, want false")
+	}
+}

--- a/cli/internal/keychain/keychain_linux.go
+++ b/cli/internal/keychain/keychain_linux.go
@@ -6,9 +6,12 @@ import (
 	"strings"
 )
 
+// commandRunner creates exec.Cmd instances. Tests override this to avoid real keychain access.
+var commandRunner = exec.Command
+
 // GetPassword retrieves a password using secret-tool (libsecret)
 func GetPassword(service, account string) (string, error) {
-	cmd := exec.Command("secret-tool", "lookup", "service", service, "account", account)
+	cmd := commandRunner("secret-tool", "lookup", "service", service, "account", account)
 
 	output, err := cmd.Output()
 	if err != nil {
@@ -29,7 +32,7 @@ func GetPassword(service, account string) (string, error) {
 
 // SetPassword stores a password using secret-tool (libsecret)
 func SetPassword(service, account, password string) error {
-	cmd := exec.Command("secret-tool", "store",
+	cmd := commandRunner("secret-tool", "store",
 		"--label", fmt.Sprintf("durian: %s", account),
 		"service", service,
 		"account", account,
@@ -45,7 +48,7 @@ func SetPassword(service, account, password string) error {
 
 // DeletePassword removes a password using secret-tool (libsecret)
 func DeletePassword(service, account string) error {
-	cmd := exec.Command("secret-tool", "clear", "service", service, "account", account)
+	cmd := commandRunner("secret-tool", "clear", "service", service, "account", account)
 
 	if err := cmd.Run(); err != nil {
 		// secret-tool clear doesn't error on missing items

--- a/cli/internal/mail/parser_test.go
+++ b/cli/internal/mail/parser_test.go
@@ -1,6 +1,7 @@
 package mail
 
 import (
+	"encoding/base64"
 	"net/mail"
 	"os"
 	"path/filepath"
@@ -231,5 +232,160 @@ func TestNewParser(t *testing.T) {
 	parser := NewParser()
 	if parser == nil {
 		t.Error("NewParser() should not return nil")
+	}
+}
+
+func TestDetectMagic(t *testing.T) {
+	tests := []struct {
+		name             string
+		data             []byte
+		transferEncoding string
+		wantMime         string
+		wantExt          string
+	}{
+		{"PDF magic", []byte("%PDF-1.4 rest of content here"), "", "application/pdf", ".pdf"},
+		{"PNG magic", append([]byte{0x89, 'P', 'N', 'G', 0x0D, 0x0A, 0x1A, 0x0A}, make([]byte, 8)...), "", "image/png", ".png"},
+		{"JPEG magic", append([]byte{0xFF, 0xD8, 0xFF, 0xE0}, make([]byte, 8)...), "", "image/jpeg", ".jpg"},
+		{"GIF magic", []byte("GIF89a rest of content"), "", "image/gif", ".gif"},
+		{"ZIP magic", append([]byte{0x50, 0x4B, 0x03, 0x04}, make([]byte, 8)...), "", "application/zip", ".zip"},
+		{"XML magic", []byte("<?xml version=\"1.0\"?>"), "", "application/xml", ".xml"},
+		{"unknown bytes", []byte{0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09}, "", "", ""},
+		{"too short", []byte{0x89, 'P', 'N'}, "", "", ""},
+		{"empty data", []byte{}, "", "", ""},
+		{
+			"base64 PDF",
+			[]byte(base64.StdEncoding.EncodeToString([]byte("%PDF-1.4 fake pdf content here"))),
+			"base64",
+			"application/pdf", ".pdf",
+		},
+		{
+			"base64 PNG",
+			[]byte(base64.StdEncoding.EncodeToString(append([]byte{0x89, 'P', 'N', 'G', 0x0D, 0x0A, 0x1A, 0x0A}, make([]byte, 16)...))),
+			"base64",
+			"image/png", ".png",
+		},
+		{
+			"base64 data with 7bit encoding ignored",
+			[]byte(base64.StdEncoding.EncodeToString([]byte("%PDF-1.4 content"))),
+			"7bit",
+			"", "",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotMime, gotExt := detectMagic(tt.data, tt.transferEncoding)
+			if gotMime != tt.wantMime {
+				t.Errorf("detectMagic() mime = %q, want %q", gotMime, tt.wantMime)
+			}
+			if gotExt != tt.wantExt {
+				t.Errorf("detectMagic() ext = %q, want %q", gotExt, tt.wantExt)
+			}
+		})
+	}
+}
+
+func TestParserHTMLOnlyFallback(t *testing.T) {
+	msg := loadTestMail(t, "html_only.eml")
+	parser := NewParser()
+
+	content := parser.Parse(msg)
+
+	if content.Subject != "HTML Only Email" {
+		t.Errorf("Subject = %q, want %q", content.Subject, "HTML Only Email")
+	}
+
+	// HTML should contain the original HTML
+	if !strings.Contains(content.HTML, "<strong>HTML</strong>") {
+		t.Errorf("HTML should contain strong tag, got: %q", content.HTML)
+	}
+
+	// Body should be auto-generated from HTML (fallback)
+	if !strings.Contains(content.Body, "Important Update") {
+		t.Errorf("Body should contain text derived from HTML, got: %q", content.Body)
+	}
+}
+
+func TestParserInlineAttachment(t *testing.T) {
+	msg := loadTestMail(t, "inline_attachment.eml")
+	parser := NewParser()
+
+	content := parser.Parse(msg)
+
+	if content.Subject != "Inline Attachment Email" {
+		t.Errorf("Subject = %q, want %q", content.Subject, "Inline Attachment Email")
+	}
+
+	// Body should contain the text part
+	if !strings.Contains(content.Body, "inline image below") {
+		t.Errorf("Body should contain text content, got: %q", content.Body)
+	}
+
+	// Should have 1 inline attachment
+	if len(content.Attachments) != 1 {
+		t.Fatalf("Should have 1 attachment, got %d", len(content.Attachments))
+	}
+
+	att := content.Attachments[0]
+	if att.Filename != "photo.png" {
+		t.Errorf("Attachment filename = %q, want %q", att.Filename, "photo.png")
+	}
+	if att.Disposition != "inline" {
+		t.Errorf("Attachment disposition = %q, want %q", att.Disposition, "inline")
+	}
+	if att.ContentID != "<photo001@example.com>" {
+		t.Errorf("Attachment ContentID = %q, want %q", att.ContentID, "<photo001@example.com>")
+	}
+}
+
+func TestParserUnnamedAttachmentMagicDetection(t *testing.T) {
+	msg := loadTestMail(t, "unnamed_attachment_pdf.eml")
+	parser := NewParser()
+
+	content := parser.Parse(msg)
+
+	if content.Subject != "Unnamed Attachment" {
+		t.Errorf("Subject = %q, want %q", content.Subject, "Unnamed Attachment")
+	}
+
+	// Body should contain the text part
+	if !strings.Contains(content.Body, "See the attached file") {
+		t.Errorf("Body should contain text content, got: %q", content.Body)
+	}
+
+	// Should have 1 attachment with magic-detected name and type
+	if len(content.Attachments) != 1 {
+		t.Fatalf("Should have 1 attachment, got %d", len(content.Attachments))
+	}
+
+	att := content.Attachments[0]
+	if att.Filename != "attachment.pdf" {
+		t.Errorf("Attachment filename = %q, want %q (from magic detection)", att.Filename, "attachment.pdf")
+	}
+	if att.ContentType != "application/pdf" {
+		t.Errorf("Attachment ContentType = %q, want %q (from magic detection)", att.ContentType, "application/pdf")
+	}
+}
+
+func TestParserEmptyContentType(t *testing.T) {
+	msg := loadTestMail(t, "empty_content_type.eml")
+	parser := NewParser()
+
+	content := parser.Parse(msg)
+
+	if content.Subject != "No Content Type" {
+		t.Errorf("Subject = %q, want %q", content.Subject, "No Content Type")
+	}
+
+	// Should fall back to text/plain
+	if !strings.Contains(content.Body, "no Content-Type header") {
+		t.Errorf("Body should contain text content, got: %q", content.Body)
+	}
+	if !strings.Contains(content.Body, "default to text/plain") {
+		t.Errorf("Body should contain full text, got: %q", content.Body)
+	}
+
+	// No HTML for plain text
+	if content.HTML != "" {
+		t.Errorf("HTML should be empty, got: %q", content.HTML)
 	}
 }

--- a/cli/internal/mail/testdata/empty_content_type.eml
+++ b/cli/internal/mail/testdata/empty_content_type.eml
@@ -1,0 +1,7 @@
+From: sender@example.com
+To: recipient@example.com
+Subject: No Content Type
+Date: Sat, 05 Apr 2026 13:00:00 +0200
+
+This email has no Content-Type header at all.
+It should default to text/plain.

--- a/cli/internal/mail/testdata/html_only.eml
+++ b/cli/internal/mail/testdata/html_only.eml
@@ -1,0 +1,20 @@
+From: sender@example.com
+To: recipient@example.com
+Subject: HTML Only Email
+Date: Sat, 05 Apr 2026 10:00:00 +0200
+MIME-Version: 1.0
+Content-Type: multipart/alternative; boundary="----=_Part_HtmlOnly_001"
+
+------=_Part_HtmlOnly_001
+Content-Type: text/html; charset=utf-8
+Content-Transfer-Encoding: 7bit
+
+<html>
+<body>
+<h1>Important Update</h1>
+<p>This email only has an <strong>HTML</strong> body, no plain text part.</p>
+<p>The parser should generate a text fallback.</p>
+</body>
+</html>
+
+------=_Part_HtmlOnly_001--

--- a/cli/internal/mail/testdata/inline_attachment.eml
+++ b/cli/internal/mail/testdata/inline_attachment.eml
@@ -1,0 +1,23 @@
+From: sender@example.com
+To: recipient@example.com
+Subject: Inline Attachment Email
+Date: Sat, 05 Apr 2026 11:00:00 +0200
+MIME-Version: 1.0
+Content-Type: multipart/mixed; boundary="----=_Part_Inline_001"
+
+------=_Part_Inline_001
+Content-Type: text/plain; charset=utf-8
+Content-Transfer-Encoding: 7bit
+
+This email has an inline image below.
+
+------=_Part_Inline_001
+Content-Type: image/png; name="photo.png"
+Content-Disposition: inline; filename="photo.png"
+Content-Transfer-Encoding: base64
+Content-Id: <photo001@example.com>
+
+iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGA
+faKk0AAAAABJRU5ErkJggg==
+
+------=_Part_Inline_001--

--- a/cli/internal/mail/testdata/unnamed_attachment_pdf.eml
+++ b/cli/internal/mail/testdata/unnamed_attachment_pdf.eml
@@ -1,0 +1,23 @@
+From: sender@example.com
+To: recipient@example.com
+Subject: Unnamed Attachment
+Date: Sat, 05 Apr 2026 12:00:00 +0200
+MIME-Version: 1.0
+Content-Type: multipart/mixed; boundary="----=_Part_Unnamed_001"
+
+------=_Part_Unnamed_001
+Content-Type: text/plain; charset=utf-8
+Content-Transfer-Encoding: 7bit
+
+See the attached file.
+
+------=_Part_Unnamed_001
+Content-Type: application/octet-stream
+Content-Disposition: attachment
+Content-Transfer-Encoding: base64
+
+JVBERi0xLjQKMSAwIG9iago8PAovVHlwZSAvQ2F0YWxvZwovUGFnZXMgMiAwIFIKPj4KZW5k
+b2JqCjIgMCBvYmoKPDwKL1R5cGUgL1BhZ2VzCi9LaWRzIFszIDAgUl0KL0NvdW50IDEKL01l
+ZGlhQm94IFswIDAgNjEyIDc5Ml0KPj4KZW5kb2JqCg==
+
+------=_Part_Unnamed_001--

--- a/cli/internal/tagsync/BUILD.bazel
+++ b/cli/internal/tagsync/BUILD.bazel
@@ -1,8 +1,15 @@
-load("@rules_go//go:def.bzl", "go_library")
+load("@rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "tagsync",
     srcs = ["client.go"],
     importpath = "github.com/durian-dev/durian/cli/internal/tagsync",
     visibility = ["//cli:__subpackages__"],
+)
+
+go_test(
+    name = "tagsync_test",
+    size = "small",
+    srcs = ["client_test.go"],
+    embed = [":tagsync"],
 )

--- a/cli/internal/tagsync/client_test.go
+++ b/cli/internal/tagsync/client_test.go
@@ -1,0 +1,257 @@
+package tagsync
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// mockStore implements MetaStore for testing.
+type mockStore struct {
+	data map[string]int64
+}
+
+func newMockStore() *mockStore {
+	return &mockStore{data: make(map[string]int64)}
+}
+
+func (m *mockStore) GetMeta(key string) int64 { return m.data[key] }
+func (m *mockStore) SetMeta(key string, v int64) { m.data[key] = v }
+
+func newTestClient(url string) *Client {
+	c := NewClient(url, "test-key")
+	return c
+}
+
+// --- Push ---
+
+func TestPush_Success(t *testing.T) {
+	var received struct {
+		Changes  []TagChange `json:"changes"`
+		ClientID string      `json:"client_id"`
+	}
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != "POST" {
+			t.Errorf("method = %s, want POST", r.Method)
+		}
+		if r.URL.Path != "/v1/sync" {
+			t.Errorf("path = %s, want /v1/sync", r.URL.Path)
+		}
+		if r.Header.Get("X-API-Key") != "test-key" {
+			t.Errorf("api key = %q, want test-key", r.Header.Get("X-API-Key"))
+		}
+		if r.Header.Get("Content-Type") != "application/json" {
+			t.Errorf("content-type = %q", r.Header.Get("Content-Type"))
+		}
+
+		body, _ := io.ReadAll(r.Body)
+		json.Unmarshal(body, &received)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	c := newTestClient(srv.URL)
+	changes := []TagChange{
+		{MessageID: "msg1@test", Account: "work", Tag: "inbox", Action: "add"},
+	}
+
+	err := c.Push(changes)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(received.Changes) != 1 {
+		t.Fatalf("received %d changes, want 1", len(received.Changes))
+	}
+	if received.Changes[0].MessageID != "msg1@test" {
+		t.Errorf("message_id = %q", received.Changes[0].MessageID)
+	}
+	if received.Changes[0].ClientID == "" {
+		t.Error("client_id should be populated")
+	}
+	if received.Changes[0].Timestamp == 0 {
+		t.Error("timestamp should be populated")
+	}
+}
+
+func TestPush_Empty(t *testing.T) {
+	c := newTestClient("http://should-not-be-called")
+	// Empty changes should return nil without making a request
+	if err := c.Push(nil); err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	if err := c.Push([]TagChange{}); err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestPush_ServerError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "internal error", http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	c := newTestClient(srv.URL)
+	err := c.Push([]TagChange{{MessageID: "msg1@test", Tag: "inbox", Action: "add"}})
+	if err == nil {
+		t.Fatal("expected error for 500 response")
+	}
+}
+
+func TestPush_PreservesExistingTimestamp(t *testing.T) {
+	var received struct {
+		Changes []TagChange `json:"changes"`
+	}
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		json.Unmarshal(body, &received)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	c := newTestClient(srv.URL)
+	changes := []TagChange{
+		{MessageID: "msg1@test", Tag: "inbox", Action: "add", Timestamp: 1234567890},
+	}
+	c.Push(changes)
+
+	if received.Changes[0].Timestamp != 1234567890 {
+		t.Errorf("timestamp = %d, want preserved 1234567890", received.Changes[0].Timestamp)
+	}
+}
+
+// --- Pull ---
+
+func TestPull_Success(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != "GET" {
+			t.Errorf("method = %s, want GET", r.Method)
+		}
+		if r.Header.Get("X-API-Key") != "test-key" {
+			t.Errorf("api key = %q", r.Header.Get("X-API-Key"))
+		}
+		if r.URL.Query().Get("since") != "100" {
+			t.Errorf("since = %q, want 100", r.URL.Query().Get("since"))
+		}
+
+		json.NewEncoder(w).Encode(map[string]any{
+			"changes": []TagChange{
+				{MessageID: "remote@test", Tag: "archived", Action: "add", Timestamp: 200},
+			},
+			"sync_at": 200,
+		})
+	}))
+	defer srv.Close()
+
+	c := newTestClient(srv.URL)
+	changes, syncAt, err := c.Pull(100)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if syncAt != 200 {
+		t.Errorf("sync_at = %d, want 200", syncAt)
+	}
+	if len(changes) != 1 {
+		t.Fatalf("got %d changes, want 1", len(changes))
+	}
+	if changes[0].MessageID != "remote@test" {
+		t.Errorf("message_id = %q", changes[0].MessageID)
+	}
+	if changes[0].Action != "add" {
+		t.Errorf("action = %q, want add", changes[0].Action)
+	}
+}
+
+func TestPull_ServerError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "unauthorized", http.StatusUnauthorized)
+	}))
+	defer srv.Close()
+
+	c := newTestClient(srv.URL)
+	_, syncAt, err := c.Pull(0)
+	if err == nil {
+		t.Fatal("expected error for 401")
+	}
+	if syncAt != 0 {
+		t.Errorf("syncAt = %d, want original since value 0", syncAt)
+	}
+}
+
+func TestPull_EmptyChanges(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode(map[string]any{
+			"changes": []TagChange{},
+			"sync_at": 500,
+		})
+	}))
+	defer srv.Close()
+
+	c := newTestClient(srv.URL)
+	changes, syncAt, err := c.Pull(400)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(changes) != 0 {
+		t.Errorf("got %d changes, want 0", len(changes))
+	}
+	if syncAt != 500 {
+		t.Errorf("sync_at = %d, want 500", syncAt)
+	}
+}
+
+// --- LoadLastSync / SaveLastSync ---
+
+func TestLoadLastSync_NilStore(t *testing.T) {
+	c := newTestClient("http://unused")
+	if got := c.LoadLastSync(); got != 0 {
+		t.Errorf("LoadLastSync() = %d, want 0 for nil store", got)
+	}
+}
+
+func TestLoadLastSync_WithStore(t *testing.T) {
+	c := newTestClient("http://unused")
+	store := newMockStore()
+	store.data["tag_sync_at"] = 42
+	c.SetStore(store)
+
+	if got := c.LoadLastSync(); got != 42 {
+		t.Errorf("LoadLastSync() = %d, want 42", got)
+	}
+}
+
+func TestSaveLastSync(t *testing.T) {
+	c := newTestClient("http://unused")
+	store := newMockStore()
+	c.SetStore(store)
+
+	c.SaveLastSync(999)
+	if store.data["tag_sync_at"] != 999 {
+		t.Errorf("store value = %d, want 999", store.data["tag_sync_at"])
+	}
+}
+
+func TestSaveLastSync_NilStore(t *testing.T) {
+	c := newTestClient("http://unused")
+	// Should not panic with nil store
+	c.SaveLastSync(123)
+}
+
+// --- NewClient ---
+
+func TestNewClient_TrimsTrailingSlash(t *testing.T) {
+	c := NewClient("http://example.com/sync/", "key")
+	if c.url != "http://example.com/sync" {
+		t.Errorf("url = %q, want trailing slash trimmed", c.url)
+	}
+}
+
+func TestNewClient_SetsClientID(t *testing.T) {
+	c := NewClient("http://example.com", "key")
+	if c.clientID == "" {
+		t.Error("clientID should not be empty")
+	}
+}

--- a/integration/BUILD.bazel
+++ b/integration/BUILD.bazel
@@ -1,0 +1,14 @@
+sh_test(
+    name = "integration_test",
+    size = "medium",
+    srcs = ["integration_test.sh"],
+    args = [
+        "$(location //cli/cmd/testseeder)",
+        "$(location //cli/cmd/durian)",
+    ],
+    data = [
+        "//cli/cmd/testseeder",
+        "//cli/cmd/durian",
+    ],
+    tags = ["integration"],
+)

--- a/integration/integration_test.sh
+++ b/integration/integration_test.sh
@@ -1,0 +1,237 @@
+#!/bin/bash
+# Integration test: starts Go durian server with seeded test data,
+# validates API contract via curl + jq, then cleans up.
+#
+# Each assertion validates a JSON field type/path that maps 1:1
+# to a Swift Decodable struct field. If it breaks here, Swift breaks too.
+set -euo pipefail
+
+SEEDER="$1"
+DURIAN="$2"
+PORT=19723
+TMPDIR=$(mktemp -d /tmp/durian-inttest-XXXXXX)
+EMAIL_DB="$TMPDIR/email.db"
+CONTACTS_DB="$TMPDIR/contacts.db"
+FAILURES=0
+PASSED=0
+
+cleanup() {
+    if [ -n "${SERVER_PID:-}" ]; then
+        kill "$SERVER_PID" 2>/dev/null || true
+        wait "$SERVER_PID" 2>/dev/null || true
+    fi
+    rm -rf "$TMPDIR"
+}
+trap cleanup EXIT
+
+fail() {
+    echo "FAIL: $1"
+    FAILURES=$((FAILURES + 1))
+}
+
+pass() {
+    echo "PASS: $1"
+    PASSED=$((PASSED + 1))
+}
+
+assert_jq() {
+    local desc="$1" json="$2" expr="$3"
+    if echo "$json" | jq -e "$expr" > /dev/null 2>&1; then
+        pass "$desc"
+    else
+        fail "$desc (expression: $expr)"
+        echo "  Response: $(echo "$json" | head -c 200)"
+    fi
+}
+
+assert_http_code() {
+    local desc="$1" url="$2" method="${3:-GET}" expected="$4" body="${5:-}"
+    local code
+    if [ "$method" = "GET" ]; then
+        code=$(curl -s -o /dev/null -w "%{http_code}" "$url")
+    else
+        code=$(curl -s -o /dev/null -w "%{http_code}" -X "$method" -H "Content-Type: application/json" -d "$body" "$url")
+    fi
+    if [ "$code" = "$expected" ]; then
+        pass "$desc"
+    else
+        fail "$desc (got $code, want $expected)"
+    fi
+}
+
+# --- Setup ---
+
+echo "==> Seeding test databases"
+"$SEEDER" "$EMAIL_DB" "$CONTACTS_DB"
+
+echo "==> Starting durian serve on port $PORT"
+"$DURIAN" serve --port "$PORT" --db "$EMAIL_DB" --contacts-db "$CONTACTS_DB" &
+SERVER_PID=$!
+
+echo "==> Waiting for server..."
+for i in $(seq 1 50); do
+    if curl -sf "http://localhost:$PORT/api/v1/version" > /dev/null 2>&1; then
+        echo "==> Server ready"
+        break
+    fi
+    if ! kill -0 "$SERVER_PID" 2>/dev/null; then
+        echo "ERROR: Server process died"; exit 1
+    fi
+    sleep 0.1
+done
+if ! curl -sf "http://localhost:$PORT/api/v1/version" > /dev/null 2>&1; then
+    echo "ERROR: Server not responding after 5s"; exit 1
+fi
+
+BASE="http://localhost:$PORT/api/v1"
+
+echo ""
+echo "=== API Contract Tests ==="
+echo ""
+
+# ─────────────────────────────────────────────
+# 1. Version
+# ─────────────────────────────────────────────
+RESP=$(curl -sf "$BASE/version")
+assert_jq "GET /version .version is string" "$RESP" '.version | type == "string"'
+assert_jq "GET /version .commit is string" "$RESP" '.commit | type == "string"'
+
+# ─────────────────────────────────────────────
+# 2. Search (DurianResponse + MailSearchResult)
+# ─────────────────────────────────────────────
+RESP=$(curl -sf "$BASE/search?query=tag:inbox&limit=10")
+assert_jq "GET /search .ok is true" "$RESP" '.ok == true'
+assert_jq "GET /search .results is array" "$RESP" '.results | type == "array"'
+assert_jq "GET /search .results[0].thread_id is string" "$RESP" '.results[0].thread_id | type == "string"'
+assert_jq "GET /search .results[0].subject is string" "$RESP" '.results[0].subject | type == "string"'
+assert_jq "GET /search .results[0].from is string" "$RESP" '.results[0].from | type == "string"'
+assert_jq "GET /search .results[0].date is string" "$RESP" '.results[0].date | type == "string"'
+assert_jq "GET /search .results[0].timestamp is number" "$RESP" '.results[0].timestamp | type == "number"'
+assert_jq "GET /search .results[0].tags is string" "$RESP" '.results[0].tags | type == "string"'
+
+# 3. Search count
+RESP=$(curl -sf "$BASE/search/count?query=tag:inbox")
+assert_jq "GET /search/count .count is number" "$RESP" '.count | type == "number"'
+assert_jq "GET /search/count .count > 0" "$RESP" '.count > 0'
+
+# Error: missing query
+assert_http_code "GET /search without query → 400" "$BASE/search" "GET" "400"
+
+# ─────────────────────────────────────────────
+# 4. Tags (DurianResponse + tags array)
+# ─────────────────────────────────────────────
+RESP=$(curl -sf "$BASE/tags")
+assert_jq "GET /tags .ok is true" "$RESP" '.ok == true'
+assert_jq "GET /tags .tags is array" "$RESP" '.tags | type == "array"'
+assert_jq "GET /tags .tags contains inbox" "$RESP" '.tags | index("inbox") != null'
+
+# ─────────────────────────────────────────────
+# 5. Show thread (DurianResponse + ThreadContent + ThreadMessage)
+# ─────────────────────────────────────────────
+THREAD_ID=$(curl -sf "$BASE/search?query=tag:inbox&limit=1" | jq -r '.results[0].thread_id')
+RESP=$(curl -sf "$BASE/threads/$THREAD_ID")
+assert_jq "GET /threads/{id} .ok is true" "$RESP" '.ok == true'
+assert_jq "GET /threads/{id} .thread.thread_id is string" "$RESP" '.thread.thread_id | type == "string"'
+assert_jq "GET /threads/{id} .thread.subject is string" "$RESP" '.thread.subject | type == "string"'
+assert_jq "GET /threads/{id} .thread.messages is array" "$RESP" '.thread.messages | type == "array"'
+assert_jq "GET /threads/{id} message.id is string" "$RESP" '.thread.messages[0].id | type == "string"'
+assert_jq "GET /threads/{id} message.from is string" "$RESP" '.thread.messages[0].from | type == "string"'
+assert_jq "GET /threads/{id} message.date is string" "$RESP" '.thread.messages[0].date | type == "string"'
+assert_jq "GET /threads/{id} message.timestamp is number" "$RESP" '.thread.messages[0].timestamp | type == "number"'
+assert_jq "GET /threads/{id} message.body is string" "$RESP" '.thread.messages[0].body | type == "string"'
+assert_jq "GET /threads/{id} message.tags is array" "$RESP" '.thread.messages[0].tags | type == "array"'
+
+# ─────────────────────────────────────────────
+# 6. Tag thread (POST, write + verify)
+# ─────────────────────────────────────────────
+RESP=$(curl -sf -X POST -H "Content-Type: application/json" \
+    -d '{"tags":"+starred"}' "$BASE/threads/$THREAD_ID/tags")
+assert_jq "POST /threads/{id}/tags .ok is true" "$RESP" '.ok == true'
+
+# Verify tag was applied
+RESP=$(curl -sf "$BASE/tags")
+assert_jq "POST /tags verified: starred exists" "$RESP" '.tags | index("starred") != null'
+
+# Error: invalid body
+assert_http_code "POST /threads/{id}/tags invalid body → 400" \
+    "$BASE/threads/$THREAD_ID/tags" "POST" "400" "not json"
+
+# ─────────────────────────────────────────────
+# 7. Message body (DurianResponse + MessageBody)
+# ─────────────────────────────────────────────
+RESP=$(curl -sf "$BASE/message/body?id=msg1@test")
+assert_jq "GET /message/body .ok is true" "$RESP" '.ok == true'
+assert_jq "GET /message/body .message_body.body is string" "$RESP" '.message_body.body | type == "string"'
+assert_jq "GET /message/body .message_body.html is string" "$RESP" '.message_body.html | type == "string"'
+assert_jq "GET /message/body body not empty" "$RESP" '.message_body.body | length > 0'
+
+# Error: missing id
+assert_http_code "GET /message/body without id → 400" "$BASE/message/body" "GET" "400"
+
+# ─────────────────────────────────────────────
+# 8. Contacts
+# ─────────────────────────────────────────────
+RESP=$(curl -sf "$BASE/contacts?limit=10")
+assert_jq "GET /contacts is array" "$RESP" 'type == "array"'
+assert_jq "GET /contacts[0].email is string" "$RESP" '.[0].email | type == "string"'
+assert_jq "GET /contacts[0].name is string" "$RESP" '.[0].name | type == "string"'
+assert_jq "GET /contacts[0].usage_count is number" "$RESP" '.[0].usage_count | type == "number"'
+assert_jq "GET /contacts[0].source is string" "$RESP" '.[0].source | type == "string"'
+
+# Search contacts
+RESP=$(curl -sf "$BASE/contacts/search?query=alice&limit=5")
+assert_jq "GET /contacts/search returns array" "$RESP" 'type == "array"'
+assert_jq "GET /contacts/search finds alice" "$RESP" '.[0].email | contains("alice")'
+
+# Increment usage
+RESP=$(curl -sf -X POST -H "Content-Type: application/json" \
+    -d '{"emails":["alice@example.com"]}' "$BASE/contacts/usage")
+assert_jq "POST /contacts/usage returns ok" "$RESP" '. == {}'
+
+# ─────────────────────────────────────────────
+# 9. Local drafts (CRUD roundtrip)
+# ─────────────────────────────────────────────
+# Save a draft
+RESP=$(curl -sf -X PUT -H "Content-Type: application/json" \
+    -d '{"draft_json":{"to":"test@example.com","subject":"Draft"}}' \
+    "$BASE/local-drafts/test-draft-1")
+assert_jq "PUT /local-drafts/{id} .ok is true" "$RESP" '.ok == true'
+
+# Get the draft back
+RESP=$(curl -sf "$BASE/local-drafts/test-draft-1")
+assert_jq "GET /local-drafts/{id} .id is string" "$RESP" '.id | type == "string"'
+assert_jq "GET /local-drafts/{id} .draft_json exists" "$RESP" '.draft_json != null'
+
+# List drafts
+RESP=$(curl -sf "$BASE/local-drafts")
+assert_jq "GET /local-drafts is array" "$RESP" 'type == "array"'
+assert_jq "GET /local-drafts has 1 entry" "$RESP" 'length == 1'
+assert_jq "GET /local-drafts[0].id is string" "$RESP" '.[0].id | type == "string"'
+assert_jq "GET /local-drafts[0].draft_json exists" "$RESP" '.[0].draft_json != null'
+
+# Delete the draft
+RESP=$(curl -sf -X DELETE "$BASE/local-drafts/test-draft-1")
+assert_jq "DELETE /local-drafts/{id} .ok is true" "$RESP" '.ok == true'
+
+# Verify deleted
+RESP=$(curl -sf "$BASE/local-drafts")
+assert_jq "GET /local-drafts empty after delete" "$RESP" 'length == 0'
+
+# ─────────────────────────────────────────────
+# 10. Outbox
+# ─────────────────────────────────────────────
+RESP=$(curl -sf "$BASE/outbox")
+assert_jq "GET /outbox is array" "$RESP" 'type == "array"'
+
+# ─────────────────────────────────────────────
+# Summary
+# ─────────────────────────────────────────────
+echo ""
+echo "=== Results ==="
+echo "$PASSED passed, $FAILURES failed"
+if [ "$FAILURES" -eq 0 ]; then
+    echo "All contract tests passed!"
+    exit 0
+else
+    exit 1
+fi

--- a/linux/qt_repo.bzl
+++ b/linux/qt_repo.bzl
@@ -44,7 +44,8 @@ def _qt_local_repository_impl(ctx):
             qt_root + "/share/qt/libexec/" + tool,
             # Fedora: QTDIR=/usr, tools in /usr/lib64/qt6/libexec/
             qt_root + "/lib64/qt6/libexec/" + tool,
-            # Ubuntu/Debian: QTDIR=/usr, tools in /usr/lib/x86_64-linux-gnu/qt6/libexec/
+            # Ubuntu/Debian: QTDIR=/usr, tools in /usr/lib/qt6/libexec/
+            qt_root + "/lib/qt6/libexec/" + tool,
             qt_root + "/lib/x86_64-linux-gnu/qt6/libexec/" + tool,
             qt_root + "/lib/aarch64-linux-gnu/qt6/libexec/" + tool,
         ]:
@@ -57,12 +58,16 @@ def _qt_local_repository_impl(ctx):
 
     # Find include dir — handles /usr/include/qt6 (Fedora) and /usr/include (standard)
     include_dir = None
-    for candidate in [qt_root + "/include/qt6", qt_root + "/include"]:
+    for candidate in [
+        qt_root + "/include/qt6",
+        qt_root + "/include/x86_64-linux-gnu/qt6",   # Ubuntu/Debian x86_64
+        qt_root + "/include/aarch64-linux-gnu/qt6",   # Ubuntu/Debian arm64
+        qt_root + "/include",
+    ]:
         if ctx.path(candidate).exists and ctx.path(candidate + "/QtCore").exists:
             include_dir = candidate
             break
     if not include_dir:
-        # Might just have /usr/include without QtCore subdir
         for candidate in [qt_root + "/include/qt6", qt_root + "/include"]:
             if ctx.path(candidate).exists:
                 include_dir = candidate

--- a/linux/qt_repo.bzl
+++ b/linux/qt_repo.bzl
@@ -12,6 +12,8 @@ def _qt_local_repository_impl(ctx):
     for candidate in [
         qt_root + "/lib",
         qt_root + "/lib64",
+        qt_root + "/lib/x86_64-linux-gnu",   # Ubuntu/Debian x86_64
+        qt_root + "/lib/aarch64-linux-gnu",   # Ubuntu/Debian arm64
         qt_root + "/../",  # QTDIR=/usr/lib64/qt6 → libs in /usr/lib64
     ]:
         p = ctx.path(candidate)
@@ -42,6 +44,9 @@ def _qt_local_repository_impl(ctx):
             qt_root + "/share/qt/libexec/" + tool,
             # Fedora: QTDIR=/usr, tools in /usr/lib64/qt6/libexec/
             qt_root + "/lib64/qt6/libexec/" + tool,
+            # Ubuntu/Debian: QTDIR=/usr, tools in /usr/lib/x86_64-linux-gnu/qt6/libexec/
+            qt_root + "/lib/x86_64-linux-gnu/qt6/libexec/" + tool,
+            qt_root + "/lib/aarch64-linux-gnu/qt6/libexec/" + tool,
         ]:
             if ctx.path(candidate).exists:
                 tool_path = candidate

--- a/macos/BUILD.bazel
+++ b/macos/BUILD.bazel
@@ -178,6 +178,51 @@ swift_test(
     deps = [":durian_core"],
 )
 
+swift_test(
+    name = "contacts_manager_test",
+    size = "small",
+    srcs = ["tests/ContactsManagerTests.swift"],
+    deps = [":durian_testlib"],
+)
+
+swift_test(
+    name = "ci_contacts_manager_test",
+    size = "small",
+    srcs = ["tests/ContactsManagerTests.swift"],
+    tags = ["ci"],
+    deps = [":durian_core"],
+)
+
+swift_test(
+    name = "email_sending_test",
+    size = "small",
+    srcs = ["tests/EmailSendingTests.swift"],
+    deps = [":durian_testlib"],
+)
+
+swift_test(
+    name = "ci_email_sending_test",
+    size = "small",
+    srcs = ["tests/EmailSendingTests.swift"],
+    tags = ["ci"],
+    deps = [":durian_core"],
+)
+
+swift_test(
+    name = "account_manager_test",
+    size = "small",
+    srcs = ["tests/AccountManagerTests.swift"],
+    deps = [":durian_testlib"],
+)
+
+swift_test(
+    name = "ci_account_manager_test",
+    size = "small",
+    srcs = ["tests/AccountManagerTests.swift"],
+    tags = ["ci"],
+    deps = [":durian_core"],
+)
+
 genrule(
     name = "StampedInfoPlist",
     srcs = ["Info.plist"],

--- a/macos/BUILD.bazel
+++ b/macos/BUILD.bazel
@@ -133,6 +133,51 @@ swift_test(
     deps = [":durian_core"],
 )
 
+swift_test(
+    name = "sync_manager_test",
+    size = "small",
+    srcs = ["tests/SyncManagerTests.swift"],
+    deps = [":durian_testlib"],
+)
+
+swift_test(
+    name = "search_manager_test",
+    size = "small",
+    srcs = ["tests/SearchManagerTests.swift"],
+    deps = [":durian_testlib"],
+)
+
+swift_test(
+    name = "outbox_manager_test",
+    size = "small",
+    srcs = ["tests/OutboxManagerTests.swift"],
+    deps = [":durian_testlib"],
+)
+
+swift_test(
+    name = "ci_sync_manager_test",
+    size = "small",
+    srcs = ["tests/SyncManagerTests.swift"],
+    tags = ["ci"],
+    deps = [":durian_core"],
+)
+
+swift_test(
+    name = "ci_search_manager_test",
+    size = "small",
+    srcs = ["tests/SearchManagerTests.swift"],
+    tags = ["ci"],
+    deps = [":durian_core"],
+)
+
+swift_test(
+    name = "ci_outbox_manager_test",
+    size = "small",
+    srcs = ["tests/OutboxManagerTests.swift"],
+    tags = ["ci"],
+    deps = [":durian_core"],
+)
+
 genrule(
     name = "StampedInfoPlist",
     srcs = ["Info.plist"],

--- a/macos/durian/Managers/OutboxManager.swift
+++ b/macos/durian/Managers/OutboxManager.swift
@@ -14,12 +14,21 @@ class OutboxManager: ObservableObject {
 
     @Published var pendingCount: Int = 0
 
-    private init() {}
+    private let backendProvider: () -> (any OutboxBackend)?
+
+    private init() {
+        self.backendProvider = { AccountManager.shared.emailBackend }
+    }
+
+    /// Test-only initializer for dependency injection
+    init(backend: @escaping () -> (any OutboxBackend)?) {
+        self.backendProvider = backend
+    }
 
     /// Refresh the pending count from the server.
     func refresh() {
         Task {
-            guard let backend = AccountManager.shared.emailBackend else { return }
+            guard let backend = backendProvider() else { return }
             let items = await backend.listOutbox()
             pendingCount = items.count
             Log.debug("OUTBOX", "Pending count: \(pendingCount)")

--- a/macos/durian/Managers/SearchManager.swift
+++ b/macos/durian/Managers/SearchManager.swift
@@ -11,25 +11,39 @@ import Foundation
 class SearchManager: ObservableObject {
     @Published var results: [MailMessage] = []
     @Published var isSearching: Bool = false
-    
+
     private var searchTask: Task<Void, Never>?
     private let debounceDelay: UInt64 = 300_000_000  // 300ms in nanoseconds
     private let resultLimit: Int = 25
-    
+
+    private let backendProvider: () -> (any SearchBackend)?
+    private let profileFilterProvider: (String) -> String
+
+    init() {
+        self.backendProvider = { AccountManager.shared.emailBackend }
+        self.profileFilterProvider = { ProfileManager.shared.applyProfileFilter(to: $0) }
+    }
+
+    /// Test-only initializer for dependency injection
+    init(backend: @escaping () -> (any SearchBackend)?, profileFilter: @escaping (String) -> String) {
+        self.backendProvider = backend
+        self.profileFilterProvider = profileFilter
+    }
+
     /// Search emails with debounce
     func search(query: String) {
         // Cancel previous search
         searchTask?.cancel()
-        
+
         // Clear results if query is empty
         guard !query.trimmingCharacters(in: .whitespaces).isEmpty else {
             results = []
             isSearching = false
             return
         }
-        
+
         isSearching = true
-        
+
         searchTask = Task {
             // Debounce
             do {
@@ -37,26 +51,26 @@ class SearchManager: ObservableObject {
             } catch {
                 return  // Task was cancelled
             }
-            
+
             guard !Task.isCancelled else { return }
-            
+
             // Perform search via EmailBackend
-            guard let backend = AccountManager.shared.emailBackend else {
+            guard let backend = backendProvider() else {
                 results = []
                 isSearching = false
                 return
             }
-            
-            let filteredQuery = ProfileManager.shared.applyProfileFilter(to: query)
+
+            let filteredQuery = profileFilterProvider(query)
             let searchResults = await backend.searchAll(query: filteredQuery, limit: resultLimit)
-            
+
             guard !Task.isCancelled else { return }
-            
+
             results = searchResults
             isSearching = false
         }
     }
-    
+
     /// Clear search results
     func clear() {
         searchTask?.cancel()

--- a/macos/durian/Network/EmailBackend.swift
+++ b/macos/durian/Network/EmailBackend.swift
@@ -114,7 +114,7 @@ enum TagError: Error, LocalizedError {
 // MARK: - Email Backend
 
 @MainActor
-class EmailBackend: ObservableObject {
+class EmailBackend: ObservableObject, SearchBackend, OutboxBackend {
     private var durianProcess: Process?
     private let decoder = JSONDecoder()
     private let baseURL = URL(string: "http://localhost:9723/api/v1")!

--- a/macos/durian/Network/MailBackendProtocol.swift
+++ b/macos/durian/Network/MailBackendProtocol.swift
@@ -10,6 +10,18 @@ import Combine
 
 // MARK: - Mail Backend Protocol
 
+/// Subset protocol for search operations (used by SearchManager DI).
+@MainActor
+protocol SearchBackend {
+    func searchAll(query: String, limit: Int) async -> [MailMessage]
+}
+
+/// Subset protocol for outbox operations (used by OutboxManager DI).
+@MainActor
+protocol OutboxBackend {
+    func listOutbox() async -> [OutboxEntry]
+}
+
 /// Protocol defining the interface for mail backends.
 /// EmailBackend conforms to this.
 @MainActor

--- a/macos/tests/AccountManagerTests.swift
+++ b/macos/tests/AccountManagerTests.swift
@@ -1,0 +1,64 @@
+import XCTest
+@testable import durian_lib
+
+@MainActor
+final class AccountManagerTests: XCTestCase {
+
+    // MARK: - removeLocally
+
+    func testRemoveLocallyRemovesMessages() {
+        let manager = AccountManager.shared
+
+        // Seed some messages
+        let msg1 = MailMessage(threadId: "t1", subject: "First", from: "a@b.com",
+                               date: "2026-04-05", timestamp: 1743868800, tags: "inbox")
+        let msg2 = MailMessage(threadId: "t2", subject: "Second", from: "c@d.com",
+                               date: "2026-04-05", timestamp: 1743868801, tags: "inbox")
+        let msg3 = MailMessage(threadId: "t3", subject: "Third", from: "e@f.com",
+                               date: "2026-04-05", timestamp: 1743868802, tags: "inbox")
+
+        manager.mailMessages = [msg1, msg2, msg3]
+        let genBefore = manager.emailListGeneration
+
+        manager.removeLocally(ids: Set(["t1", "t3"]))
+
+        XCTAssertEqual(manager.mailMessages.count, 1)
+        XCTAssertEqual(manager.mailMessages.first?.id, "t2")
+        XCTAssertGreaterThan(manager.emailListGeneration, genBefore)
+    }
+
+    func testRemoveLocallyEmptySet() {
+        let manager = AccountManager.shared
+
+        let msg = MailMessage(threadId: "t1", subject: "Test", from: "a@b.com",
+                              date: "2026-04-05", timestamp: 1743868800, tags: "inbox")
+        manager.mailMessages = [msg]
+
+        manager.removeLocally(ids: Set())
+
+        XCTAssertEqual(manager.mailMessages.count, 1)
+    }
+
+    func testRemoveLocallyNonexistentIds() {
+        let manager = AccountManager.shared
+
+        let msg = MailMessage(threadId: "t1", subject: "Test", from: "a@b.com",
+                              date: "2026-04-05", timestamp: 1743868800, tags: "inbox")
+        manager.mailMessages = [msg]
+
+        manager.removeLocally(ids: Set(["nonexistent"]))
+
+        XCTAssertEqual(manager.mailMessages.count, 1)
+    }
+
+    // MARK: - mailFolders
+
+    func testMailFoldersReturnsDefaultFolders() {
+        let manager = AccountManager.shared
+        let folders = manager.mailFolders
+
+        // Should have at least inbox
+        let names = folders.map { $0.name }
+        XCTAssertTrue(names.contains("inbox"))
+    }
+}

--- a/macos/tests/ContactsManagerTests.swift
+++ b/macos/tests/ContactsManagerTests.swift
@@ -1,0 +1,101 @@
+import XCTest
+@testable import durian_lib
+
+@MainActor
+final class ContactsManagerTests: XCTestCase {
+
+    // MARK: - Contact Model
+
+    func testDisplayStringWithName() {
+        let c = Contact(id: "1", email: "alice@example.com", name: "Alice Smith",
+                        usageCount: 5, source: "imported", createdAt: Date())
+        XCTAssertEqual(c.displayString, "Alice Smith <alice@example.com>")
+    }
+
+    func testDisplayStringWithoutName() {
+        let c = Contact(id: "1", email: "alice@example.com", name: nil,
+                        usageCount: 0, source: "imported", createdAt: Date())
+        XCTAssertEqual(c.displayString, "alice@example.com")
+    }
+
+    func testDisplayStringWithEmptyName() {
+        let c = Contact(id: "1", email: "alice@example.com", name: "",
+                        usageCount: 0, source: "imported", createdAt: Date())
+        XCTAssertEqual(c.displayString, "alice@example.com")
+    }
+
+    func testDisplayNameWithName() {
+        let c = Contact(id: "1", email: "alice@example.com", name: "Alice",
+                        usageCount: 0, source: "imported", createdAt: Date())
+        XCTAssertEqual(c.displayName, "Alice")
+    }
+
+    func testDisplayNameFallsBackToEmail() {
+        let c = Contact(id: "1", email: "alice@example.com", name: nil,
+                        usageCount: 0, source: "imported", createdAt: Date())
+        XCTAssertEqual(c.displayName, "alice@example.com")
+    }
+
+    // MARK: - Contact from API Response
+
+    func testContactFromResponse() {
+        let response = ContactResponse(
+            id: "abc", email: "bob@example.com", name: "Bob",
+            last_used: "2026-04-01T12:00:00Z",
+            usage_count: 3, source: "sent",
+            created_at: "2026-01-01T00:00:00Z"
+        )
+        let contact = Contact(from: response)
+
+        XCTAssertEqual(contact.id, "abc")
+        XCTAssertEqual(contact.email, "bob@example.com")
+        XCTAssertEqual(contact.name, "Bob")
+        XCTAssertEqual(contact.usageCount, 3)
+        XCTAssertEqual(contact.source, "sent")
+        XCTAssertNotNil(contact.lastUsed)
+        XCTAssertNotNil(contact.createdAt)
+    }
+
+    func testContactFromResponseNilLastUsed() {
+        let response = ContactResponse(
+            id: "abc", email: "bob@example.com", name: nil,
+            last_used: nil,
+            usage_count: 0, source: "imported",
+            created_at: "2026-01-01T00:00:00Z"
+        )
+        let contact = Contact(from: response)
+
+        XCTAssertNil(contact.lastUsed)
+        XCTAssertNotNil(contact.createdAt)
+    }
+
+    func testContactFromResponseSQLiteDate() {
+        let response = ContactResponse(
+            id: "abc", email: "bob@example.com", name: "Bob",
+            last_used: "2026-04-01 12:00:00",
+            usage_count: 1, source: "imported",
+            created_at: "2026-01-01 00:00:00"
+        )
+        let contact = Contact(from: response)
+        XCTAssertNotNil(contact.lastUsed, "Should parse SQLite date format")
+    }
+
+    func testContactFromResponseISO8601WithFractions() {
+        let response = ContactResponse(
+            id: "abc", email: "bob@example.com", name: "Bob",
+            last_used: "2026-04-01T12:00:00.123Z",
+            usage_count: 0, source: "imported",
+            created_at: "2026-01-01T00:00:00.000Z"
+        )
+        let contact = Contact(from: response)
+        XCTAssertNotNil(contact.lastUsed, "Should parse ISO8601 with fractional seconds")
+    }
+
+    // MARK: - Contact Hashable/Identifiable
+
+    func testContactEquality() {
+        let c1 = Contact(id: "1", email: "a@b.com", name: "A", usageCount: 0, source: "imported", createdAt: Date())
+        let c2 = Contact(id: "1", email: "a@b.com", name: "A", usageCount: 0, source: "imported", createdAt: c1.createdAt)
+        XCTAssertEqual(c1, c2)
+    }
+}

--- a/macos/tests/EmailSendingTests.swift
+++ b/macos/tests/EmailSendingTests.swift
@@ -1,0 +1,80 @@
+import XCTest
+@testable import durian_lib
+
+@MainActor
+final class EmailSendingTests: XCTestCase {
+
+    // MARK: - EmailDraft
+
+    func testHasRecipientsWithTo() {
+        var draft = EmailDraft(from: "me@example.com")
+        draft.to = ["alice@example.com"]
+        XCTAssertTrue(draft.hasRecipients)
+    }
+
+    func testHasRecipientsWithCCOnly() {
+        var draft = EmailDraft(from: "me@example.com")
+        draft.cc = ["alice@example.com"]
+        XCTAssertTrue(draft.hasRecipients)
+    }
+
+    func testHasRecipientsWithBCCOnly() {
+        var draft = EmailDraft(from: "me@example.com")
+        draft.bcc = ["alice@example.com"]
+        XCTAssertTrue(draft.hasRecipients)
+    }
+
+    func testHasRecipientsEmpty() {
+        let draft = EmailDraft(from: "me@example.com")
+        XCTAssertFalse(draft.hasRecipients)
+    }
+
+    func testIsValidRequiresRecipientsAndSubject() {
+        var draft = EmailDraft(from: "me@example.com")
+        XCTAssertFalse(draft.isValid)
+
+        draft.to = ["alice@example.com"]
+        XCTAssertFalse(draft.isValid) // still no subject
+
+        draft.subject = "Hello"
+        XCTAssertTrue(draft.isValid)
+    }
+
+    // MARK: - EmailHelper
+
+    func testIsValidEmail() {
+        XCTAssertTrue(EmailHelper.isValidEmail("user@example.com"))
+        XCTAssertTrue(EmailHelper.isValidEmail("user@sub.domain.co.uk"))
+        XCTAssertTrue(EmailHelper.isValidEmail("Alice <alice@example.com>"))
+        XCTAssertFalse(EmailHelper.isValidEmail("not-an-email"))
+        XCTAssertFalse(EmailHelper.isValidEmail("user@"))
+        XCTAssertFalse(EmailHelper.isValidEmail("user@.com"))
+        XCTAssertFalse(EmailHelper.isValidEmail(""))
+    }
+
+    func testCleanEmail() {
+        XCTAssertEqual(EmailHelper.cleanEmail("alice@example.com"), "alice@example.com")
+        XCTAssertEqual(EmailHelper.cleanEmail("Alice Smith <alice@example.com>"), "alice@example.com")
+        XCTAssertEqual(EmailHelper.cleanEmail("  alice@example.com  "), "alice@example.com")
+    }
+
+    func testValidateRecipientsReturnsInvalid() {
+        let invalid = EmailHelper.validateRecipients(["good@example.com", "bad", "also@good.com"])
+        XCTAssertEqual(invalid, ["bad"])
+    }
+
+    func testValidateRecipientsAllValid() {
+        let invalid = EmailHelper.validateRecipients(["a@b.com", "c@d.com"])
+        XCTAssertTrue(invalid.isEmpty)
+    }
+
+    // MARK: - EmailSendingError
+
+    func testErrorDescriptions() {
+        XCTAssertNotNil(EmailSendingError.noSMTPConfiguration.errorDescription)
+        XCTAssertNotNil(EmailSendingError.invalidRecipients.errorDescription)
+        XCTAssertNotNil(EmailSendingError.sendFailed("timeout").errorDescription)
+        XCTAssertNotNil(EmailSendingError.invalidEmailFormat(["bad"]).errorDescription)
+        XCTAssertTrue(EmailSendingError.invalidEmailFormat(["bad"]).errorDescription!.contains("bad"))
+    }
+}

--- a/macos/tests/IntegrationTests.swift
+++ b/macos/tests/IntegrationTests.swift
@@ -1,0 +1,157 @@
+import XCTest
+@testable import durian_lib
+
+/// Integration tests that hit a real durian server.
+/// The server URL is passed via DURIAN_TEST_URL environment variable.
+/// These tests validate that the Go backend produces JSON that Swift can decode.
+@MainActor
+final class IntegrationTests: XCTestCase {
+
+    private var baseURL: URL!
+
+    override func setUp() async throws {
+        guard let urlString = ProcessInfo.processInfo.environment["DURIAN_TEST_URL"] else {
+            throw XCTSkip("DURIAN_TEST_URL not set — skipping integration tests")
+        }
+        guard let url = URL(string: urlString) else {
+            throw XCTSkip("DURIAN_TEST_URL is not a valid URL: \(urlString)")
+        }
+        baseURL = url
+    }
+
+    // MARK: - Helpers
+
+    private func get(_ path: String) async throws -> (Data, HTTPURLResponse) {
+        let url = baseURL.appendingPathComponent(path)
+        let (data, response) = try await URLSession.shared.data(from: url)
+        let httpResp = try XCTUnwrap(response as? HTTPURLResponse)
+        return (data, httpResp)
+    }
+
+    // MARK: - Search
+
+    func testSearchReturnsDecodableResults() async throws {
+        let url = baseURL.appendingPathComponent("/search")
+        var components = URLComponents(url: url, resolvingAgainstBaseURL: false)!
+        components.queryItems = [
+            URLQueryItem(name: "query", value: "tag:inbox"),
+            URLQueryItem(name: "limit", value: "10"),
+        ]
+
+        let (data, httpResp) = try await URLSession.shared.data(from: components.url!)
+        XCTAssertEqual(httpResp.statusCode, 200)
+
+        // This is THE contract test: can Swift decode what Go produces?
+        let response = try JSONDecoder().decode(DurianResponse.self, from: data)
+        XCTAssertTrue(response.ok)
+        XCTAssertNotNil(response.results)
+        XCTAssertGreaterThan(response.results?.count ?? 0, 0)
+
+        // Verify search result fields
+        if let first = response.results?.first {
+            XCTAssertFalse(first.thread_id.isEmpty)
+            XCTAssertFalse(first.subject.isEmpty)
+            XCTAssertFalse(first.from.isEmpty)
+            XCTAssertFalse(first.tags.isEmpty)
+        }
+    }
+
+    func testSearchCountReturnsInt() async throws {
+        let url = baseURL.appendingPathComponent("/search/count")
+        var components = URLComponents(url: url, resolvingAgainstBaseURL: false)!
+        components.queryItems = [URLQueryItem(name: "query", value: "tag:inbox")]
+
+        let (data, httpResp) = try await URLSession.shared.data(from: components.url!)
+        XCTAssertEqual(httpResp.statusCode, 200)
+
+        struct CountResponse: Decodable { let count: Int }
+        let response = try JSONDecoder().decode(CountResponse.self, from: data)
+        XCTAssertGreaterThan(response.count, 0)
+    }
+
+    // MARK: - Tags
+
+    func testListTagsDecodable() async throws {
+        let (data, httpResp) = try await get("/tags")
+        XCTAssertEqual(httpResp.statusCode, 200)
+
+        let response = try JSONDecoder().decode(DurianResponse.self, from: data)
+        XCTAssertTrue(response.ok)
+        XCTAssertNotNil(response.tags)
+        XCTAssertTrue(response.tags?.contains("inbox") ?? false)
+    }
+
+    // MARK: - Threads
+
+    func testShowThreadDecodable() async throws {
+        // First search to get a thread_id
+        let searchURL = baseURL.appendingPathComponent("/search")
+        var components = URLComponents(url: searchURL, resolvingAgainstBaseURL: false)!
+        components.queryItems = [
+            URLQueryItem(name: "query", value: "tag:inbox"),
+            URLQueryItem(name: "limit", value: "1"),
+        ]
+        let (searchData, _) = try await URLSession.shared.data(from: components.url!)
+        let searchResp = try JSONDecoder().decode(DurianResponse.self, from: searchData)
+        let threadId = try XCTUnwrap(searchResp.results?.first?.thread_id)
+
+        // Now fetch the thread
+        let (data, httpResp) = try await get("/threads/\(threadId)")
+        XCTAssertEqual(httpResp.statusCode, 200)
+
+        let response = try JSONDecoder().decode(DurianResponse.self, from: data)
+        XCTAssertTrue(response.ok)
+
+        let thread = try XCTUnwrap(response.thread)
+        XCTAssertEqual(thread.thread_id, threadId)
+        XCTAssertFalse(thread.subject.isEmpty)
+        XCTAssertGreaterThan(thread.messages.count, 0)
+
+        // Verify ThreadMessage fields
+        let msg = thread.messages[0]
+        XCTAssertFalse(msg.id.isEmpty)
+        XCTAssertFalse(msg.from.isEmpty)
+        XCTAssertFalse(msg.body.isEmpty)
+    }
+
+    // MARK: - Outbox
+
+    func testListOutboxDecodable() async throws {
+        let (data, httpResp) = try await get("/outbox")
+        XCTAssertEqual(httpResp.statusCode, 200)
+
+        // Outbox returns an array directly (not wrapped in DurianResponse)
+        let entries = try JSONDecoder().decode([OutboxEntry].self, from: data)
+        // Empty is fine — we just need to verify the type decodes
+        XCTAssertNotNil(entries)
+    }
+
+    // MARK: - Local Drafts
+
+    func testListLocalDraftsDecodable() async throws {
+        let (data, httpResp) = try await get("/local-drafts")
+        XCTAssertEqual(httpResp.statusCode, 200)
+
+        struct LocalDraft: Decodable {
+            let id: String
+            let draft_json: String
+            let updated_at: Int64
+        }
+        let drafts = try JSONDecoder().decode([LocalDraft].self, from: data)
+        XCTAssertNotNil(drafts)
+    }
+
+    // MARK: - Version
+
+    func testVersionEndpoint() async throws {
+        let (data, httpResp) = try await get("/version")
+        XCTAssertEqual(httpResp.statusCode, 200)
+
+        struct VersionResponse: Decodable {
+            let version: String
+            let commit: String
+        }
+        let response = try JSONDecoder().decode(VersionResponse.self, from: data)
+        XCTAssertFalse(response.version.isEmpty)
+    }
+}

--- a/macos/tests/OutboxManagerTests.swift
+++ b/macos/tests/OutboxManagerTests.swift
@@ -1,0 +1,55 @@
+import XCTest
+@testable import durian_lib
+
+@MainActor
+private class MockOutboxBackend: OutboxBackend {
+    var outboxItems: [OutboxEntry] = []
+
+    func listOutbox() async -> [OutboxEntry] {
+        return outboxItems
+    }
+}
+
+@MainActor
+final class OutboxManagerTests: XCTestCase {
+
+    private func makeEntry(id: Int64, subject: String) -> OutboxEntry {
+        OutboxEntry(id: id, subject: subject, to: "test@example.com",
+                    attempts: 0, last_error: nil, created_at: 1743868800)
+    }
+
+    func testRefreshUpdatesPendingCount() async {
+        let mock = MockOutboxBackend()
+        mock.outboxItems = [
+            makeEntry(id: 1, subject: "Email 1"),
+            makeEntry(id: 2, subject: "Email 2"),
+            makeEntry(id: 3, subject: "Email 3"),
+        ]
+        let manager = OutboxManager(backend: { mock })
+
+        manager.refresh()
+        try? await Task.sleep(nanoseconds: 200_000_000)
+
+        XCTAssertEqual(manager.pendingCount, 3)
+    }
+
+    func testRefreshEmptyOutbox() async {
+        let mock = MockOutboxBackend()
+        mock.outboxItems = []
+        let manager = OutboxManager(backend: { mock })
+
+        manager.refresh()
+        try? await Task.sleep(nanoseconds: 200_000_000)
+
+        XCTAssertEqual(manager.pendingCount, 0)
+    }
+
+    func testRefreshNoBackend() async {
+        let manager = OutboxManager(backend: { nil })
+
+        manager.refresh()
+        try? await Task.sleep(nanoseconds: 200_000_000)
+
+        XCTAssertEqual(manager.pendingCount, 0)
+    }
+}

--- a/macos/tests/SearchManagerTests.swift
+++ b/macos/tests/SearchManagerTests.swift
@@ -1,0 +1,103 @@
+import XCTest
+@testable import durian_lib
+
+@MainActor
+private class MockSearchBackend: SearchBackend {
+    var searchResults: [MailMessage] = []
+    var lastQuery: String?
+    var lastLimit: Int?
+
+    func searchAll(query: String, limit: Int) async -> [MailMessage] {
+        lastQuery = query
+        lastLimit = limit
+        return searchResults
+    }
+}
+
+@MainActor
+final class SearchManagerTests: XCTestCase {
+
+    private func makeMessage(id: String, subject: String) -> MailMessage {
+        MailMessage(threadId: id, subject: subject, from: "test@example.com",
+                    date: "2026-04-05", timestamp: 1743868800, tags: "inbox")
+    }
+
+    private func makeManager(results: [MailMessage] = []) -> (SearchManager, MockSearchBackend) {
+        let mock = MockSearchBackend()
+        mock.searchResults = results
+        let manager = SearchManager(
+            backend: { mock },
+            profileFilter: { $0 }  // identity — no filtering
+        )
+        return (manager, mock)
+    }
+
+    // MARK: - Tests
+
+    func testSearchEmptyQueryClearsResults() {
+        let (manager, _) = makeManager()
+        manager.search(query: "")
+        XCTAssertTrue(manager.results.isEmpty)
+        XCTAssertFalse(manager.isSearching)
+    }
+
+    func testSearchWhitespaceClearsResults() {
+        let (manager, _) = makeManager()
+        manager.search(query: "   ")
+        XCTAssertTrue(manager.results.isEmpty)
+        XCTAssertFalse(manager.isSearching)
+    }
+
+    func testSearchSetsIsSearching() {
+        let (manager, _) = makeManager()
+        manager.search(query: "test")
+        // isSearching should be true immediately (before debounce completes)
+        XCTAssertTrue(manager.isSearching)
+    }
+
+    func testSearchReturnsResults() async {
+        let msg = makeMessage(id: "t1", subject: "Meeting Notes")
+        let (manager, mock) = makeManager(results: [msg])
+
+        manager.search(query: "meeting")
+        try? await Task.sleep(nanoseconds: 500_000_000)
+
+        XCTAssertEqual(manager.results.count, 1)
+        XCTAssertEqual(manager.results.first?.subject, "Meeting Notes")
+        XCTAssertEqual(mock.lastQuery, "meeting")
+        XCTAssertFalse(manager.isSearching)
+    }
+
+    func testSearchCancellation() async {
+        let msg1 = makeMessage(id: "t1", subject: "First")
+        let msg2 = makeMessage(id: "t2", subject: "Second")
+        let (manager, mock) = makeManager(results: [msg2])
+
+        // Fire two searches rapidly — only the second should win
+        mock.searchResults = [msg1]
+        manager.search(query: "first")
+        mock.searchResults = [msg2]
+        manager.search(query: "second")
+
+        // Wait for debounce + execution
+        try? await Task.sleep(nanoseconds: 500_000_000)
+
+        XCTAssertEqual(mock.lastQuery, "second")
+        XCTAssertEqual(manager.results.count, 1)
+        XCTAssertEqual(manager.results.first?.subject, "Second")
+    }
+
+    func testClearResetsState() async {
+        let msg = makeMessage(id: "t1", subject: "Test")
+        let (manager, _) = makeManager(results: [msg])
+
+        manager.search(query: "test")
+        try? await Task.sleep(nanoseconds: 500_000_000)
+        XCTAssertFalse(manager.results.isEmpty)
+
+        manager.clear()
+        try? await Task.sleep(nanoseconds: 200_000_000)
+        XCTAssertTrue(manager.results.isEmpty)
+        XCTAssertFalse(manager.isSearching)
+    }
+}

--- a/macos/tests/SyncManagerTests.swift
+++ b/macos/tests/SyncManagerTests.swift
@@ -1,0 +1,54 @@
+import XCTest
+import SwiftUI
+@testable import durian_lib
+
+@MainActor
+final class SyncManagerTests: XCTestCase {
+
+    // MARK: - SyncState.color
+
+    func testSyncStateIdleColor() {
+        XCTAssertEqual(SyncState.idle.color, Color.secondary)
+    }
+
+    func testSyncStateSyncingColor() {
+        XCTAssertEqual(SyncState.syncing.color, Color.blue)
+    }
+
+    func testSyncStateSuccessColor() {
+        XCTAssertEqual(SyncState.success.color, Color.green)
+    }
+
+    func testSyncStateFailedColor() {
+        XCTAssertEqual(SyncState.failed("err").color, Color.red)
+    }
+
+    // MARK: - SyncState.shouldNotify
+
+    func testSyncStateShouldNotifyOnlyForFailed() {
+        XCTAssertFalse(SyncState.idle.shouldNotify)
+        XCTAssertFalse(SyncState.syncing.shouldNotify)
+        XCTAssertFalse(SyncState.success.shouldNotify)
+        XCTAssertTrue(SyncState.failed("error").shouldNotify)
+    }
+
+    // MARK: - SyncState.statusText
+
+    func testSyncStateStatusText() {
+        XCTAssertEqual(SyncState.idle.statusText, "")
+        XCTAssertEqual(SyncState.syncing.statusText, "Syncing...")
+        XCTAssertEqual(SyncState.success.statusText, "Synced")
+        XCTAssertEqual(SyncState.failed("timeout").statusText, "Failed: timeout")
+    }
+
+    // MARK: - SyncState Equatable
+
+    func testSyncStateEquality() {
+        XCTAssertEqual(SyncState.idle, SyncState.idle)
+        XCTAssertEqual(SyncState.syncing, SyncState.syncing)
+        XCTAssertEqual(SyncState.success, SyncState.success)
+        XCTAssertEqual(SyncState.failed("a"), SyncState.failed("a"))
+        XCTAssertNotEqual(SyncState.failed("a"), SyncState.failed("b"))
+        XCTAssertNotEqual(SyncState.idle, SyncState.syncing)
+    }
+}


### PR DESCRIPTION
## Summary

- Go: 16/16 packages now have tests (was 10/16)
- Swift: 10 CI test targets (was 4), 7/12 managers tested
- Integration: 52 API contract assertions against real server
- `serve.go`: new `--port`, `--db`, `--contacts-db` flags

## What's covered

| Area | What |
|------|------|
| Go auth + keychain | OAuth2, password, exec mocking |
| Go mail MIME | detectMagic, HTML fallback, inline attachments |
| Go contacts | CRUD, search, upsert, batch, email validation |
| Go draft | extractMessageID, helper functions |
| Go tagsync | Push/Pull with httptest mock server |
| Swift managers | SyncState, Search, Outbox, Contacts, EmailSending, Account |
| Integration | Real server, 13/17 endpoints, curl+jq contract validation |

## Not covered (by design)

- SwiftUI Views (blocked by Xcode 26 + rules_swift)
- `/events` SSE + `/attachments` IMAP (need live infrastructure)
- 5 thin Swift manager wrappers (AvatarManager, NetworkMonitor, etc.)

## Test plan

- [x] `bazel test //cli/...`
- [x] `bazel test //macos:ci_*` (10 targets)
- [x] `bazel test //integration:integration_test` (52/52 assertions)