### PR TITLE
doc: document missing options in config examples

### DIFF
--- a/docs/config-example.toml
+++ b/docs/config-example.toml
@@ -8,6 +8,10 @@ notifications_enabled = true      # Global notification toggle
 load_remote_images = false        # Block tracking pixels by default
 # accent_color = "#3B82F6"        # Optional: app-wide accent color (hex). Per-profile colors override this.
 
+# Optional: override the contacts database location.
+# [contacts]
+# db_path = "~/.config/durian/contacts.db"
+
 [sync]
 gui_auto_sync = true              # GUI auto-syncs on launch and periodically
 auto_fetch_interval = 120         # Quick sync interval in seconds (GUI)

--- a/docs/keymaps-example.toml
+++ b/docs/keymaps-example.toml
@@ -161,6 +161,11 @@ action = "toggle_selection"
 key = " "
 description = "Toggle current email in selection"
 
+[[keymaps]]
+action = "exit_visual_mode"
+key = "Escape"
+description = "Exit visual mode and keep cursor position"
+
 # ── Search Popup (context = "search") ────────────────────────────────
 # These bindings are only active when the search popup is open.
 # Arrow keys, Return, and Escape are always available (built-in).

--- a/docs/profiles-example.toml
+++ b/docs/profiles-example.toml
@@ -49,6 +49,8 @@ query = "tag:trash"
 [[profile]]
 name = "Work"
 accounts = ["work"]
+color = "#EF4444"                 # Optional: per-profile accent color (hex).
+                                  # Overrides settings.accent_color when this profile is active.
 
 [[profile.folders]]
 name = "Inbox"


### PR DESCRIPTION
## Summary

Three options exist in code but weren't in the example files.

| File | Added | Used by |
|---|---|---|
| `config-example.toml` | `[contacts] db_path` | `cli/cmd/durian/contacts.go:89` |
| `profiles-example.toml` | profile `color` field | `ProfileManager.swift resolvedAccentColor` |
| `keymaps-example.toml` | `exit_visual_mode` action | Swift keymap engine + `validate.go` |

11 lines added across 3 files.