### PR TITLE
feat(go-rules): add exec hooks for external rule commands

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,6 +9,7 @@ Email client: Go CLI backend + Swift macOS GUI.
 - **Tests:** `bazel test //cli/...` (CLI) / `bazel test //macos/...` (GUI, requires Xcode 26) / `bazel test //...` (all)
 - **CI Tests (GUI):** `bazel test //macos:ci_config_test //macos:ci_profile_test //macos:ci_banner_manager_test //macos:ci_model_test //macos:ci_sync_manager_test //macos:ci_search_manager_test //macos:ci_outbox_manager_test` (uses `durian_core` target, no Views, works on Xcode 16+)
 - **Integration Tests:** `bazel test //integration:integration_test` (starts real server, validates API contract via curl+jq)
+- **Validate Config:** `durian validate` (checks config.toml, rules.toml, profiles.toml, keymaps.toml)
 - **Logs (GUI/Swift):** `log stream --level debug --predicate 'subsystem == "org.js-lab.durian.nightly"'` (nightly) / `subsystem == "org.js-lab.durian"` (release)
 - **Logs (CLI/Go):** `~/.config/durian/serve.log` (truncated on each `durian serve` start). Default: Info+, with `--debug`: Debug+. Other commands: Error → stderr, with `--debug`: Debug+ → stderr.
 

--- a/README.md
+++ b/README.md
@@ -73,8 +73,9 @@ bazel build -c opt //macos:Durian # GUI (macOS only, release)
 ## Test
 
 ```bash
-bazel test //cli/...            # CLI tests
-bazel test //macos/...            # GUI tests (requires Xcode 26)
+bazel test //cli/...                       # CLI unit tests
+bazel test //macos/...                     # GUI tests (requires Xcode 26)
+bazel test //integration:integration_test  # API contract tests (real server)
 ```
 
 ## CLI
@@ -85,6 +86,8 @@ durian auth status              # show auth status
 durian sync work                # sync an account
 durian search "tag:inbox" -l 10 # search
 durian search "date:today"      # relative date search
