### PR TITLE
fix(go): slog migration + validate enrich param

### DIFF
--- a/cli/internal/draft/draft.go
+++ b/cli/internal/draft/draft.go
@@ -3,6 +3,7 @@ package draft
 
 import (
 	"fmt"
+	"log/slog"
 	"time"
 
 	"github.com/emersion/go-imap"
@@ -63,7 +64,8 @@ func (s *Service) Save(msg *smtp.Message, replaceMessageID string) (*SaveResult,
 	if replaceMessageID != "" {
 		if err := s.deleteByMessageID(client, draftsMailbox, replaceMessageID); err != nil {
 			// Log but don't fail - the old draft might not exist anymore
-			fmt.Printf("Warning: failed to delete old draft: %v\n", err)
+			slog.Warn("Failed to delete old draft",
+				"module", "DRAFT", "message_id", replaceMessageID, "err", err)
 		}
 	}
 

--- a/cli/internal/handler/http.go
+++ b/cli/internal/handler/http.go
@@ -43,7 +43,12 @@ func (h *Handler) SearchHandler(w http.ResponseWriter, r *http.Request) {
 
 	var enrichLimit int
 	if enrichStr := r.URL.Query().Get("enrich"); enrichStr != "" {
-		enrichLimit, _ = strconv.Atoi(enrichStr)
+		var err error
+		enrichLimit, err = strconv.Atoi(enrichStr)
+		if err != nil {
+			http.Error(w, "Invalid enrich parameter", http.StatusBadRequest)
+			return
+		}
 	}
 
 	response := h.Search(query, limit, enrichLimit)

--- a/cli/internal/oauth/flow.go
+++ b/cli/internal/oauth/flow.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"net"
 	"net/http"
+	"os"
 	"os/exec"
 	"runtime"
 	"time"
@@ -55,15 +56,15 @@ func StartFlow(provider *Provider, clientID, redirectURI string, pkce *PKCE) (*F
 		authURL = provider.AuthorizationURL(clientID, actualRedirectURI, state, pkce)
 	}
 
-	// Open browser
-	fmt.Printf("Opening browser for authorization...\n")
-	fmt.Printf("If browser doesn't open, visit:\n%s\n\n", authURL)
+	// Open browser (user-facing CLI prompts go to stderr per CLI convention)
+	fmt.Fprintln(os.Stderr, "Opening browser for authorization...")
+	fmt.Fprintf(os.Stderr, "If browser doesn't open, visit:\n%s\n\n", authURL)
 
 	if err := openBrowser(authURL); err != nil {
-		fmt.Printf("Warning: Could not open browser automatically: %v\n", err)
+		fmt.Fprintf(os.Stderr, "Warning: Could not open browser automatically: %v\n", err)
 	}
 
-	fmt.Printf("Waiting for authorization (timeout: %v)...\n", DefaultTimeout)
+	fmt.Fprintf(os.Stderr, "Waiting for authorization (timeout: %v)...\n", DefaultTimeout)
 
 	// Wait for callback or timeout
 	select {
@@ -182,7 +183,7 @@ func startCallbackServer(expectedState string, resultChan chan *FlowResult, errC
 		}
 	}()
 
-	fmt.Printf("OAuth callback server listening on http://localhost:%d%s\n", port, CallbackPath)
+	fmt.Fprintf(os.Stderr, "OAuth callback server listening on http://localhost:%d%s\n", port, CallbackPath)
 
 	return server, port, nil
 }
@@ -229,7 +230,7 @@ func Authenticate(provider *Provider, clientID, clientSecret, email string) (*To
 	// Determine actual redirect URI (port might have changed)
 	// For now, we'll reconstruct it - in practice the server handles this
 
-	fmt.Println("Exchanging authorization code for tokens...")
+	fmt.Fprintln(os.Stderr, "Exchanging authorization code for tokens...")
 
 	// Exchange code for tokens
 	token, err := ExchangeCode(provider, clientID, clientSecret, redirectURI, result.Code, pkce.Verifier)


### PR DESCRIPTION
## Summary

Three small cleanups flagged in the latest code-quality review:

### 1. `internal/draft/draft.go:66` — background warning → slog
Was `fmt.Printf("Warning: failed to delete old draft...")`. The draft service is called from `durian serve` (background context), so diagnostic output should go through `slog.Warn` with the standard `"module"` key to land in `serve.log`, not stdout.

### 2. `internal/oauth/flow.go` — 6 interactive prompts → stderr
Had 6 `fmt.Printf` calls for interactive OAuth flow prompts ("Opening browser...", "Waiting for authorization..."). These are user-facing CLI prompts, not log events — switched to `fmt.Fprintln(os.Stderr, ...)` / `fmt.Fprintf(os.Stderr, ...)` to match the convention used in `cmd/durian/rules.go`, `auth.go`, `attachment.go`.

Note: deliberately **not** routed through slog — these are interactive prompts during `durian auth login`, and slog adds timestamp/level/JSON prefixes that would make them unreadable.

### 3. `internal/handler/http.go:46` — silent error swallow → 400
Was `enrichLimit, _ = strconv.Atoi(enrichStr)` which silently ignores parse errors and falls back to `enrichLimit=0`. Now returns `400 Bad Request` on invalid input, matching how the `?limit=...` parameter is already validated a few lines above.

## Test plan

- [x] `bazel test //cli/...` — all 15 test targets pass (including handler_test, draft_test, oauth_test)