### PR TITLE
fix(swift-search): fix ESC not restoring folder list and folder-switch race

### DIFF
--- a/macos/durian/ContentView+Keymaps.swift
+++ b/macos/durian/ContentView+Keymaps.swift
@@ -384,6 +384,15 @@ extension ContentView {
                 await MainActor.run {
                     showSearchPopup = false
                     showTagPicker = false
+                    // ESC in search popup should exit search mode entirely —
+                    // the user pressed ESC (cancel), not Enter (confirm).
+                    // Tag picker ESC should NOT exit search mode (user may
+                    // be tagging a search result and wants to return to results).
+                    if ctx == .search && isSearchMode {
+                        isSearchMode = false
+                        searchResults = []
+                        lastSearchQuery = ""
+                    }
                 }
             }
         }

--- a/macos/durian/Managers/AccountManager.swift
+++ b/macos/durian/Managers/AccountManager.swift
@@ -115,7 +115,9 @@ class AccountManager: ObservableObject {
     func selectTag(_ tag: String) async {
         guard let backend = emailBackend else { return }
         selectedFolder = tag
-        mailMessages.removeAll()
+        // Don't clear mailMessages eagerly — the old list stays visible
+        // until search() replaces it with fresh results. This avoids the
+        // blank-screen flash on rapid folder switching (gi → gs → gd).
         await backend.selectFolder(tag)
         syncFromBackend()
         await refreshFolderCounts()

--- a/macos/durian/Network/EmailBackend.swift
+++ b/macos/durian/Network/EmailBackend.swift
@@ -131,8 +131,9 @@ class EmailBackend: ObservableObject, SearchBackend, OutboxBackend {
     private var currentFolder = "inbox"
     private var currentQuery = "tag:inbox"
     
-    // Cancellation support for prefetch
+    // Cancellation support for prefetch and active search
     private var prefetchTask: Task<Void, Never>?
+    private var searchTask: Task<Void, Never>?
     private var shouldCancelPrefetch = false
 
     // Generation counter to discard stale search results on rapid folder/profile switches
@@ -262,11 +263,16 @@ class EmailBackend: ObservableObject, SearchBackend, OutboxBackend {
         shouldCancelPrefetch = true
         prefetchTask?.cancel()
         prefetchTask = nil
-        
+        searchTask?.cancel()
+
         currentFolder = name
         currentQuery = ProfileManager.shared.buildQuery(folderName: name)
         Log.debug("BACKEND", "selectFolder: \(currentQuery)")
-        await search(currentQuery)
+
+        // Wrap search in a stored Task so the next selectFolder() can cancel it
+        let task = Task { await search(currentQuery) }
+        searchTask = task
+        await task.value
     }
 
     // MARK: - Generic HTTP Request Function
@@ -410,6 +416,12 @@ class EmailBackend: ObservableObject, SearchBackend, OutboxBackend {
         }
 
         let response: DurianResponse? = await request(endpoint: endpoint)
+
+        // Cancelled by a newer selectFolder() call — bail out
+        guard !Task.isCancelled else {
+            Log.debug("BACKEND", "Search cancelled (gen \(myGeneration))")
+            return
+        }
 
         // A newer search has started — discard this stale result silently
         guard myGeneration == searchGeneration else {

--- a/macos/durian/Views/EmailListView.swift
+++ b/macos/durian/Views/EmailListView.swift
@@ -76,6 +76,9 @@ struct EmailListView: View {
             .onChange(of: emailListGeneration) { _, _ in
                 cachedItems = buildEmailList()
             }
+            .onChange(of: emails) { _, _ in
+                cachedItems = buildEmailList()
+            }
             .onAppear {
                 if cachedItems.isEmpty { cachedItems = buildEmailList() }
             }


### PR DESCRIPTION
## Summary
- **ESC exits search mode**: Pressing ESC in the search popup now fully exits search mode (clears query, results, and restores the folder view). Tag picker ESC is unaffected.
- **Folder-switch race condition**: `selectFolder()` now cancels in-flight search tasks via Swift concurrency cancellation, complementing the existing generation counter (belt-and-suspenders).
- **No blank-screen flash**: Removed eager `mailMessages.removeAll()` in `selectTag()` — the old list stays visible until fresh results arrive.
- **EmailListView cache invalidation**: Added `.onChange(of: emails)` so the cached list rebuilds when switching from search results back to folder view (root cause of the stale list bug).

## Test plan
- [x] Open search (`/`), type query, press Enter to see results, then ESC → list should return to current folder
- [x] Rapidly switch folders (`gi` → `gs` → `gd`) → no blank flash, correct folder loads
- [x] Search, view results, switch folder via sidebar → search mode exits, folder loads
- [x] Tag picker ESC during search mode → should return to search results, not exit search