### PR TITLE
test(swift-keymaps): add KeyBuffer and SequenceMatcher coverage

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -60,7 +60,7 @@ jobs:
           restore-keys: bazel-gui-
 
       - name: Test
-        run: bazel test //macos:ci_config_test //macos:ci_profile_test //macos:ci_banner_manager_test //macos:ci_model_test //macos:ci_sync_manager_test //macos:ci_search_manager_test //macos:ci_outbox_manager_test //macos:ci_contacts_manager_test //macos:ci_email_sending_test //macos:ci_account_manager_test --test_output=errors
+        run: bazel test //macos:ci_config_test //macos:ci_profile_test //macos:ci_banner_manager_test //macos:ci_model_test //macos:ci_sync_manager_test //macos:ci_search_manager_test //macos:ci_outbox_manager_test //macos:ci_contacts_manager_test //macos:ci_email_sending_test //macos:ci_account_manager_test //macos:ci_key_buffer_test //macos:ci_sequence_matcher_test --test_output=errors
 
   linux:
     name: Linux GUI (Qt)

--- a/macos/BUILD.bazel
+++ b/macos/BUILD.bazel
@@ -223,6 +223,36 @@ swift_test(
     deps = [":durian_core"],
 )
 
+swift_test(
+    name = "key_buffer_test",
+    size = "small",
+    srcs = ["tests/KeyBufferTests.swift"],
+    deps = [":durian_testlib"],
+)
+
+swift_test(
+    name = "ci_key_buffer_test",
+    size = "small",
+    srcs = ["tests/KeyBufferTests.swift"],
+    tags = ["ci"],
+    deps = [":durian_core"],
+)
+
+swift_test(
+    name = "sequence_matcher_test",
+    size = "small",
+    srcs = ["tests/SequenceMatcherTests.swift"],
+    deps = [":durian_testlib"],
+)
+
+swift_test(
+    name = "ci_sequence_matcher_test",
+    size = "small",
+    srcs = ["tests/SequenceMatcherTests.swift"],
+    tags = ["ci"],
+    deps = [":durian_core"],
+)
+
 genrule(
     name = "StampedInfoPlist",
     srcs = ["Info.plist"],

--- a/macos/tests/KeyBufferTests.swift
+++ b/macos/tests/KeyBufferTests.swift
@@ -1,0 +1,137 @@
+import XCTest
+@testable import durian_lib
+
+@MainActor
+final class KeyBufferTests: XCTestCase {
+
+    // MARK: - Initial State
+
+    func testInitialBufferIsEmpty() {
+        let buffer = KeyBuffer()
+        XCTAssertTrue(buffer.isEmpty)
+        XCTAssertEqual(buffer.count, 0)
+        XCTAssertEqual(buffer.asString, "")
+        XCTAssertNil(buffer.countPrefix)
+        XCTAssertFalse(buffer.isCountOnly)
+    }
+
+    // MARK: - Append + Clear
+
+    func testAppendSingleKey() {
+        let buffer = KeyBuffer()
+        buffer.append(key: "j")
+        XCTAssertFalse(buffer.isEmpty)
+        XCTAssertEqual(buffer.count, 1)
+        XCTAssertEqual(buffer.asString, "j")
+    }
+
+    func testAppendMultipleKeys() {
+        let buffer = KeyBuffer()
+        buffer.append(key: "g")
+        buffer.append(key: "g")
+        XCTAssertEqual(buffer.count, 2)
+        XCTAssertEqual(buffer.asString, "gg")
+    }
+
+    func testClearResetsBuffer() {
+        let buffer = KeyBuffer()
+        buffer.append(key: "5")
+        buffer.append(key: "j")
+        buffer.clear()
+        XCTAssertTrue(buffer.isEmpty)
+        XCTAssertEqual(buffer.asString, "")
+        XCTAssertEqual(buffer.displayString, "")
+    }
+
+    // MARK: - Count Prefix Parsing
+
+    func testNoCountPrefixForPureSequence() {
+        let buffer = KeyBuffer()
+        buffer.append(key: "g")
+        buffer.append(key: "g")
+        XCTAssertNil(buffer.countPrefix)
+        XCTAssertEqual(buffer.sequenceWithoutCount, "gg")
+    }
+
+    func testSingleDigitCountPrefix() {
+        let buffer = KeyBuffer()
+        buffer.append(key: "5")
+        buffer.append(key: "j")
+        XCTAssertEqual(buffer.countPrefix, 5)
+        XCTAssertEqual(buffer.sequenceWithoutCount, "j")
+    }
+
+    func testMultiDigitCountPrefix() {
+        let buffer = KeyBuffer()
+        for ch in "12" { buffer.append(key: String(ch)) }
+        buffer.append(key: "g")
+        buffer.append(key: "g")
+        XCTAssertEqual(buffer.countPrefix, 12)
+        XCTAssertEqual(buffer.sequenceWithoutCount, "gg")
+    }
+
+    func testCountPrefixOnlyLeadingDigits() {
+        // "5j3k" should be count=5, sequence="j3k" — only leading digits are count
+        let buffer = KeyBuffer()
+        buffer.append(key: "5")
+        buffer.append(key: "j")
+        buffer.append(key: "3")
+        buffer.append(key: "k")
+        XCTAssertEqual(buffer.countPrefix, 5)
+        XCTAssertEqual(buffer.sequenceWithoutCount, "j3k")
+    }
+
+    // MARK: - isCountOnly
+
+    func testIsCountOnlyWithDigitsOnly() {
+        let buffer = KeyBuffer()
+        buffer.append(key: "5")
+        XCTAssertTrue(buffer.isCountOnly)
+    }
+
+    func testIsCountOnlyWithMultipleDigits() {
+        let buffer = KeyBuffer()
+        buffer.append(key: "1")
+        buffer.append(key: "2")
+        XCTAssertTrue(buffer.isCountOnly)
+    }
+
+    func testIsCountOnlyFalseWhenSequenceFollows() {
+        let buffer = KeyBuffer()
+        buffer.append(key: "5")
+        buffer.append(key: "j")
+        XCTAssertFalse(buffer.isCountOnly)
+    }
+
+    func testIsCountOnlyFalseForEmptyBuffer() {
+        let buffer = KeyBuffer()
+        XCTAssertFalse(buffer.isCountOnly)
+    }
+
+    // MARK: - Display String
+
+    func testDisplayStringUpdatesOnAppend() {
+        let buffer = KeyBuffer()
+        XCTAssertEqual(buffer.displayString, "")
+        buffer.append(key: "d")
+        XCTAssertEqual(buffer.displayString, "d")
+        buffer.append(key: "d")
+        XCTAssertEqual(buffer.displayString, "dd")
+    }
+
+    // MARK: - KeyEvent append (modifier-aware)
+
+    func testAppendKeyEventWithCtrlModifier() {
+        let buffer = KeyBuffer()
+        let event = KeyEvent(key: "d", modifiers: [.ctrl])
+        buffer.append(event)
+        XCTAssertEqual(buffer.asString, "ctrl+d")
+    }
+
+    func testShiftedLetterBecomesUppercase() {
+        let buffer = KeyBuffer()
+        let event = KeyEvent(key: "g", modifiers: [.shift])
+        buffer.append(event)
+        XCTAssertEqual(buffer.asString, "G")
+    }
+}

--- a/macos/tests/SequenceMatcherTests.swift
+++ b/macos/tests/SequenceMatcherTests.swift
@@ -1,0 +1,163 @@
+import XCTest
+@testable import durian_lib
+
+@MainActor
+final class SequenceMatcherTests: XCTestCase {
+
+    /// Inject a curated set of test keymaps into the shared KeymapsManager
+    /// and trigger a SequenceMatcher reload. Runs before each test so state
+    /// is deterministic across tests.
+    override func setUp() {
+        super.setUp()
+
+        let entries: [KeymapEntry] = [
+            // List context
+            .init(action: "next_email", key: "j", modifiers: [], description: "",
+                  enabled: true, sequence: false, supportsCount: true, context: "list"),
+            .init(action: "prev_email", key: "k", modifiers: [], description: "",
+                  enabled: true, sequence: false, supportsCount: true, context: "list"),
+            .init(action: "first_email", key: "gg", modifiers: [], description: "",
+                  enabled: true, sequence: true, supportsCount: false, context: "list"),
+            .init(action: "go_inbox", key: "gi", modifiers: [], description: "",
+                  enabled: true, sequence: true, supportsCount: false, context: "list"),
+            .init(action: "delete", key: "dd", modifiers: [], description: "",
+                  enabled: true, sequence: true, supportsCount: true, context: "list"),
+            .init(action: "page_down", key: "d", modifiers: ["ctrl"], description: "",
+                  enabled: true, sequence: false, supportsCount: true, context: "list"),
+            .init(action: "compose", key: "c", modifiers: [], description: "",
+                  enabled: true, sequence: false, supportsCount: false, context: "list"),
+            // Thread context (to verify context isolation)
+            .init(action: "reply", key: "r", modifiers: [], description: "",
+                  enabled: true, sequence: false, supportsCount: false, context: "thread"),
+            // Disabled entry (should be ignored)
+            .init(action: "archive", key: "a", modifiers: [], description: "",
+                  enabled: false, sequence: false, supportsCount: false, context: "list"),
+        ]
+
+        KeymapsManager.shared.keymaps = KeymapConfig()
+        KeymapsManager.shared.keymaps.keymaps = entries
+        SequenceMatcher.shared.reloadFromConfig()
+    }
+
+    // MARK: - Exact Match
+
+    func testExactSingleKeyMatch() {
+        let result = SequenceMatcher.shared.match(buffer: "j", context: .list)
+        XCTAssertEqual(result, .match(action: .nextEmail, count: 1))
+    }
+
+    func testExactMultiKeyMatch() {
+        let result = SequenceMatcher.shared.match(buffer: "gg", context: .list)
+        XCTAssertEqual(result, .match(action: .firstEmail, count: 1))
+    }
+
+    func testExactDeleteSequence() {
+        let result = SequenceMatcher.shared.match(buffer: "dd", context: .list)
+        XCTAssertEqual(result, .match(action: .deleteEmail, count: 1))
+    }
+
+    // MARK: - Partial Match
+
+    func testPartialMatchForSharedPrefix() {
+        // "g" is a prefix of both "gg" and "gi" — must return partial
+        let result = SequenceMatcher.shared.match(buffer: "g", context: .list)
+        XCTAssertEqual(result, .partial)
+    }
+
+    func testPartialMatchForDd() {
+        // "d" alone — but wait, "d" with ctrl is page_down (ctrl+d).
+        // Plain "d" is only a prefix of "dd" → partial.
+        let result = SequenceMatcher.shared.match(buffer: "d", context: .list)
+        XCTAssertEqual(result, .partial)
+    }
+
+    // MARK: - No Match
+
+    func testEmptyBufferIsNoMatch() {
+        let result = SequenceMatcher.shared.match(buffer: "", context: .list)
+        XCTAssertEqual(result, .noMatch)
+    }
+
+    func testUnknownSequenceIsNoMatch() {
+        let result = SequenceMatcher.shared.match(buffer: "xyz", context: .list)
+        XCTAssertEqual(result, .noMatch)
+    }
+
+    func testDisabledEntryNotMatched() {
+        // "a" is archive but disabled in setUp — should not match
+        let result = SequenceMatcher.shared.match(buffer: "a", context: .list)
+        XCTAssertEqual(result, .noMatch)
+    }
+
+    // MARK: - Count Prefix
+
+    func testSingleDigitCountWithAction() {
+        let result = SequenceMatcher.shared.match(buffer: "5j", context: .list)
+        XCTAssertEqual(result, .match(action: .nextEmail, count: 5))
+    }
+
+    func testMultiDigitCount() {
+        let result = SequenceMatcher.shared.match(buffer: "12j", context: .list)
+        XCTAssertEqual(result, .match(action: .nextEmail, count: 12))
+    }
+
+    func testCountWithMultiKeySequence() {
+        let result = SequenceMatcher.shared.match(buffer: "3dd", context: .list)
+        XCTAssertEqual(result, .match(action: .deleteEmail, count: 3))
+    }
+
+    func testCountOnlyIsPartial() {
+        // Pure digits → waiting for action
+        let result = SequenceMatcher.shared.match(buffer: "5", context: .list)
+        XCTAssertEqual(result, .partial)
+    }
+
+    func testCountIgnoredWhenActionDoesNotSupportIt() {
+        // `compose` has supportsCount=false → count is forced to 1
+        let result = SequenceMatcher.shared.match(buffer: "5c", context: .list)
+        XCTAssertEqual(result, .match(action: .compose, count: 1))
+    }
+
+    func testCountIgnoredForFirstEmail() {
+        // `first_email` (gg) has supportsCount=false
+        let result = SequenceMatcher.shared.match(buffer: "5gg", context: .list)
+        XCTAssertEqual(result, .match(action: .firstEmail, count: 1))
+    }
+
+    // MARK: - Ctrl Modifier Matching
+
+    func testCtrlModifierMatch() {
+        // "ctrl+d" is normalized form for Ctrl+d → page_down
+        let result = SequenceMatcher.shared.match(buffer: "ctrl+d", context: .list)
+        XCTAssertEqual(result, .match(action: .pageDown, count: 1))
+    }
+
+    func testCtrlWithCount() {
+        let result = SequenceMatcher.shared.match(buffer: "3ctrl+d", context: .list)
+        XCTAssertEqual(result, .match(action: .pageDown, count: 3))
+    }
+
+    // MARK: - Context Isolation
+
+    func testContextSpecificMatch() {
+        // "r" is only defined in .thread context
+        let result = SequenceMatcher.shared.match(buffer: "r", context: .thread)
+        XCTAssertEqual(result, .match(action: .reply, count: 1))
+    }
+
+    func testContextDoesNotLeakIntoList() {
+        // "r" is NOT defined in .list context
+        let result = SequenceMatcher.shared.match(buffer: "r", context: .list)
+        XCTAssertEqual(result, .noMatch)
+    }
+
+    // MARK: - supportsCount API
+
+    func testSupportsCountReturnsTrueForNextEmail() {
+        XCTAssertTrue(SequenceMatcher.shared.supportsCount(.nextEmail, context: .list))
+    }
+
+    func testSupportsCountReturnsFalseForCompose() {
+        XCTAssertFalse(SequenceMatcher.shared.supportsCount(.compose, context: .list))
+    }
+}

--- a/macos/tests/SyncManagerTests.swift
+++ b/macos/tests/SyncManagerTests.swift
@@ -51,4 +51,26 @@ final class SyncManagerTests: XCTestCase {
         XCTAssertNotEqual(SyncState.failed("a"), SyncState.failed("b"))
         XCTAssertNotEqual(SyncState.idle, SyncState.syncing)
     }
+
+    // MARK: - SyncManager Singleton Contract
+
+    func testSharedReturnsSameInstance() {
+        XCTAssertTrue(SyncManager.shared === SyncManager.shared)
+    }
+
+    func testIsSyncingFalseWhenIdle() {
+        // When state is idle, no sync is in progress
+        XCTAssertFalse(SyncManager.shared.syncState == .syncing)
+    }
+
+    func testStopTimersDoesNotCrash() {
+        // stopTimers() should be idempotent and safe to call without setup
+        SyncManager.shared.stopTimers()
+        SyncManager.shared.stopTimers()  // Called twice — must not crash
+    }
+
+    // Note: Deeper SyncManager coverage (concurrent sync lock behavior,
+    // consecutiveFailures threshold, banner suppression) requires
+    // dependency injection for NetworkMonitor / ConfigManager /
+    // ProfileManager / runDurianSync. That's a separate refactor.
 }


