### PR TITLE
refactor(swift-ui): @ObservedObject for singleton managers in ContentView

### DIFF
--- a/macos/durian/ContentView.swift
+++ b/macos/durian/ContentView.swift
@@ -26,13 +26,13 @@ enum DetailViewMode: Equatable {
 
 struct ContentView: View {
     @Environment(\.openWindow) private var openWindow
-    @StateObject private var accountManager = AccountManager.shared
-    @StateObject private var keymapsManager = KeymapsManager.shared
-    @StateObject private var keymapHandler = KeymapHandler.shared
-    @StateObject private var profileManager = ProfileManager.shared
-    @StateObject private var syncManager = SyncManager.shared
-    @StateObject private var networkMonitor = NetworkMonitor.shared
-    @StateObject private var bannerManager = BannerManager.shared
+    @ObservedObject private var accountManager = AccountManager.shared
+    @ObservedObject private var keymapsManager = KeymapsManager.shared
+    @ObservedObject private var keymapHandler = KeymapHandler.shared
+    @ObservedObject private var profileManager = ProfileManager.shared
+    @ObservedObject private var syncManager = SyncManager.shared
+    @ObservedObject private var networkMonitor = NetworkMonitor.shared
+    @ObservedObject private var bannerManager = BannerManager.shared
     @State private var selectedTagID: String? = "inbox"
     @State private var cursorEmailId: String? = nil       // Highlighted email (cursor position)
     @State private var markedEmails: Set<String> = []     // Marked emails (selection for batch ops)


### PR DESCRIPTION
## Summary
- Replace `@StateObject` with `@ObservedObject` for the 7 singleton manager declarations in `ContentView`
- `@StateObject` is meant for view-owned objects (lifecycle managed by the view); `.shared` singletons live independently and should be observed, not owned
- `DurianApp` (App struct) intentionally keeps `@StateObject` since App lifecycle == process lifecycle

## Why now
Code-quality review flagged this as the highest-priority quick win — fixes a subtle ownership-semantics bug that doesn't crash today but can cause unexpected behavior on view recreations.

## Out of scope (follow-up)
Same anti-pattern exists in `ComposeWindow.swift:16-18` and `ComposeForm.swift:18` — separate PR.

## Test plan
- [x] `bazel build //macos:Durian` passes
- [x] `bazel test //macos:ci_sync_manager_test //macos:ci_banner_manager_test //macos:ci_model_test //macos:ci_outbox_manager_test //macos:ci_search_manager_test //macos:ci_config_test` all pass
- [x] Manual: account switching, sync status, banner display, profile switch, accent color
- Note: `ci_profile_test` failure (`testResolvedAccentColor_NoProfileColor`) is pre-existing on `main` from #158, unrelated to this change