### PR TITLE
doc: fix broken paths + config drift

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,8 +68,8 @@ bazel build //macos:Durian        # GUI (macOS only, debug)
 bazel build -c opt //macos:Durian # GUI (macOS only, release)
 
 ./cli/install.sh                # build & install CLI to /usr/local/bin
-./gui/install.sh                # build & install GUI to /Applications
-./gui/run.sh                    # build & run debug GUI (DurianNightly.app)
+./macos/install.sh              # build & install GUI to /Applications
+./macos/run.sh                  # build & run debug GUI (DurianNightly.app)
 ```
 
 ## Test
@@ -125,7 +125,7 @@ durian sync --debug                   # debug output on stderr
 
 - [OAuth Setup](docs/OAUTH_SETUP.md) — Gmail & Microsoft 365
 - [Password Setup](docs/PASSWORD_SETUP.md) — IMAP/SMTP with password auth
-- [Tag Sync](docs/TAG_SYNC.md) — Multi-machine tag sync via self-hosted server
+- [Tag Sync](sync/README.md) — Multi-machine tag sync via self-hosted server
 - [Vim Compose](docs/vim-compose.md) — Vim keybindings in the compose editor
 
 ## Alternatives

--- a/cli/internal/config/helpers.go
+++ b/cli/internal/config/helpers.go
@@ -311,7 +311,8 @@ func (a *AccountConfig) GetIMAPMaxMessages() int {
 	return a.IMAP.MaxMessages
 }
 
-// GetIMAPBatchSize returns the batch size for fetching, defaulting to 5000
+// GetIMAPBatchSize returns the batch size for fetching, defaulting to
+// DefaultIMAPBatchSize (100) when not configured.
 func (a *AccountConfig) GetIMAPBatchSize() int {
 	if a.IMAP.BatchSize <= 0 {
 		return DefaultIMAPBatchSize

--- a/cli/internal/config/types.go
+++ b/cli/internal/config/types.go
@@ -78,7 +78,7 @@ type IMAPConfig struct {
 	Port        int      `toml:"port"`
 	Auth        string   `toml:"auth"`         // "password" or "oauth2"
 	MaxMessages int      `toml:"max_messages"` // Default: 5000, 0 = unlimited
-	BatchSize   int      `toml:"batch_size"`   // Default: 5000
+	BatchSize   int      `toml:"batch_size"`   // Default: 100 (see DefaultIMAPBatchSize)
 	Mailboxes   []string `toml:"mailboxes"`    // Optional: specific mailboxes to sync
 }
 

--- a/docs/PASSWORD_SETUP.md
+++ b/docs/PASSWORD_SETUP.md
@@ -19,6 +19,11 @@ port = 587
 auth = "password"
 max_attachment_size = "20MB"
 
+[accounts.imap]
+host = "imap.gmx.net"
+port = 993
+auth = "password"
+
 [accounts.auth]
 username = "you@gmx.de"
 ```

--- a/docs/config-example.toml
+++ b/docs/config-example.toml
@@ -14,7 +14,7 @@ auto_fetch_interval = 120         # Quick sync interval in seconds (GUI)
 full_sync_interval = 7200         # Full sync interval in seconds (GUI)
 
 # Optional: sync tags across machines via a self-hosted sync server.
-# See docs/TAG_SYNC.md for setup instructions.
+# See sync/README.md for setup instructions.
 # [sync.tag_sync]
 # url = "http://nas:8724"         # Sync server URL (e.g. Tailnet hostname)
 # api_key = "your-secret"         # Shared API key

--- a/macos/install.sh
+++ b/macos/install.sh
@@ -7,7 +7,7 @@ INSTALL_DIR="/Applications"
 # Build first (must run as normal user, not sudo — sudo uses a different bazel cache)
 if [ "$(id -u)" -eq 0 ]; then
     echo "Error: Do not run the entire script with sudo."
-    echo "Usage: ./gui/install.sh"
+    echo "Usage: ./macos/install.sh"
     exit 1
 fi
 


### PR DESCRIPTION
## Summary

Quick-win docs fixes flagged by the docs quality review. Only the **verified** items are in this PR — several other drift claims from the review turned out to be false alarms.

| File | Fix |
|---|---|
| `README.md:128` + `docs/config-example.toml:17` | Dead link to `docs/TAG_SYNC.md` → `sync/README.md` |
| `README.md:71-72` + `macos/install.sh:10` | `./gui/install.sh` / `./gui/run.sh` → `./macos/*.sh` |
| `docs/PASSWORD_SETUP.md` | Example config was missing `[accounts.imap]` block |
| `cli/internal/config/types.go:81` + `helpers.go:314` | `BatchSize` default comment said 5000, actual `DefaultIMAPBatchSize` is 100 |

## False alarms (not in this PR)

- `gui_auto_sync` vs `auto_fetch_enabled`: example uses the Swift name (correct). Go has a dead `AutoFetchEnabled` field nobody reads at runtime.
- `load_remote_images = false` in example matches Swift's `AppSettings` default. The Go `Default()` returning `true` is dead code.
- `CLAUDE.md` was accused of the `gui/install.sh` issue but is actually already correct.

## Test plan

- [x] `bazel test //cli/internal/config:config_test` passes (verified comment-only changes don't break parsing tests)