### PR TITLE
refactor(go-handler): dedup convertThread / convertThreadLight

### DIFF
--- a/cli/internal/handler/convert_thread_test.go
+++ b/cli/internal/handler/convert_thread_test.go
@@ -385,6 +385,79 @@ func TestConvertThread_MixedHTMLAndPlaintext(t *testing.T) {
 	}
 }
 
+// --- Light mode (used for search enrichment) ---
+
+func TestConvertThread_LightOmitsHTMLAndReplyHeaders(t *testing.T) {
+	db := newTestStore(t)
+	now := time.Now().Unix()
+
+	seedThreadMessage(t, db, &store.Message{
+		MessageID: "light@test", Subject: "Light",
+		FromAddr:  "a@example.com",
+		InReplyTo: "<prev@test>",
+		Refs:      "<prev@test>",
+		Date:      now, CreatedAt: now,
+		BodyText: "plain body",
+		BodyHTML: "<p>html body</p>",
+		Mailbox:  "INBOX",
+	})
+
+	m, _ := db.GetByMessageID("light@test")
+	msgs, _ := db.GetByThread(m.ThreadID)
+	h := New(db, nil)
+
+	thread := h.convertThread(m.ThreadID, msgs, true)
+	if len(thread.Messages) != 1 {
+		t.Fatalf("expected 1 message, got %d", len(thread.Messages))
+	}
+	msg := thread.Messages[0]
+
+	// Light mode: Body is preserved
+	if msg.Body != "plain body" {
+		t.Errorf("Body = %q, want %q", msg.Body, "plain body")
+	}
+	// Light mode: HTML is omitted
+	if msg.HTML != "" {
+		t.Errorf("HTML should be empty in light mode, got %q", msg.HTML)
+	}
+	// Light mode: reply headers are omitted
+	if msg.InReplyTo != "" {
+		t.Errorf("InReplyTo should be empty in light mode, got %q", msg.InReplyTo)
+	}
+	if msg.References != "" {
+		t.Errorf("References should be empty in light mode, got %q", msg.References)
+	}
+}
+
+func TestConvertThread_LightKeepsTagsAndAttachments(t *testing.T) {
+	db := newTestStore(t)
+	now := time.Now().Unix()
+
+	m := seedThreadMessage(t, db, &store.Message{
+		MessageID: "lightatts@test", Subject: "With stuff",
+		FromAddr: "a@example.com", Date: now, CreatedAt: now,
+		BodyText: "hello", Mailbox: "INBOX",
+	})
+	db.AddTag(m.ID, "inbox")
+	db.InsertAttachment(&store.Attachment{
+		MessageDBID: m.ID, PartID: 1,
+		Filename: "doc.pdf", ContentType: "application/pdf",
+		Size: 1024, Disposition: "attachment",
+	})
+
+	msgs, _ := db.GetByThread(m.ThreadID)
+	h := New(db, nil)
+	thread := h.convertThread(m.ThreadID, msgs, true)
+
+	if len(thread.Messages[0].Tags) == 0 {
+		t.Error("light mode should still populate tags")
+	}
+	if len(thread.Messages[0].Attachments) != 1 {
+		t.Errorf("light mode should still populate attachments, got %d",
+			len(thread.Messages[0].Attachments))
+	}
+}
+
 // --- ThreadID propagation ---
 
 func TestConvertThread_ThreadIDPropagated(t *testing.T) {

--- a/cli/internal/handler/search.go
+++ b/cli/internal/handler/search.go
@@ -47,7 +47,7 @@ func (h *Handler) Search(query string, limit int, enrichLimit int) protocol.Resp
 		if err != nil || len(msgs) == 0 {
 			continue
 		}
-		threads[r.Thread] = h.convertThreadLight(r.Thread, msgs)
+		threads[r.Thread] = h.convertThread(r.Thread, msgs, true)
 	}
 
 	return protocol.SuccessWithResultsAndThreads(mails, threads)

--- a/cli/internal/handler/show.go
+++ b/cli/internal/handler/show.go
@@ -43,7 +43,7 @@ func (h *Handler) ShowThread(threadID string) protocol.Response {
 		return protocol.Fail(protocol.ErrNotFound, errors.New("no messages found for thread"))
 	}
 
-	thread := h.convertThread(threadID, msgs)
+	thread := h.convertThread(threadID, msgs, false)
 	return protocol.SuccessWithThread(thread)
 }
 
@@ -64,24 +64,29 @@ func (h *Handler) ShowMessageBody(messageID string) protocol.Response {
 	})
 }
 