+durian validate                 # check all config files for errors
+durian validate rules           # check just rules.toml
 ```
 
 ## Config
@@ -96,7 +99,7 @@ All configuration lives in `~/.config/durian/` (or `$XDG_CONFIG_HOME/durian/`):
 | `config.toml` | Accounts, signatures, settings |
 | `profiles.toml` | Sidebar profiles (account groups, folders) |
 | `keymaps.toml` | Vim-style keyboard shortcuts |
-| `rules.toml` | Client-side filter rules |
+| `rules.toml` | Filter rules (static tags + exec hooks for external commands) |
 
 Examples:
 - [config-example.toml](docs/config-example.toml) — Accounts, signatures, settings

--- a/cli/internal/config/rules.go
+++ b/cli/internal/config/rules.go
@@ -20,8 +20,9 @@ type RuleConfig struct {
 	AddTags     []string `toml:"add_tags"`
 	RemoveTags  []string `toml:"remove_tags"`
 	Accounts    []string `toml:"accounts"`     // If set, only apply to these accounts (by alias)
-	Exec        string   `toml:"exec"`         // Optional: external command to run (stdin=email JSON, stdout=tag ops JSON)
-	ExecTimeout int      `toml:"exec_timeout"` // Timeout in seconds (default: 10)
+	Exec        string   `toml:"exec"`          // Optional: external command to run (stdin=email JSON, stdout=tag ops JSON)
+	ExecTimeout int      `toml:"exec_timeout"`  // Timeout in seconds (default: 10)
+	AllowedTags []string `toml:"allowed_tags"`  // Optional: restrict exec output to these tags
 }
 
 // LoadRules loads filter rules from the given path.

--- a/cli/internal/config/rules.go
+++ b/cli/internal/config/rules.go
@@ -15,11 +15,13 @@ type RulesConfig struct {
 
 // RuleConfig defines a single filter rule applied at sync time
 type RuleConfig struct {
-	Name       string   `toml:"name"`
-	Match      string   `toml:"match"`
-	AddTags    []string `toml:"add_tags"`
-	RemoveTags []string `toml:"remove_tags"`
-	Accounts   []string `toml:"accounts"` // If set, only apply to these accounts (by alias)
+	Name        string   `toml:"name"`
+	Match       string   `toml:"match"`
+	AddTags     []string `toml:"add_tags"`
+	RemoveTags  []string `toml:"remove_tags"`
+	Accounts    []string `toml:"accounts"`     // If set, only apply to these accounts (by alias)
+	Exec        string   `toml:"exec"`         // Optional: external command to run (stdin=email JSON, stdout=tag ops JSON)
+	ExecTimeout int      `toml:"exec_timeout"` // Timeout in seconds (default: 10)
 }
 
 // LoadRules loads filter rules from the given path.

--- a/cli/internal/config/validate.go
+++ b/cli/internal/config/validate.go
@@ -161,8 +161,12 @@ func ValidateRules(rules []RuleConfig, cfg *Config, queryValidator RuleQueryVali
 			}
 		}
 
-		if len(rule.AddTags) == 0 && len(rule.RemoveTags) == 0 {
-			warn(prefix, "rule has no add_tags or remove_tags (no-op)")
+		if len(rule.AddTags) == 0 && len(rule.RemoveTags) == 0 && rule.Exec == "" {
+			warn(prefix, "rule has no add_tags, remove_tags, or exec (no-op)")
+		}
+
+		if rule.ExecTimeout < 0 {
+			add(prefix+".exec_timeout", "must be non-negative")
 		}
 
 		for _, acct := range rule.Accounts {

--- a/cli/internal/imap/BUILD.bazel
+++ b/cli/internal/imap/BUILD.bazel
@@ -4,6 +4,7 @@ go_library(
     name = "imap",
     srcs = [
         "client.go",
+        "exec.go",
         "flags.go",
         "rules.go",
         "state.go",
@@ -27,6 +28,7 @@ go_test(
     name = "imap_test",
     size = "small",
     srcs = [
+        "exec_test.go",
         "flags_test.go",
         "gmail_test.go",
         "rules_test.go",

--- a/cli/internal/imap/exec.go
+++ b/cli/internal/imap/exec.go
@@ -1,0 +1,105 @@
+package imap
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"os/exec"
+	"time"
+
+	"github.com/durian-dev/durian/cli/internal/config"
+	"github.com/durian-dev/durian/cli/internal/store"
+)
+
+// ExecInput is the JSON sent to an exec rule's stdin.
+type ExecInput struct {
+	From          string   `json:"from"`
+	To            string   `json:"to"`
+	CC            string   `json:"cc,omitempty"`
+	Subject       string   `json:"subject"`
+	Body          string   `json:"body"`
+	HTML          string   `json:"html,omitempty"`
+	Account       string   `json:"account"`
+	Tags          []string `json:"tags"`
+	HasAttachment bool     `json:"has_attachment"`
+}
+
+// ExecOutput is the JSON expected from an exec rule's stdout.
+type ExecOutput struct {
+	AddTags    []string `json:"add_tags"`
+	RemoveTags []string `json:"remove_tags"`
+}
+
+const defaultExecTimeout = 10 // seconds
+
+// RunExecRule runs an external command for a matched rule and returns tag operations.
+// Returns nil, nil if the rule has no exec command.
+func RunExecRule(rule config.RuleConfig, msg *store.Message, tags []string, account string) (*ExecOutput, error) {
+	if rule.Exec == "" {
+		return nil, nil
+	}
+
+	timeout := rule.ExecTimeout
+	if timeout <= 0 {
+		timeout = defaultExecTimeout
+	}
+
+	input := ExecInput{
+		From:          msg.FromAddr,
+		To:            msg.ToAddrs,
+		CC:            msg.CCAddrs,
+		Subject:       msg.Subject,
+		Body:          msg.BodyText,
+		HTML:          msg.BodyHTML,
+		Account:       account,
+		Tags:          tags,
+		HasAttachment: false, // caller can set this
+	}
+
+	inputJSON, err := json.Marshal(input)
+	if err != nil {
+		return nil, fmt.Errorf("marshal exec input: %w", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Duration(timeout)*time.Second)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, rule.Exec)
+	cmd.Stdin = bytes.NewReader(inputJSON)
+
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+
+	slog.Debug("Running exec rule", "module", "RULES", "rule", rule.Name, "cmd", rule.Exec, "timeout", timeout)
+
+	if err := cmd.Run(); err != nil {
+		if ctx.Err() == context.DeadlineExceeded {
+			return nil, fmt.Errorf("exec rule %q timed out after %ds", rule.Name, timeout)
+		}
+		stderrStr := stderr.String()
+		if stderrStr != "" {
+			slog.Warn("Exec rule stderr", "module", "RULES", "rule", rule.Name, "stderr", stderrStr)
+		}
+		return nil, fmt.Errorf("exec rule %q failed: %w", rule.Name, err)
+	}
+
+	if stderr.Len() > 0 {
+		slog.Debug("Exec rule stderr", "module", "RULES", "rule", rule.Name, "stderr", stderr.String())
+	}
+
+	// Empty stdout = no action
+	if stdout.Len() == 0 || bytes.TrimSpace(stdout.Bytes()) == nil {
+		return &ExecOutput{}, nil
+	}
+
+	var output ExecOutput
+	if err := json.Unmarshal(stdout.Bytes(), &output); err != nil {
+		return nil, fmt.Errorf("exec rule %q: invalid JSON output: %w", rule.Name, err)
+	}
+
+	slog.Debug("Exec rule result", "module", "RULES", "rule", rule.Name, "add", output.AddTags, "remove", output.RemoveTags)
+	return &output, nil
+}

--- a/cli/internal/imap/exec.go
+++ b/cli/internal/imap/exec.go
@@ -34,6 +34,27 @@ type ExecOutput struct {
 
 const defaultExecTimeout = 10 // seconds
 
+// filterAllowedTags returns only tags that are in the allowed list.
+// Rejected tags are logged as warnings.
+func filterAllowedTags(tags, allowed []string, ruleName string) []string {
+	if len(tags) == 0 {
+		return tags
+	}
+	set := make(map[string]bool, len(allowed))
+	for _, t := range allowed {
+		set[t] = true
+	}
+	var filtered []string
+	for _, t := range tags {
+		if set[t] {
+			filtered = append(filtered, t)
+		} else {
+			slog.Warn("Exec rule returned disallowed tag", "module", "RULES", "rule", ruleName, "tag", t)
+		}
+	}
+	return filtered
+}
+
 // RunExecRule runs an external command for a matched rule and returns tag operations.
 // Returns nil, nil if the rule has no exec command.
 func RunExecRule(rule config.RuleConfig, msg *store.Message, tags []string, account string) (*ExecOutput, error) {

--- a/cli/internal/imap/exec_test.go
+++ b/cli/internal/imap/exec_test.go
@@ -1,0 +1,155 @@
+package imap
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/durian-dev/durian/cli/internal/config"
+	"github.com/durian-dev/durian/cli/internal/store"
+)
+
+func writeTestScript(t *testing.T, name, content string) string {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, name)
+	if err := os.WriteFile(path, []byte(content), 0755); err != nil {
+		t.Fatalf("write script: %v", err)
+	}
+	return path
+}
+
+func TestRunExecRule_NoExec(t *testing.T) {
+	rule := config.RuleConfig{Name: "Static", Match: "from:test"}
+	out, err := RunExecRule(rule, &store.Message{}, nil, "test")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if out != nil {
+		t.Error("expected nil for rule without exec")
+	}
+}
+
+func TestRunExecRule_Success(t *testing.T) {
+	script := writeTestScript(t, "classify.sh", `#!/bin/bash
+cat > /dev/null
+echo '{"add_tags":["important","finance"],"remove_tags":["unread"]}'
+`)
+	rule := config.RuleConfig{Name: "Classify", Exec: script, ExecTimeout: 5}
+	msg := &store.Message{
+		FromAddr: "alice@example.com",
+		Subject:  "Invoice Q4",
+		BodyText: "Please find attached",
+	}
+
+	out, err := RunExecRule(rule, msg, []string{"inbox", "unread"}, "work")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(out.AddTags) != 2 || out.AddTags[0] != "important" || out.AddTags[1] != "finance" {
+		t.Errorf("add_tags = %v, want [important, finance]", out.AddTags)
+	}
+	if len(out.RemoveTags) != 1 || out.RemoveTags[0] != "unread" {
+		t.Errorf("remove_tags = %v, want [unread]", out.RemoveTags)
+	}
+}
+
+func TestRunExecRule_ReceivesJSON(t *testing.T) {
+	// Script echoes back the from field to verify input
+	script := writeTestScript(t, "echo_from.sh", `#!/bin/bash
+INPUT=$(cat)
+FROM=$(echo "$INPUT" | grep -o '"from":"[^"]*"' | head -1)
+if echo "$FROM" | grep -q "alice@test.com"; then
+  echo '{"add_tags":["matched"]}'
+else
+  echo '{"add_tags":["no-match"]}'
+fi
+`)
+	rule := config.RuleConfig{Name: "Echo", Exec: script}
+	msg := &store.Message{FromAddr: "alice@test.com", Subject: "Test"}
+
+	out, err := RunExecRule(rule, msg, nil, "test")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(out.AddTags) != 1 || out.AddTags[0] != "matched" {
+		t.Errorf("add_tags = %v, want [matched]", out.AddTags)
+	}
+}
+
+func TestRunExecRule_EmptyOutput(t *testing.T) {
+	script := writeTestScript(t, "noop.sh", `#!/bin/bash
+cat > /dev/null
+`)
+	rule := config.RuleConfig{Name: "NoOp", Exec: script}
+
+	out, err := RunExecRule(rule, &store.Message{}, nil, "test")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(out.AddTags) != 0 && len(out.RemoveTags) != 0 {
+		t.Errorf("expected empty output, got add=%v remove=%v", out.AddTags, out.RemoveTags)
+	}
+}
+
+func TestRunExecRule_NonZeroExit(t *testing.T) {
+	script := writeTestScript(t, "fail.sh", `#!/bin/bash
+echo "something went wrong" >&2
+exit 1
+`)
+	rule := config.RuleConfig{Name: "Fail", Exec: script}
+
+	_, err := RunExecRule(rule, &store.Message{}, nil, "test")
+	if err == nil {
+		t.Fatal("expected error for non-zero exit")
+	}
+	if !strings.Contains(err.Error(), "failed") {
+		t.Errorf("error = %q, should mention failure", err.Error())
+	}
+}
+
+func TestRunExecRule_Timeout(t *testing.T) {
+	script := writeTestScript(t, "slow.sh", `#!/bin/bash
+sleep 30
+`)
+	rule := config.RuleConfig{Name: "Slow", Exec: script, ExecTimeout: 1}
+
+	_, err := RunExecRule(rule, &store.Message{}, nil, "test")
+	if err == nil {
+		t.Fatal("expected timeout error")
+	}
+	if !strings.Contains(err.Error(), "timed out") {
+		t.Errorf("error = %q, should mention timeout", err.Error())
+	}
+}
+
+func TestRunExecRule_InvalidJSON(t *testing.T) {
+	script := writeTestScript(t, "bad_json.sh", `#!/bin/bash
+cat > /dev/null
+echo 'not json'
+`)
+	rule := config.RuleConfig{Name: "BadJSON", Exec: script}
+
+	_, err := RunExecRule(rule, &store.Message{}, nil, "test")
+	if err == nil {
+		t.Fatal("expected error for invalid JSON")
+	}
+	if !strings.Contains(err.Error(), "invalid JSON") {
+		t.Errorf("error = %q, should mention invalid JSON", err.Error())
+	}
+}
+
+func TestRunExecRule_DefaultTimeout(t *testing.T) {
+	// Just verify it doesn't panic with zero timeout (should use default)
+	script := writeTestScript(t, "quick.sh", `#!/bin/bash
+cat > /dev/null
+echo '{}'
+`)
+	rule := config.RuleConfig{Name: "Quick", Exec: script} // ExecTimeout = 0 → default
+
+	_, err := RunExecRule(rule, &store.Message{}, nil, "test")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}

--- a/cli/internal/imap/exec_test.go
+++ b/cli/internal/imap/exec_test.go
@@ -140,6 +140,27 @@ echo 'not json'
 	}
 }
 
+func TestFilterAllowedTags(t *testing.T) {
+	filtered := filterAllowedTags(
+		[]string{"finance", "spam", "unknown", "important"},
+		[]string{"finance", "important", "newsletter"},
+		"test-rule",
+	)
+	if len(filtered) != 2 {
+		t.Fatalf("got %d tags, want 2", len(filtered))
+	}
+	if filtered[0] != "finance" || filtered[1] != "important" {
+		t.Errorf("filtered = %v, want [finance, important]", filtered)
+	}
+}
+
+func TestFilterAllowedTags_Empty(t *testing.T) {
+	filtered := filterAllowedTags(nil, []string{"a"}, "test")
+	if len(filtered) != 0 {
+		t.Errorf("expected empty, got %v", filtered)
+	}
+}
+
 func TestRunExecRule_DefaultTimeout(t *testing.T) {
 	// Just verify it doesn't panic with zero timeout (should use default)
 	script := writeTestScript(t, "quick.sh", `#!/bin/bash