### PR DESCRIPTION
## Summary

Adds 35 new unit tests for the vim keymap engine that drives all keyboard shortcuts in the GUI. Previously the keymap layer had zero test coverage.

### `KeyBufferTests.swift` (16 cases)
- Count prefix parsing (`5j`, `12gg`, `5j3k` → only leading digits count)
- `isCountOnly` detection (pure digits → true)
- `clear()` / `append()` semantics
- Ctrl/Shift modifier normalization (`ctrl+d`, `G` from `Shift+g`)

### `SequenceMatcherTests.swift` (19 cases)
- Exact match (`j`, `gg`, `dd`)
- Partial match for shared prefixes (`g` → partial because both `gg` and `gi` exist)
- Count support per action (`5j` → count=5 if `supportsCount=true`, else forced to 1)
- Multi-digit counts (`12j` → count=12)
- Context isolation (`r` matches in `thread` but not `list`)
- Disabled entries are ignored
- Ctrl+d normalized to `ctrl+d` in match lookup
- `supportsCount(action:)` API

### `SyncManagerTests.swift` (3 additions)
- Singleton contract (`.shared === .shared`)
- Idempotent `stopTimers()`
- Idle state sanity check

Deeper SyncManager coverage (concurrent sync lock, consecutiveFailures threshold, banner suppression) requires dependency injection for `NetworkMonitor` / `ConfigManager` / `ProfileManager` / `runDurianSync` — intentionally out of scope.

## Test plan

- [x] `bazel test //macos:key_buffer_test //macos:sequence_matcher_test //macos:sync_manager_test` — all pass
- [x] `bazel test //macos:ci_key_buffer_test //macos:ci_sequence_matcher_test //macos:ci_sync_manager_test` — all pass
- [x] CI workflow (`test.yml`) updated to include both new `ci_*` targets