### PR TITLE
fix(swift-ui): guard NSScrollView.documentView instead of force-unwrap

### DIFF
--- a/macos/durian/Views/EmailDetailView.swift
+++ b/macos/durian/Views/EmailDetailView.swift
@@ -68,8 +68,9 @@ struct EmailDetailView: View {
             sv.reflectScrolledClipView(sv.contentView)
         }
         .onReceive(NotificationCenter.default.publisher(for: .threadScrollToBottom)) { _ in
-            guard let sv = detailScrollView else { return }
-            let maxY = max(sv.documentView!.frame.height - sv.contentView.bounds.height, 0)
+            guard let sv = detailScrollView,
+                  let docView = sv.documentView else { return }
+            let maxY = max(docView.frame.height - sv.contentView.bounds.height, 0)
             sv.contentView.setBoundsOrigin(NSPoint(x: 0, y: maxY))
             sv.reflectScrolledClipView(sv.contentView)
         }
@@ -192,9 +193,10 @@ struct EmailDetailView: View {
     }
     
     private func scrollBy(_ delta: CGFloat) {
-        guard let sv = detailScrollView else { return }
+        guard let sv = detailScrollView,
+              let docView = sv.documentView else { return }
         let current = sv.contentView.bounds.origin
-        let maxY = max(sv.documentView!.frame.height - sv.contentView.bounds.height, 0)
+        let maxY = max(docView.frame.height - sv.contentView.bounds.height, 0)
         let newY = min(max(current.y + delta, 0), maxY)
         sv.contentView.setBoundsOrigin(NSPoint(x: current.x, y: newY))
         sv.reflectScrolledClipView(sv.contentView)


### PR DESCRIPTION
## Summary

`EmailDetailView` had two force-unwraps of `sv.documentView!` flagged in the round-3 code quality review:

- **line 72** — `threadScrollToBottom` notification handler
- **line 197** — private `scrollBy(_:)` helper used by the vim j/k scroll handlers

In practice `documentView` is always present once the thread view has rendered, but AppKit doesn't guarantee this at every notification timing — if the view is being reconfigured when a scroll notification fires, the force-unwrap crashes the whole app.

## Fix

Extended the existing `guard let sv = detailScrollView else { return }` patterns to also guard `sv.documentView`. No behavioral change when documentView is present; the handlers now silently return on the rare nil case (same as when `detailScrollView` itself is nil).

## Test plan

- [x] `bazel build //macos:Durian` passes
- [x] Manual: scrolling in thread view (j/k/gg/G), no crash on rapid email switching