### PR TITLE
feat(go-config): add durian validate command

### DIFF
--- a/cli/cmd/durian/BUILD.bazel
+++ b/cli/cmd/durian/BUILD.bazel
@@ -17,6 +17,7 @@ go_library(
         "sync.go",
         "tag.go",
         "tagsync.go",
+        "validate.go",
     ],
     importpath = "github.com/durian-dev/durian/cli/cmd/durian",
     visibility = ["//visibility:private"],

--- a/cli/cmd/durian/validate.go
+++ b/cli/cmd/durian/validate.go
@@ -1,0 +1,182 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/durian-dev/durian/cli/internal/config"
+	"github.com/durian-dev/durian/cli/internal/imap"
+)
+
+var validateCmd = &cobra.Command{
+	Use:   "validate [config|rules|profiles|keymaps]",
+	Short: "Validate configuration files",
+	Long: `Validate Durian configuration files for errors.
+Without arguments, validates all files. Pass a name to validate just one.`,
+	Example: `  durian validate
+  durian validate config
+  durian validate rules
+  durian validate profiles`,
+	Args: cobra.MaximumNArgs(1),
+	RunE: runValidate,
+}
+
+func init() {
+	rootCmd.AddCommand(validateCmd)
+}
+
+func runValidate(cmd *cobra.Command, args []string) error {
+	target := ""
+	if len(args) > 0 {
+		target = strings.ToLower(args[0])
+		switch target {
+		case "config", "rules", "profiles", "keymaps":
+		default:
+			return fmt.Errorf("unknown target %q (valid: config, rules, profiles, keymaps)", target)
+		}
+	}
+
+	configDir := filepath.Dir(config.DefaultPath())
+	hasErrors := false
+
+	// Always load config first (needed as reference for other validations)
+	var loadedCfg *config.Config
+	configPath := config.DefaultPath()
+	if cfgFile != "" {
+		configPath = cfgFile
+	}
+
+	if config.Exists(configPath) {
+		var err error
+		loadedCfg, err = config.Load(configPath)
+		if err != nil && (target == "" || target == "config") {
+			printError("config.toml", fmt.Sprintf("failed to parse: %v", err))
+			hasErrors = true
+			loadedCfg = config.Default()
+		}
+	} else {
+		loadedCfg = config.Default()
+		if target == "" || target == "config" {
+			printSkipped("config.toml", "not found")
+		}
+	}
+
+	// Validate config.toml
+	if target == "" || target == "config" {
+		if config.Exists(configPath) {
+			errs := config.ValidateConfig(loadedCfg)
+			if printResults("config.toml", errs, configSummary(loadedCfg)) {
+				hasErrors = true
+			}
+		}
+	}
+
+	// Validate rules.toml
+	if target == "" || target == "rules" {
+		rulesPath := filepath.Join(configDir, "rules.toml")
+		rules, err := config.LoadRules("")
+		if err != nil {
+			printError("rules.toml", fmt.Sprintf("failed to parse: %v", err))
+			hasErrors = true
+		} else if rules == nil {
+			printSkipped("rules.toml", "not found at "+rulesPath)
+		} else {
+			errs := config.ValidateRules(rules, loadedCfg, imap.ValidateRuleQuery)
+			if printResults("rules.toml", errs, fmt.Sprintf("%d rules", len(rules))) {
+				hasErrors = true
+			}
+		}
+	}
+
+	// Validate profiles.toml
+	if target == "" || target == "profiles" {
+		profiles, err := config.LoadProfiles("")
+		if err != nil {
+			printError("profiles.toml", fmt.Sprintf("failed to parse: %v", err))
+			hasErrors = true
+		} else if profiles == nil {
+			printSkipped("profiles.toml", "not found (using defaults)")
+		} else {
+			errs := config.ValidateProfiles(profiles, loadedCfg)
+			if printResults("profiles.toml", errs, fmt.Sprintf("%d profiles", len(profiles))) {
+				hasErrors = true
+			}
+		}
+	}
+
+	// Validate keymaps.toml
+	if target == "" || target == "keymaps" {
+		keymaps, err := config.LoadKeymaps("")
+		if err != nil {
+			printError("keymaps.toml", fmt.Sprintf("failed to parse: %v", err))
+			hasErrors = true
+		} else if keymaps == nil {
+			printSkipped("keymaps.toml", "not found (using defaults)")
+		} else {
+			errs := config.ValidateKeymaps(keymaps)
+			if printResults("keymaps.toml", errs, fmt.Sprintf("%d bindings", len(keymaps.Keymaps))) {
+				hasErrors = true
+			}
+		}
+	}
+
+	if hasErrors {
+		os.Exit(1)
+	}
+	return nil
+}
+
+func configSummary(cfg *config.Config) string {
+	if len(cfg.Accounts) == 0 {
+		return "no accounts"
+	}
+	names := make([]string, 0, len(cfg.Accounts))
+	for _, a := range cfg.Accounts {
+		names = append(names, a.Name)
+	}
+	return fmt.Sprintf("%d accounts (%s)", len(cfg.Accounts), strings.Join(names, ", "))
+}
+
+// printResults prints validation results and returns true if errors were found.
+func printResults(file string, errs []config.ValidationError, summary string) bool {
+	errors := 0
+	warnings := 0
+	for _, e := range errs {
+		if e.Severity == "error" {
+			errors++
+		} else {
+			warnings++
+		}
+	}
+
+	if errors == 0 && warnings == 0 {
+		fmt.Printf("  ✓ %s — %s\n", file, summary)
+		return false
+	}
+
+	if errors > 0 {
+		fmt.Printf("  ✗ %s — %s\n", file, summary)
+	} else {
+		fmt.Printf("  ~ %s — %s\n", file, summary)
+	}
+	for _, e := range errs {
+		if e.Severity == "error" {
+			fmt.Printf("    ✗ %s\n", e)
+		} else {
+			fmt.Printf("    ~ %s\n", e)
+		}
+	}
+	return errors > 0
+}
+
+func printError(file, msg string) {
+	fmt.Printf("  ✗ %s — %s\n", file, msg)
+}
+
+func printSkipped(file, msg string) {
+	fmt.Printf("  - %s — %s\n", file, msg)
+}