-// convertThread converts store messages into ThreadContent format.
-func (h *Handler) convertThread(threadID string, msgs []*store.Message) *internmail.ThreadContent {
+// convertThread converts store messages into ThreadContent format, sorted
+// newest-first. When light=true, HTML and reply headers (InReplyTo,
+// References) are omitted — used by search enrichment to keep response
+// size small; the full thread is loaded on demand via /threads/{id}.
+func (h *Handler) convertThread(threadID string, msgs []*store.Message, light bool) *internmail.ThreadContent {
 	messages := make([]internmail.MessageInfo, 0, len(msgs))
 	var subject string
 
 	for _, msg := range msgs {
 		info := internmail.MessageInfo{
-			ID:         msg.MessageID,
-			From:       msg.FromAddr,
-			To:         msg.ToAddrs,
-			CC:         msg.CCAddrs,
-			Date:       time.Unix(msg.Date, 0).Format(time.RFC1123Z),
-			Timestamp:  msg.Date,
-			MessageID:  msg.MessageID,
-			InReplyTo:  msg.InReplyTo,
-			References: msg.Refs,
-			Body:       msg.BodyText,
-			HTML:       sanitize.StripQuotedContent(msg.BodyHTML),
+			ID:        msg.MessageID,
+			From:      msg.FromAddr,
+			To:        msg.ToAddrs,
+			CC:        msg.CCAddrs,
+			Date:      time.Unix(msg.Date, 0).Format(time.RFC1123Z),
+			Timestamp: msg.Date,
+			MessageID: msg.MessageID,
+			Body:      msg.BodyText,
+		}
+		if !light {
+			info.InReplyTo = msg.InReplyTo
+			info.References = msg.Refs
+			info.HTML = sanitize.StripQuotedContent(msg.BodyHTML)
 		}
 
 		if subject == "" {
@@ -109,60 +114,6 @@ func (h *Handler) convertThread(threadID string, msgs []*store.Message) *internm
 	}
 
 	// Sort newest first
-	sort.Slice(messages, func(i, j int) bool {
-		return messages[i].Timestamp > messages[j].Timestamp
-	})
-
-	return &internmail.ThreadContent{
-		ThreadID: threadID,
-		Subject:  subject,
-		Messages: messages,
-	}
-}
-
-// convertThreadLight creates a lightweight thread for search enrichment.
-// Bodies are trimmed to 200 chars plaintext, no HTML. This reduces search
-// response size by ~95% compared to full thread content.
-func (h *Handler) convertThreadLight(threadID string, msgs []*store.Message) *internmail.ThreadContent {
-	messages := make([]internmail.MessageInfo, 0, len(msgs))
-	var subject string
-
-	for _, msg := range msgs {
-		info := internmail.MessageInfo{
-			ID:        msg.MessageID,
-			From:      msg.FromAddr,
-			To:        msg.ToAddrs,
-			CC:        msg.CCAddrs,
-			Date:      time.Unix(msg.Date, 0).Format(time.RFC1123Z),
-			Timestamp: msg.Date,
-			MessageID: msg.MessageID,
-			Body:      msg.BodyText,
-			// HTML omitted — loaded on thread click via /threads/{id}
-		}
-
-		if subject == "" {
-			subject = msg.Subject
-		}
-
-		if tags, err := h.store.GetMessageTags(msg.ID); err == nil {
-			info.Tags = tags
-		}
-		if atts, err := h.store.GetAttachmentsByMessage(msg.ID); err == nil {
-			for _, a := range atts {
-				info.Attachments = append(info.Attachments, internmail.AttachmentInfo{
-					PartID:      a.PartID,
-					Filename:    a.Filename,
-					ContentType: a.ContentType,
-					Size:        a.Size,
-					Disposition: a.Disposition,
-					ContentID:   a.ContentID,
-				})
-			}
-		}
-
-		messages = append(messages, info)
-	}
-
 	sort.Slice(messages, func(i, j int) bool {
 		return messages[i].Timestamp > messages[j].Timestamp
 	})


### PR DESCRIPTION
## Summary

`convertThread` and `convertThreadLight` in `cli/internal/handler/show.go` were ~90% duplicated. The only differences:

| | `convertThread` | `convertThreadLight` |
|---|---|---|
| `HTML` (quote-stripped) | ✅ | ❌ |
| `InReplyTo` / `References` | ✅ | ❌ |
| Tags / Attachments / Sort / Subject | ✅ | ✅ |

Merged into a single `convertThread(threadID, msgs, light bool)`. When `light=true`, the optional fields are skipped — this is used by the search path to keep response size small (the full thread is loaded on demand via `/threads/{id}`).

## Changes

- `cli/internal/handler/show.go`: two functions (~105 lines) → one function (~55 lines). File drops from 219 to 169 lines.
- `cli/internal/handler/search.go`: one-line call site update
- `cli/internal/handler/convert_thread_test.go`: two new tests for `light=true` — previously the light path had zero direct coverage (only exercised end-to-end via the search handler)

## Test plan

- [x] `bazel test //cli/internal/handler:handler_test` — passes (including new light tests)
- [x] `bazel test //cli/...` — all 15 CLI test targets pass
- [x] Existing `convert_thread_test.go` tests (ordering, field mapping, quote stripping, tags, attachments) still pass — they exercise the `light=false` path