--- a/cli/internal/imap/rules.go
+++ b/cli/internal/imap/rules.go
@@ -294,6 +294,9 @@ func evalExpr(node ruleNode, msg *store.Message, attachmentCount int, header mai
 			return false
 		}
 	case *ruleBareNode:
+		if n.value == "*" {
+			return true // wildcard: match everything
+		}
 		v := strings.ToLower(n.value)
 		return strings.Contains(strings.ToLower(msg.Subject), v) ||
 			strings.Contains(strings.ToLower(msg.BodyText), v)

--- a/cli/internal/imap/rules_test.go
+++ b/cli/internal/imap/rules_test.go
@@ -186,6 +186,18 @@ func TestMatchingRules(t *testing.T) {
 	}
 }
 
+func TestWildcardMatchesEverything(t *testing.T) {
+	rules := []config.RuleConfig{
+		{Name: "CatchAll", Match: "*", AddTags: []string{"all"}},
+	}
+
+	msg := &store.Message{FromAddr: "anyone@anywhere.com", Subject: "Whatever"}
+	matched := MatchingRules(rules, msg, 0, nil, "test")
+	if len(matched) != 1 {
+		t.Errorf("wildcard * should match everything, got %d matches", len(matched))
+	}
+}
+
 func TestMatchingRules_AccountScope(t *testing.T) {
 	rules := []config.RuleConfig{
 		{Name: "Scoped", Match: "from:@work.test", AddTags: []string{"work"}, Accounts: []string{"personal"}},

--- a/cli/internal/imap/sync.go
+++ b/cli/internal/imap/sync.go
@@ -1589,8 +1589,17 @@ func (s *Syncer) storeInsertMessage(mailboxName string, imapMsg *goimap.Message,
 				if err != nil {
 					slog.Warn("Exec rule failed, using static tags", "module", "RULES", "rule", rule.Name, "err", err)
 				} else if execOut != nil {
-					addTags = append(addTags, execOut.AddTags...)
-					removeTags = append(removeTags, execOut.RemoveTags...)
+					execAdd := execOut.AddTags
+					execRemove := execOut.RemoveTags
+
+					// Filter by allowed_tags if set
+					if len(rule.AllowedTags) > 0 {
+						execAdd = filterAllowedTags(execAdd, rule.AllowedTags, rule.Name)
+						execRemove = filterAllowedTags(execRemove, rule.AllowedTags, rule.Name)
+					}
+
+					addTags = append(addTags, execAdd...)
+					removeTags = append(removeTags, execRemove...)
 				}
 			}
 

--- a/cli/internal/imap/sync.go
+++ b/cli/internal/imap/sync.go
@@ -1577,13 +1577,29 @@ func (s *Syncer) storeInsertMessage(mailboxName string, imapMsg *goimap.Message,
 	// Apply user-defined filter rules
 	if len(s.options.FilterRules) > 0 {
 		matched := MatchingRules(s.options.FilterRules, storeMsg, len(content.Attachments), parsed.Header, s.accountName())
+		slog.Debug("Filter rules matched", "module", "RULES", "matched", len(matched), "total", len(s.options.FilterRules), "message_id", messageID)
 		for _, rule := range matched {
-			for _, tag := range rule.AddTags {
+			addTags := rule.AddTags
+			removeTags := rule.RemoveTags
+
+			// Run exec hook if configured
+			if rule.Exec != "" {
+				currentTags, _ := s.store.GetTagsByMessageID(storeMsg.MessageID)
+				execOut, err := RunExecRule(rule, storeMsg, currentTags, s.accountName())
+				if err != nil {
+					slog.Warn("Exec rule failed, using static tags", "module", "RULES", "rule", rule.Name, "err", err)
+				} else if execOut != nil {
+					addTags = append(addTags, execOut.AddTags...)
+					removeTags = append(removeTags, execOut.RemoveTags...)
+				}
+			}
+
+			for _, tag := range addTags {
 				if err := s.store.AddTag(storeMsg.ID, tag); err != nil {
 					return fmt.Errorf("add rule tag %q: %w", tag, err)
 				}
 			}
-			for _, tag := range rule.RemoveTags {
+			for _, tag := range removeTags {
 				if err := s.store.RemoveTag(storeMsg.ID, tag); err != nil {
 					return fmt.Errorf("remove rule tag %q: %w", tag, err)
 				}

--- a/docs/rules-example.toml
+++ b/docs/rules-example.toml
@@ -1,5 +1,8 @@
 # Filter rules — applied automatically when syncing new messages.
 # Copy to ~/.config/durian/rules.toml and customize.
+# Validate with: durian validate rules
+
+# ── Static tag rules ──────────────────────────────────────────────────
 
 [[rules]]
 name = "Work emails"
@@ -20,7 +23,7 @@ add_tags = ["invoice"]
 [[rules]]
 name = "Mailing list"
 match = "header:list-id:dev-list"
-accounts = ["personal"]
+accounts = ["personal"]                    # Only apply to this account
 add_tags = ["mailing-list"]
 remove_tags = ["inbox"]
 
@@ -29,33 +32,40 @@ name = "Bounce detection"
 match = "header:return-path:bounces@"
 add_tags = ["bounce"]
 
-# Supported match syntax:
-#   from:value              — case-insensitive contains on sender address
-#   to:value                — case-insensitive contains on recipient addresses
-#   subject:value           — case-insensitive contains on subject
-#   header:Name:value       — case-insensitive contains on any email header
-#   has:attachment           — message has at least one attachment
-#   bare words              — case-insensitive contains on subject + body
-#   AND (implicit)          — adjacent terms are ANDed
-#   OR                      — explicit OR between terms
-#   NOT                     — negates the next term
-#   ( )                     — grouping
+# ── Exec hook (external command) ──────────────────────────────────────
+# Runs a command for each matching email. The command receives email
+# data as JSON on stdin and returns tag operations on stdout.
 #
-# Optional fields:
-#   accounts = ["alias"]    — only apply this rule to specific accounts (by alias)
-#   exec = "command"        — run external command (stdin=email JSON, stdout=tag ops JSON)
-#   exec_timeout = 10       — timeout in seconds (default: 10)
+# stdin:  {"from":"...", "to":"...", "subject":"...", "body":"...",
+#          "account":"...", "tags":["..."], "has_attachment":false}
+# stdout: {"add_tags":["label1"], "remove_tags":["label2"]}
 #
-# Exec hook example:
-#   The command receives email data as JSON on stdin:
-#     {"from":"...", "to":"...", "subject":"...", "body":"...", "account":"...", "tags":["..."], "has_attachment":false}
-#   It should output tag operations as JSON on stdout:
-#     {"add_tags":["label1"], "remove_tags":["label2"]}
-#   Non-zero exit = error (rule skipped, static add_tags/remove_tags used as fallback).
+# Non-zero exit = error (rule skipped, static add_tags/remove_tags
+# used as fallback if set).
 
 # [[rules]]
 # name = "ML Classifier"
-# match = "*"
-# exec = "durian-classify"
-# exec_timeout = 5
-# accounts = ["work", "uni"]
+# match = "*"                              # Wildcard: matches every email
+# exec = "durian-classify"                 # Command in PATH (or full path)
+# exec_timeout = 5                         # Seconds (default: 10)
+# accounts = ["work", "uni"]              # Optional: limit to accounts
+# allowed_tags = ["finance", "spam", "newsletter"]  # Optional: restrict exec output tags
+
+# ── Match syntax reference ────────────────────────────────────────────
+#   *                         — wildcard, matches everything
+#   from:value                — case-insensitive contains on sender
+#   to:value                  — case-insensitive contains on recipients
+#   subject:value             — case-insensitive contains on subject
+#   header:Name:value         — case-insensitive contains on any header
+#   has:attachment            — message has at least one attachment
+#   bare words                — case-insensitive contains on subject + body
+#   AND (implicit)            — adjacent terms are ANDed
+#   OR                        — explicit OR
+#   NOT                       — negates the next term
+#   ( )                       — grouping
+#
+# Optional fields:
+#   accounts = ["alias"]      — only apply to specific accounts
+#   exec = "command"          — run external command
+#   exec_timeout = 10         — exec timeout in seconds (default: 10)
+#   allowed_tags = [...]      — restrict exec output to these tags only

--- a/docs/rules-example.toml
+++ b/docs/rules-example.toml
@@ -43,3 +43,19 @@ add_tags = ["bounce"]
 #
 # Optional fields:
 #   accounts = ["alias"]    — only apply this rule to specific accounts (by alias)
+#   exec = "command"        — run external command (stdin=email JSON, stdout=tag ops JSON)
+#   exec_timeout = 10       — timeout in seconds (default: 10)
+#
+# Exec hook example:
+#   The command receives email data as JSON on stdin:
+#     {"from":"...", "to":"...", "subject":"...", "body":"...", "account":"...", "tags":["..."], "has_attachment":false}
+#   It should output tag operations as JSON on stdout:
+#     {"add_tags":["label1"], "remove_tags":["label2"]}
+#   Non-zero exit = error (rule skipped, static add_tags/remove_tags used as fallback).
+
+# [[rules]]
+# name = "ML Classifier"
+# match = "*"
+# exec = "durian-classify"
+# exec_timeout = 5
+# accounts = ["work", "uni"]


### PR DESCRIPTION
## Summary

Rules can now run external commands during sync via `exec` field. Enables ML classifiers, custom taggers, or any external processing pipeline.

## Format

```toml
[[rules]]
name = "Auto-classify"
match = "*"
exec = "durian-classify"
exec_timeout = 5
accounts = ["habric"]
allowed_tags = ["finance", "newsletter", "legal", "investors"]
```

**stdin** (JSON): `{"from":"...", "subject":"...", "body":"...", "account":"...", "tags":[...], "has_attachment":false}`

**stdout** (JSON): `{"add_tags":["finance"], "remove_tags":["unread"]}`

## Features

- Per-rule configurable timeout (default 10s)
- `allowed_tags` restricts which tags exec can apply (disallowed tags logged as warning)
- Non-zero exit → warning logged, static `add_tags`/`remove_tags` used as fallback
- Wildcard match (`*`) for catch-all rules
- JSON format for future pipeline extensibility

## Test plan

- [x] `bazel test //cli/internal/imap:imap_test` — 10 new tests (exec success, input validation, empty output, failure, timeout, invalid JSON, default timeout, allowed_tags filter)
- [x] Manual: tested with Ollama LLM classifier against real habric emails