--- a/cli/internal/config/BUILD.bazel
+++ b/cli/internal/config/BUILD.bazel
@@ -5,8 +5,11 @@ go_library(
     srcs = [
         "config.go",
         "helpers.go",
+        "keymaps.go",
+        "profiles.go",
         "rules.go",
         "types.go",
+        "validate.go",
     ],
     importpath = "github.com/durian-dev/durian/cli/internal/config",
     visibility = ["//cli:__subpackages__"],

--- a/cli/internal/config/keymaps.go
+++ b/cli/internal/config/keymaps.go
@@ -1,0 +1,54 @@
+package config
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/BurntSushi/toml"
+)
+
+// KeymapConfig represents the full keymaps.toml file.
+type KeymapConfig struct {
+	Keymaps        []KeymapEntry        `toml:"keymaps"`
+	GlobalSettings KeymapGlobalSettings `toml:"global_settings"`
+}
+
+// KeymapEntry represents a single keymap binding.
+type KeymapEntry struct {
+	Action        string   `toml:"action"`
+	Key           string   `toml:"key"`
+	Modifiers     []string `toml:"modifiers"`
+	Description   string   `toml:"description"`
+	Enabled       bool     `toml:"enabled"`
+	Sequence      bool     `toml:"sequence"`
+	SupportsCount bool     `toml:"supports_count"`
+	Context       string   `toml:"context"`
+}
+
+// KeymapGlobalSettings contains global keymap preferences.
+type KeymapGlobalSettings struct {
+	KeymapsEnabled  bool    `toml:"keymaps_enabled"`
+	ShowKeymapHints bool    `toml:"show_keymap_hints"`
+	SequenceTimeout float64 `toml:"sequence_timeout"`
+}
+
+// LoadKeymaps loads and parses keymaps.toml from the given path.
+// If path is empty, uses the default config directory.
+// Returns nil (not error) if the file doesn't exist.
+func LoadKeymaps(path string) (*KeymapConfig, error) {
+	if path == "" {
+		path = filepath.Join(filepath.Dir(DefaultPath()), "keymaps.toml")
+	}
+
+	if _, err := os.Stat(path); os.IsNotExist(err) {
+		return nil, nil
+	}
+
+	var cfg KeymapConfig
+	if _, err := toml.DecodeFile(path, &cfg); err != nil {
+		return nil, fmt.Errorf("failed to load keymaps: %w", err)
+	}
+
+	return &cfg, nil
+}

--- a/cli/internal/config/profiles.go
+++ b/cli/internal/config/profiles.go
@@ -1,0 +1,49 @@
+package config
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/BurntSushi/toml"
+)
+
+// ProfileConfig represents a single profile entry in profiles.toml.
+type ProfileConfig struct {
+	Name     string         `toml:"name"`
+	Accounts []string       `toml:"accounts"`
+	Default  bool           `toml:"default"`
+	Color    string         `toml:"color"`
+	Folders  []FolderConfig `toml:"folders"`
+}
+
+// FolderConfig represents a folder entry within a profile.
+type FolderConfig struct {
+	Name  string `toml:"name"`
+	Icon  string `toml:"icon"`
+	Query string `toml:"query"`
+}
+
+type profilesFile struct {
+	Profile []ProfileConfig `toml:"profile"`
+}
+
+// LoadProfiles loads and parses profiles.toml from the given path.
+// If path is empty, uses the default config directory.
+// Returns nil (not error) if the file doesn't exist.
+func LoadProfiles(path string) ([]ProfileConfig, error) {
+	if path == "" {
+		path = filepath.Join(filepath.Dir(DefaultPath()), "profiles.toml")
+	}
+
+	if _, err := os.Stat(path); os.IsNotExist(err) {
+		return nil, nil
+	}
+
+	var cfg profilesFile
+	if _, err := toml.DecodeFile(path, &cfg); err != nil {
+		return nil, fmt.Errorf("failed to load profiles: %w", err)
+	}
+
+	return cfg.Profile, nil
+}

