### PR TITLE
refactor(go-config): strip dead GUI-only fields from Go structs

### DIFF
--- a/cli/internal/config/config.go
+++ b/cli/internal/config/config.go
@@ -89,16 +89,6 @@ func Exists(path string) bool {
 // Default returns an empty default config
 func Default() *Config {
 	return &Config{
-		Settings: SettingsConfig{
-			Theme:                "light",
-			NotificationsEnabled: true,
-			LoadRemoteImages:     true,
-		},
-		Sync: SyncConfig{
-			AutoFetchEnabled:  true,
-			AutoFetchInterval: 120,
-			FullSyncInterval:  7200,
-		},
 		Signatures: map[string]string{},
 		Accounts:   []AccountConfig{},
 	}

--- a/cli/internal/config/config_test.go
+++ b/cli/internal/config/config_test.go
@@ -79,24 +79,6 @@ func TestLoadValidConfig(t *testing.T) {
 		t.Fatalf("Load() error: %v", err)
 	}
 
-	// Settings
-	if cfg.Settings.Theme != "dark" {
-		t.Errorf("Settings.Theme = %q, want %q", cfg.Settings.Theme, "dark")
-	}
-	if !cfg.Settings.NotificationsEnabled {
-		t.Error("Settings.NotificationsEnabled = false, want true")
-	}
-	if cfg.Settings.LoadRemoteImages {
-		t.Error("Settings.LoadRemoteImages = true, want false")
-	}
-
-	// Sync
-	if !cfg.Sync.AutoFetchEnabled {
-		t.Error("Sync.AutoFetchEnabled = false, want true")
-	}
-	if cfg.Sync.AutoFetchInterval != 120 {
-		t.Errorf("Sync.AutoFetchInterval = %v, want %v", cfg.Sync.AutoFetchInterval, 120)
-	}
 	// Signatures
 	if len(cfg.Signatures) != 2 {
 		t.Errorf("Signatures count = %d, want 2", len(cfg.Signatures))
@@ -271,20 +253,11 @@ func TestDefault(t *testing.T) {
 	if cfg == nil {
 		t.Fatal("Default() returned nil")
 	}
-	if cfg.Settings.Theme != "light" {
-		t.Errorf("Default Settings.Theme = %q, want %q", cfg.Settings.Theme, "light")
-	}
-	if !cfg.Settings.NotificationsEnabled {
-		t.Error("Default Settings.NotificationsEnabled = false, want true")
-	}
-	if !cfg.Sync.AutoFetchEnabled {
-		t.Error("Default Sync.AutoFetchEnabled = false, want true")
-	}
-	if cfg.Sync.AutoFetchInterval != 120 {
-		t.Errorf("Default Sync.AutoFetchInterval = %v, want %v", cfg.Sync.AutoFetchInterval, 120)
-	}
 	if len(cfg.Accounts) != 0 {
 		t.Errorf("Default Accounts length = %d, want 0", len(cfg.Accounts))
+	}
+	if cfg.Signatures == nil {
+		t.Error("Default Signatures is nil")
 	}
 }
 

--- a/cli/internal/config/types.go
+++ b/cli/internal/config/types.go
@@ -9,19 +9,18 @@ type Config struct {
 	Accounts   []AccountConfig   `toml:"accounts"`
 }
 
-// SettingsConfig contains GUI-only settings (ignored by CLI)
+// SettingsConfig holds settings that `durian validate` can check before
+// the Swift GUI loads the same config file. All other GUI-only fields
+// (theme, notifications_enabled, load_remote_images, …) are parsed by
+// Swift directly and silently ignored here.
 type SettingsConfig struct {
-	Theme                string `toml:"theme"`
-	NotificationsEnabled bool   `toml:"notifications_enabled"`
-	LoadRemoteImages     bool   `toml:"load_remote_images"`
-	AccentColor          string `toml:"accent_color"` // Hex color, e.g. "#3B82F6"
+	AccentColor string `toml:"accent_color"` // Hex color, e.g. "#3B82F6"
 }
 
-// SyncConfig contains sync settings
+// SyncConfig contains sync settings consumed by the Go CLI.
+// The GUI auto-sync interval fields (gui_auto_sync, auto_fetch_interval,
+// full_sync_interval) are read by Swift directly and silently ignored here.
 type SyncConfig struct {
-	AutoFetchEnabled  bool    `toml:"auto_fetch_enabled"`
-	AutoFetchInterval float64 `toml:"auto_fetch_interval"` // seconds
-	FullSyncInterval  float64 `toml:"full_sync_interval"`  // seconds
 	// TagSync configures the optional tag sync server for multi-machine setups
 	TagSync TagSyncConfig `toml:"tag_sync"`
 }


### PR DESCRIPTION
## Summary

Closes the loose end from PR #171, which flagged several Go config fields as "parsed but never read in production". Removing them.

These fields only existed as schema placeholders for `config.toml` keys that the Swift GUI reads directly via its own `TOMLDecoder`. Since BurntSushi/toml decodes **non-strictly** and silently ignores unknown keys, the Go structs don't need to mirror GUI-only options at all.

## Removed

| Field | TOML key | Who reads it |
|---|---|---|
| `SyncConfig.AutoFetchEnabled` | `auto_fetch_enabled` | Nobody (Swift reads `gui_auto_sync`) |
| `SyncConfig.AutoFetchInterval` | `auto_fetch_interval` | Swift only (direct TOML parse) |
| `SyncConfig.FullSyncInterval` | `full_sync_interval` | Swift only |
| `SettingsConfig.Theme` | `theme` | Swift only |
| `SettingsConfig.NotificationsEnabled` | `notifications_enabled` | Swift only |
| `SettingsConfig.LoadRemoteImages` | `load_remote_images` | Swift only |

## Kept

- `SettingsConfig.AccentColor` — `validate.go:39-44` checks the hex format so `durian validate` can catch errors before the GUI loads.
- `SyncConfig.TagSync` — used by `serve`, `sync`, `tag`, `tagsync` commands.

## Notes

- `Default()` no longer sets the dead fields
- Test assertions for them removed from `config_test.go`
- `testdata/*.toml` still contain the old keys — they parse fine thanks to non-strict decoding, and now document "what Swift reads" rather than "what Go mirrors"

## Test plan

- [x] `bazel test //cli/...` — all 15 test targets pass
- [x] Verified no production references to any removed field: `grep -rn "AutoFetchEnabled\|LoadRemoteImages\|..." cli/ --include="*.go" | grep -v _test.go` returns nothing