### PR TITLE
fix(swift): sync timeout force-unwrap + ConfigManager lock

### DIFF
--- a/macos/durian/Managers/ConfigManager.swift
+++ b/macos/durian/Managers/ConfigManager.swift
@@ -98,15 +98,34 @@ struct AppConfig: Codable {
 
 class ConfigManager {
     static let shared = ConfigManager()
-    private var config: AppConfig?
-    
+
+    // The config is accessed from many contexts (Views on MainActor, but also
+    // background Tasks in AccountManager/DraftService). An NSLock guards the
+    // stored value so concurrent reads/writes are race-free without forcing
+    // @MainActor on every call site.
+    private let lock = NSLock()
+    private var _config: AppConfig?
+
+    private var config: AppConfig? {
+        get {
+            lock.lock()
+            defer { lock.unlock() }
+            return _config
+        }
+        set {
+            lock.lock()
+            defer { lock.unlock() }
+            _config = newValue
+        }
+    }
+
     init() {
         loadConfig()
     }
 
     /// Test-only initializer: inject config directly, skip file loading
     init(config: AppConfig) {
-        self.config = config
+        self._config = config
     }
     
     private func loadConfig() {

--- a/macos/durian/Managers/SyncManager.swift
+++ b/macos/durian/Managers/SyncManager.swift
@@ -540,24 +540,22 @@ class SyncManager: ObservableObject {
                 process.standardError = errorPipe
                 
                 // Set up timeout
-                var timeoutWorkItem: DispatchWorkItem?
                 var didTimeout = false
-                
-                timeoutWorkItem = DispatchWorkItem {
+                let timeoutWorkItem = DispatchWorkItem {
                     if process.isRunning {
                         Log.error("SYNC", "Command timed out after \(timeout)s, terminating process")
                         didTimeout = true
                         process.terminate()
                     }
                 }
-                DispatchQueue.global().asyncAfter(deadline: .now() + timeout, execute: timeoutWorkItem!)
+                DispatchQueue.global().asyncAfter(deadline: .now() + timeout, execute: timeoutWorkItem)
                 
                 do {
                     try process.run()
                     process.waitUntilExit()
                     
                     // Cancel timeout timer if process completed
-                    timeoutWorkItem?.cancel()
+                    timeoutWorkItem.cancel()
                     
                     if didTimeout {
                         continuation.resume(returning: CommandResult(
@@ -577,7 +575,7 @@ class SyncManager: ObservableObject {
                     let success = process.terminationStatus == 0
                     continuation.resume(returning: CommandResult(success: success, output: output, error: error))
                 } catch {
-                    timeoutWorkItem?.cancel()
+                    timeoutWorkItem.cancel()
                     continuation.resume(returning: CommandResult(success: false, output: nil, error: error.localizedDescription))
                 }
             }


### PR DESCRIPTION
## Summary

Two small safety fixes flagged in the latest code-quality review:

### 1. SyncManager.runCommand force-unwrap
`timeoutWorkItem` was declared as `var timeoutWorkItem: DispatchWorkItem?` then force-unwrapped at the scheduling call site (`execute: timeoutWorkItem!`). In a critical timeout path this is unsafe — if the closure construction ever fails or reorders, it crashes the CLI bridge.

Fix: declare as `let timeoutWorkItem = DispatchWorkItem { ... }` (non-optional from construction) and switch the two `.cancel()` call sites to non-optional form.

### 2. ConfigManager concurrent access
`ConfigManager.config` is a stored property that's read/written from many contexts:
- SwiftUI Views on MainActor (via `ConfigManager.shared.getAccounts()`)
- Background Tasks in `AccountManager` / `DraftService`
- `SyncManager` (which is `@MainActor` but its internals dispatch off-main)

Previously unsynchronized — potential data race.

Fix: Wrapped the stored property access behind an `NSLock`. Chose the lock approach over `@MainActor` annotation because adding `@MainActor` to `ConfigManager` would cascade into `SettingsManager`, `DraftService`, and several other call sites — out of scope for a quick fix.

## Test plan

- [x] `bazel build //macos:Durian` passes
- [x] 8 CI test targets pass (banner, config, model, key_buffer, sequence_matcher, outbox, search, sync_manager)
- [x] Manual: config loads normally on app start, settings persistence works