--- a/cli/internal/config/validate.go
+++ b/cli/internal/config/validate.go
@@ -1,0 +1,342 @@
+package config
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+)
+
+// ValidationError represents a single validation issue.
+type ValidationError struct {
+	File     string // "config.toml", "rules.toml", etc.
+	Field    string // e.g. "accounts[0].smtp.host"
+	Message  string
+	Severity string // "error" or "warning"
+}
+
+func (e ValidationError) String() string {
+	if e.Field != "" {
+		return fmt.Sprintf("[%s] %s: %s", e.File, e.Field, e.Message)
+	}
+	return fmt.Sprintf("[%s] %s", e.File, e.Message)
+}
+
+// RuleQueryValidator is a function that validates a rule match expression.
+// Injected from the imap package to avoid a circular dependency.
+type RuleQueryValidator func(query string) error
+
+// ValidateConfig validates config.toml and returns any issues found.
+func ValidateConfig(cfg *Config) []ValidationError {
+	var errs []ValidationError
+	add := func(field, msg string) {
+		errs = append(errs, ValidationError{File: "config.toml", Field: field, Message: msg, Severity: "error"})
+	}
+	warn := func(field, msg string) {
+		errs = append(errs, ValidationError{File: "config.toml", Field: field, Message: msg, Severity: "warning"})
+	}
+
+	if len(cfg.Accounts) == 0 {
+		warn("accounts", "no accounts configured")
+		return errs
+	}
+
+	// Alias validation (reuse existing)
+	if err := cfg.ValidateAliases(); err != nil {
+		add("accounts", err.Error())
+	}
+
+	defaultCount := 0
+	for i, acct := range cfg.Accounts {
+		prefix := fmt.Sprintf("accounts[%d]", i)
+
+		if acct.Email == "" {
+			add(prefix+".email", "required")
+		} else if !isValidEmail(acct.Email) {
+			add(prefix+".email", fmt.Sprintf("invalid email: %q", acct.Email))
+		}
+
+		if acct.Name == "" {
+			warn(prefix+".name", "account name is empty")
+		}
+
+		if acct.Default {
+			defaultCount++
+		}
+
+		if acct.AuthEmail != "" && !isValidEmail(acct.AuthEmail) {
+			add(prefix+".auth_email", fmt.Sprintf("invalid email: %q", acct.AuthEmail))
+		}
+
+		// Signature reference
+		if acct.DefaultSignature != "" && cfg.Signatures != nil {
+			if _, ok := cfg.Signatures[acct.DefaultSignature]; !ok {
+				keys := make([]string, 0, len(cfg.Signatures))
+				for k := range cfg.Signatures {
+					keys = append(keys, k)
+				}
+				warn(prefix+".default_signature", fmt.Sprintf("%q not found in [signatures] (available: %s)", acct.DefaultSignature, strings.Join(keys, ", ")))
+			}
+		}
+
+		// SMTP
+		if acct.SMTP.Host != "" || acct.SMTP.Port != 0 {
+			if acct.SMTP.Host == "" {
+				add(prefix+".smtp.host", "required when smtp is configured")
+			}
+			if acct.SMTP.Port <= 0 {
+				add(prefix+".smtp.port", "must be a positive integer")
+			}
+			if acct.SMTP.Auth != "" && acct.SMTP.Auth != "password" && acct.SMTP.Auth != "oauth2" {
+				add(prefix+".smtp.auth", fmt.Sprintf("must be \"password\" or \"oauth2\", got %q", acct.SMTP.Auth))
+			}
+			if acct.SMTP.MaxAttachmentSize != "" {
+				if _, err := ParseSize(acct.SMTP.MaxAttachmentSize); err != nil {
+					add(prefix+".smtp.max_attachment_size", err.Error())
+				}
+			}
+		}
+
+		// IMAP
+		if acct.IMAP.Host != "" || acct.IMAP.Port != 0 {
+			if acct.IMAP.Host == "" {
+				add(prefix+".imap.host", "required when imap is configured")
+			}
+			if acct.IMAP.Port <= 0 {
+				add(prefix+".imap.port", "must be a positive integer")
+			}
+			if acct.IMAP.Auth != "" && acct.IMAP.Auth != "password" && acct.IMAP.Auth != "oauth2" {
+				add(prefix+".imap.auth", fmt.Sprintf("must be \"password\" or \"oauth2\", got %q", acct.IMAP.Auth))
+			}
+		}
+
+		// OAuth
+		if acct.SMTP.Auth == "oauth2" || acct.IMAP.Auth == "oauth2" {
+			if acct.OAuth.Provider == "" {
+				add(prefix+".oauth.provider", "required when auth is oauth2")
+			} else if acct.OAuth.Provider != "google" && acct.OAuth.Provider != "microsoft" {
+				add(prefix+".oauth.provider", fmt.Sprintf("must be \"google\" or \"microsoft\", got %q", acct.OAuth.Provider))
+			}
+			if acct.OAuth.Provider == "google" {
+				if acct.OAuth.ClientID == "" {
+					add(prefix+".oauth.client_id", "required for Google OAuth")
+				}
+				if acct.OAuth.ClientSecret == "" {
+					add(prefix+".oauth.client_secret", "required for Google OAuth")
+				}
+			}
+		}
+	}
+
+	if defaultCount > 1 {
+		warn("accounts", fmt.Sprintf("%d accounts marked as default (expected at most 1)", defaultCount))
+	}
+
+	return errs
+}
+
+// ValidateRules validates rules.toml entries. Pass a RuleQueryValidator to check match syntax.
+func ValidateRules(rules []RuleConfig, cfg *Config, queryValidator RuleQueryValidator) []ValidationError {
+	var errs []ValidationError
+	add := func(field, msg string) {
+		errs = append(errs, ValidationError{File: "rules.toml", Field: field, Message: msg, Severity: "error"})
+	}
+	warn := func(field, msg string) {
+		errs = append(errs, ValidationError{File: "rules.toml", Field: field, Message: msg, Severity: "warning"})
+	}
+
+	aliases := configAliasSet(cfg)
+
+	for i, rule := range rules {
+		prefix := fmt.Sprintf("rules[%d]", i)
+
+		if rule.Name == "" {
+			add(prefix+".name", "required")
+		}
+
+		if rule.Match == "" {
+			add(prefix+".match", "required")
+		} else if queryValidator != nil {
+			if err := queryValidator(rule.Match); err != nil {
+				add(prefix+".match", fmt.Sprintf("invalid expression: %v", err))
+			}
+		}
+
+		if len(rule.AddTags) == 0 && len(rule.RemoveTags) == 0 {
+			warn(prefix, "rule has no add_tags or remove_tags (no-op)")
+		}
+
+		for _, acct := range rule.Accounts {
+			if _, ok := aliases[strings.ToLower(acct)]; !ok {
+				warn(prefix+".accounts", fmt.Sprintf("account %q not found in config", acct))
+			}
+		}
+	}
+
+	return errs
+}
+
+// ValidateProfiles validates profiles.toml entries against the config.
+func ValidateProfiles(profiles []ProfileConfig, cfg *Config) []ValidationError {
+	var errs []ValidationError
+	add := func(field, msg string) {
+		errs = append(errs, ValidationError{File: "profiles.toml", Field: field, Message: msg, Severity: "error"})
+	}
+	warn := func(field, msg string) {
+		errs = append(errs, ValidationError{File: "profiles.toml", Field: field, Message: msg, Severity: "warning"})
+	}
+
+	aliases := configAliasSet(cfg)
+	hexColor := regexp.MustCompile(`^#([0-9a-fA-F]{3}|[0-9a-fA-F]{6})$`)
+	defaultCount := 0
+
+	for i, profile := range profiles {
+		prefix := fmt.Sprintf("profile[%d]", i)
+
+		if profile.Name == "" {
+			add(prefix+".name", "required")
+		}
+
+		if len(profile.Accounts) == 0 {
+			add(prefix+".accounts", "required (use [\"*\"] for all accounts)")
+		}
+
+		for _, acct := range profile.Accounts {
+			if acct == "*" {
+				continue
+			}
+			if _, ok := aliases[strings.ToLower(acct)]; !ok {
+				warn(prefix+".accounts", fmt.Sprintf("account %q not found in config", acct))
+			}
+		}
+
+		if profile.Default {
+			defaultCount++
+		}
+
+		if profile.Color != "" && !hexColor.MatchString(profile.Color) {
+			add(prefix+".color", fmt.Sprintf("invalid hex color: %q (expected #RGB or #RRGGBB)", profile.Color))
+		}
+
+		for j, folder := range profile.Folders {
+			fp := fmt.Sprintf("%s.folders[%d]", prefix, j)
+			if folder.Name == "" {
+				add(fp+".name", "required")
+			}
+			if folder.Icon == "" {
+				warn(fp+".icon", "empty (will show no icon)")
+			}
+			if folder.Query == "" {
+				add(fp+".query", "required")
+			}
+		}
+	}
+
+	if defaultCount > 1 {
+		warn("profiles", fmt.Sprintf("%d profiles marked as default (expected at most 1)", defaultCount))
+	}
+
+	return errs
+}
+
+// Known valid keymap values.
+var (
+	validKeymapActions = map[string]bool{
+		"next_email": true, "prev_email": true, "first_email": true, "last_email": true,
+		"page_down": true, "page_up": true,
+		"archive": true, "compose": true, "reply": true, "reply_all": true, "forward": true,
+		"toggle_read": true, "toggle_star": true, "delete": true,
+		"go_inbox": true, "go_sent": true, "go_drafts": true, "go_archive": true,
+		"search": true, "close_detail": true, "reload_inbox": true, "tag_picker": true,
+		"enter_visual_mode": true, "enter_toggle_mode": true, "toggle_selection": true, "exit_visual_mode": true,
+		"select_next": true, "select_prev": true, "exit_insert": true,
+		"scroll_down": true, "scroll_up": true, "enter_thread": true,
+		"next_message": true, "prev_message": true,
+		"next_profile": true, "prev_profile": true,
+		"open_in_browser": true, "copy_link": true,
+	}
+	validKeymapModifiers = map[string]bool{"cmd": true, "ctrl": true, "shift": true}
+	validKeymapContexts  = map[string]bool{
+		"list": true, "search": true, "tag_picker": true, "thread": true, "compose_normal": true,
+	}
+)
+
+// ValidateKeymaps validates keymaps.toml.
+func ValidateKeymaps(keymaps *KeymapConfig) []ValidationError {
+	var errs []ValidationError
+	add := func(field, msg string) {
+		errs = append(errs, ValidationError{File: "keymaps.toml", Field: field, Message: msg, Severity: "error"})
+	}
+	warn := func(field, msg string) {
+		errs = append(errs, ValidationError{File: "keymaps.toml", Field: field, Message: msg, Severity: "warning"})
+	}
+
+	if keymaps.GlobalSettings.SequenceTimeout <= 0 {
+		warn("global_settings.sequence_timeout", "should be positive (using default 1.0s)")
+	}
+
+	seen := make(map[string]int) // "key+modifiers+context" → index
+	for i, entry := range keymaps.Keymaps {
+		prefix := fmt.Sprintf("keymaps[%d]", i)
+
+		if entry.Action == "" {
+			add(prefix+".action", "required")
+		} else if !validKeymapActions[entry.Action] {
+			warn(prefix+".action", fmt.Sprintf("unknown action %q", entry.Action))
+		}
+
+		if entry.Key == "" {
+			add(prefix+".key", "required")
+		}
+
+		for _, mod := range entry.Modifiers {
+			if !validKeymapModifiers[mod] {
+				add(prefix+".modifiers", fmt.Sprintf("unknown modifier %q (valid: cmd, ctrl, shift)", mod))
+			}
+		}
+
+		ctx := entry.Context
+		if ctx == "" {
+			ctx = "list"
+		}
+		if !validKeymapContexts[ctx] {
+			add(prefix+".context", fmt.Sprintf("unknown context %q", ctx))
+		}
+
+		// Check duplicates
+		dupKey := fmt.Sprintf("%s|%s|%s", entry.Key, strings.Join(entry.Modifiers, ","), ctx)
+		if prev, ok := seen[dupKey]; ok {
+			warn(prefix, fmt.Sprintf("duplicate binding: same key/modifiers/context as keymaps[%d]", prev))
+		}
+		seen[dupKey] = i
+	}
+
+	return errs
+}
+
+// configAliasSet builds a lowercase set of account aliases + names from config.
+func configAliasSet(cfg *Config) map[string]bool {
+	aliases := make(map[string]bool)
+	if cfg == nil {
+		return aliases
+	}
+	for _, acct := range cfg.Accounts {
+		if acct.Alias != "" {
+			aliases[strings.ToLower(acct.Alias)] = true
+		}
+		if acct.Name != "" {
+			aliases[strings.ToLower(acct.Name)] = true
+		}
+	}
+	return aliases
+}
+
+// isValidEmail does a basic email format check.
+func isValidEmail(email string) bool {
+	// Simple check: has @ with something before and after, and a dot after @
+	at := strings.Index(email, "@")
+	if at <= 0 || at >= len(email)-1 {
+		return false
+	}
+	domain := email[at+1:]
+	return strings.Contains(domain, ".") && !strings.HasPrefix(domain, ".") && !strings.HasSuffix(domain, ".")
+}

--- a/cli/internal/config/validate_test.go
+++ b/cli/internal/config/validate_test.go
@@ -1,0 +1,386 @@
+package config
+
+import (
+	"errors"
+	"strings"
+	"testing"
+)
+
+// --- ValidateConfig ---
+
+func TestValidateConfig_ValidMinimal(t *testing.T) {
+	cfg := &Config{
+		Accounts: []AccountConfig{
+			{Name: "Test", Email: "test@example.com"},
+		},
+	}
+	errs := ValidateConfig(cfg)
+	for _, e := range errs {
+		if e.Severity == "error" {
+			t.Errorf("unexpected error: %s", e)
+		}
+	}
+}
+
+func TestValidateConfig_NoAccounts(t *testing.T) {
+	cfg := &Config{}
+	errs := ValidateConfig(cfg)
+	if len(errs) == 0 {
+		t.Error("expected warning for no accounts")
+	}
+}
+
+func TestValidateConfig_MissingEmail(t *testing.T) {
+	cfg := &Config{Accounts: []AccountConfig{{Name: "Test"}}}
+	errs := ValidateConfig(cfg)
+	hasError := false
+	for _, e := range errs {
+		if strings.Contains(e.Field, "email") && e.Severity == "error" {
+			hasError = true
+		}
+	}
+	if !hasError {
+		t.Error("expected error for missing email")
+	}
+}
+
+func TestValidateConfig_InvalidSMTPAuth(t *testing.T) {
+	cfg := &Config{Accounts: []AccountConfig{{
+		Name: "Test", Email: "test@example.com",
+		SMTP: SMTPConfig{Host: "smtp.example.com", Port: 587, Auth: "plain"},
+	}}}
+	errs := ValidateConfig(cfg)
+	hasError := false
+	for _, e := range errs {
+		if strings.Contains(e.Message, "password") && strings.Contains(e.Message, "oauth2") {
+			hasError = true
+		}
+	}
+	if !hasError {
+		t.Error("expected error for invalid auth method")
+	}
+}
+
+func TestValidateConfig_OAuthGoogleRequiresClientID(t *testing.T) {
+	cfg := &Config{Accounts: []AccountConfig{{
+		Name: "Test", Email: "test@example.com",
+		SMTP:  SMTPConfig{Host: "smtp.gmail.com", Port: 587, Auth: "oauth2"},
+		OAuth: OAuthConfig{Provider: "google"},
+	}}}
+	errs := ValidateConfig(cfg)
+	found := false
+	for _, e := range errs {
+		if strings.Contains(e.Message, "client_id") {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("expected error for missing Google client_id")
+	}
+}
+
+func TestValidateConfig_SignatureRefMissing(t *testing.T) {
+	cfg := &Config{
+		Signatures: map[string]string{"default": "Best regards"},
+		Accounts: []AccountConfig{{
+			Name: "Test", Email: "test@example.com",
+			DefaultSignature: "nonexistent",
+		}},
+	}
+	errs := ValidateConfig(cfg)
+	found := false
+	for _, e := range errs {
+		if strings.Contains(e.Message, "nonexistent") && strings.Contains(e.Message, "not found") {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("expected warning for missing signature reference")
+	}
+}
+
+func TestValidateConfig_MultipleDefaults(t *testing.T) {
+	cfg := &Config{Accounts: []AccountConfig{
+		{Name: "A", Email: "a@example.com", Default: true},
+		{Name: "B", Email: "b@example.com", Default: true},
+	}}
+	errs := ValidateConfig(cfg)
+	found := false
+	for _, e := range errs {
+		if strings.Contains(e.Message, "2 accounts marked as default") {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("expected warning for multiple defaults")
+	}
+}
+
+// --- ValidateRules ---
+
+func okValidator(_ string) error   { return nil }
+func failValidator(_ string) error { return errors.New("parse error") }
+
+func TestValidateRules_Valid(t *testing.T) {
+	rules := []RuleConfig{{Name: "Test", Match: "from:@test.com", AddTags: []string{"test"}}}
+	errs := ValidateRules(rules, nil, okValidator)
+	for _, e := range errs {
+		if e.Severity == "error" {
+			t.Errorf("unexpected error: %s", e)
+		}
+	}
+}
+
+func TestValidateRules_MissingName(t *testing.T) {
+	rules := []RuleConfig{{Match: "from:test", AddTags: []string{"x"}}}
+	errs := ValidateRules(rules, nil, okValidator)
+	found := false
+	for _, e := range errs {
+		if strings.Contains(e.Field, "name") {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("expected error for missing name")
+	}
+}
+
+func TestValidateRules_InvalidMatch(t *testing.T) {
+	rules := []RuleConfig{{Name: "Bad", Match: "(((", AddTags: []string{"x"}}}
+	errs := ValidateRules(rules, nil, failValidator)
+	found := false
+	for _, e := range errs {
+		if strings.Contains(e.Message, "invalid expression") {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("expected error for invalid match expression")
+	}
+}
+
+func TestValidateRules_NoOp(t *testing.T) {
+	rules := []RuleConfig{{Name: "NoOp", Match: "from:test"}}
+	errs := ValidateRules(rules, nil, okValidator)
+	found := false
+	for _, e := range errs {
+		if strings.Contains(e.Message, "no-op") {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("expected warning for no-op rule")
+	}
+}
+
+func TestValidateRules_UnknownAccount(t *testing.T) {
+	cfg := &Config{Accounts: []AccountConfig{{Name: "Work", Alias: "work"}}}
+	rules := []RuleConfig{{Name: "R", Match: "from:test", AddTags: []string{"x"}, Accounts: []string{"nonexistent"}}}
+	errs := ValidateRules(rules, cfg, okValidator)
+	found := false
+	for _, e := range errs {
+		if strings.Contains(e.Message, "nonexistent") {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("expected warning for unknown account")
+	}
+}
+
+// --- ValidateProfiles ---
+
+func TestValidateProfiles_Valid(t *testing.T) {
+	profiles := []ProfileConfig{{Name: "All", Accounts: []string{"*"}}}
+	errs := ValidateProfiles(profiles, nil)
+	for _, e := range errs {
+		if e.Severity == "error" {
+			t.Errorf("unexpected error: %s", e)
+		}
+	}
+}
+
+func TestValidateProfiles_MissingName(t *testing.T) {
+	profiles := []ProfileConfig{{Accounts: []string{"*"}}}
+	errs := ValidateProfiles(profiles, nil)
+	found := false
+	for _, e := range errs {
+		if strings.Contains(e.Field, "name") {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("expected error for missing name")
+	}
+}
+
+func TestValidateProfiles_InvalidColor(t *testing.T) {
+	profiles := []ProfileConfig{{Name: "Test", Accounts: []string{"*"}, Color: "not-hex"}}
+	errs := ValidateProfiles(profiles, nil)
+	found := false
+	for _, e := range errs {
+		if strings.Contains(e.Message, "hex color") {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("expected error for invalid color")
+	}
+}
+
+func TestValidateProfiles_ValidColors(t *testing.T) {
+	tests := []string{"#FFF", "#3B82F6", "#abc", "#AABBCC"}
+	for _, c := range tests {
+		profiles := []ProfileConfig{{Name: "T", Accounts: []string{"*"}, Color: c}}
+		errs := ValidateProfiles(profiles, nil)
+		for _, e := range errs {
+			if strings.Contains(e.Message, "hex color") {
+				t.Errorf("color %q should be valid but got error: %s", c, e)
+			}
+		}
+	}
+}
+
+func TestValidateProfiles_UnknownAccount(t *testing.T) {
+	cfg := &Config{Accounts: []AccountConfig{{Name: "Work", Alias: "work"}}}
+	profiles := []ProfileConfig{{Name: "T", Accounts: []string{"bogus"}}}
+	errs := ValidateProfiles(profiles, cfg)
+	found := false
+	for _, e := range errs {
+		if strings.Contains(e.Message, "bogus") {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("expected warning for unknown account")
+	}
+}
+
+func TestValidateProfiles_FolderMissingQuery(t *testing.T) {
+	profiles := []ProfileConfig{{
+		Name: "T", Accounts: []string{"*"},
+		Folders: []FolderConfig{{Name: "Inbox", Icon: "tray"}},
+	}}
+	errs := ValidateProfiles(profiles, nil)
+	found := false
+	for _, e := range errs {
+		if strings.Contains(e.Field, "query") {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("expected error for missing folder query")
+	}
+}
+
+// --- ValidateKeymaps ---
+
+func TestValidateKeymaps_Valid(t *testing.T) {
+	km := &KeymapConfig{
+		GlobalSettings: KeymapGlobalSettings{SequenceTimeout: 1.0},
+		Keymaps: []KeymapEntry{
+			{Action: "next_email", Key: "j", Context: "list"},
+		},
+	}
+	errs := ValidateKeymaps(km)
+	for _, e := range errs {
+		if e.Severity == "error" {
+			t.Errorf("unexpected error: %s", e)
+		}
+	}
+}
+
+func TestValidateKeymaps_UnknownAction(t *testing.T) {
+	km := &KeymapConfig{
+		GlobalSettings: KeymapGlobalSettings{SequenceTimeout: 1.0},
+		Keymaps:        []KeymapEntry{{Action: "fly_to_moon", Key: "x"}},
+	}
+	errs := ValidateKeymaps(km)
+	found := false
+	for _, e := range errs {
+		if strings.Contains(e.Message, "fly_to_moon") {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("expected warning for unknown action")
+	}
+}
+
+func TestValidateKeymaps_InvalidModifier(t *testing.T) {
+	km := &KeymapConfig{
+		GlobalSettings: KeymapGlobalSettings{SequenceTimeout: 1.0},
+		Keymaps:        []KeymapEntry{{Action: "next_email", Key: "j", Modifiers: []string{"alt"}}},
+	}
+	errs := ValidateKeymaps(km)
+	found := false
+	for _, e := range errs {
+		if strings.Contains(e.Message, "alt") {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("expected error for invalid modifier")
+	}
+}
+
+func TestValidateKeymaps_DuplicateBinding(t *testing.T) {
+	km := &KeymapConfig{
+		GlobalSettings: KeymapGlobalSettings{SequenceTimeout: 1.0},
+		Keymaps: []KeymapEntry{
+			{Action: "next_email", Key: "j", Context: "list"},
+			{Action: "scroll_down", Key: "j", Context: "list"},
+		},
+	}
+	errs := ValidateKeymaps(km)
+	found := false
+	for _, e := range errs {
+		if strings.Contains(e.Message, "duplicate") {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("expected warning for duplicate binding")
+	}
+}
+
+func TestValidateKeymaps_InvalidContext(t *testing.T) {
+	km := &KeymapConfig{
+		GlobalSettings: KeymapGlobalSettings{SequenceTimeout: 1.0},
+		Keymaps:        []KeymapEntry{{Action: "next_email", Key: "j", Context: "unknown_ctx"}},
+	}
+	errs := ValidateKeymaps(km)
+	found := false
+	for _, e := range errs {
+		if strings.Contains(e.Message, "unknown_ctx") {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("expected error for unknown context")
+	}
+}
+
+// --- isValidEmail ---
+
+func TestIsValidEmail(t *testing.T) {
+	tests := []struct {
+		email string
+		valid bool
+	}{
+		{"user@example.com", true},
+		{"user@sub.domain.co.uk", true},
+		{"a@b.c", true},
+		{"", false},
+		{"noat", false},
+		{"@example.com", false},
+		{"user@", false},
+		{"user@.com", false},
+		{"user@com.", false},
+	}
+	for _, tt := range tests {
+		if got := isValidEmail(tt.email); got != tt.valid {
+			t.Errorf("isValidEmail(%q) = %v, want %v", tt.email, got, tt.valid)
+		}
+	}
+}

--- a/cli/internal/imap/rules.go
+++ b/cli/internal/imap/rules.go
@@ -2,12 +2,19 @@ package imap
 
 import (
 	"fmt"
+	"log/slog"
 	"net/mail"
 	"strings"
 
 	"github.com/durian-dev/durian/cli/internal/config"
 	"github.com/durian-dev/durian/cli/internal/store"
 )
+
+// ValidateRuleQuery checks if a rule match expression is syntactically valid.
+func ValidateRuleQuery(query string) error {
+	_, err := parseRuleQuery(query)
+	return err
+}
 
 // MatchingRules returns the rules whose match expression matches the message.
 // account is the account identifier (e.g. alias); header is the parsed mail header.
@@ -19,7 +26,8 @@ func MatchingRules(rules []config.RuleConfig, msg *store.Message, attachmentCoun
 		}
 		expr, err := parseRuleQuery(rule.Match)
 		if err != nil {
-			continue // skip malformed rules
+			slog.Warn("Skipping malformed rule", "module", "RULES", "name", rule.Name, "match", rule.Match, "err", err)
+			continue
 		}
 		if evalExpr(expr, msg, attachmentCount, header) {
 			matched = append(matched, rule)


### PR DESCRIPTION
## Summary

New `durian validate` CLI command that checks all 4 config files for errors.

```
$ durian validate
  ✓ config.toml — 2 accounts (Personal, Work)
  ✓ rules.toml — 3 rules
  ✗ profiles.toml — account "worke" not found in config
  ✓ keymaps.toml — 24 bindings
```

## What it validates

| File | Checks |
|------|--------|
| config.toml | Email format, SMTP/IMAP hosts+ports, auth method, OAuth provider+credentials, signature refs, alias uniqueness |
| rules.toml | Match expression syntax, required fields, no-op rules, account references |
| profiles.toml | Account references, hex colors, folder fields, multiple defaults |
| keymaps.toml | Action names, modifiers, contexts, duplicate bindings |

Also: malformed rules are now logged via `slog.Warn` during `serve`/`sync` instead of being silently skipped.

## Usage

```
durian validate              # all files
durian validate config       # just config.toml
durian validate rules        # just rules.toml
```

## Test plan

- [x] `bazel test //cli/internal/config:config_test` — 20 new validation tests
- [x] `bazel build //cli/cmd/durian` — builds with new command
- [x] Manual: `durian validate` finds real issues in existing config