### PR TITLE
fix(swift-ux): polish UX — i18n, empty states, context menu, a11y

### DIFF
--- a/macos/durian/ContentView.swift
+++ b/macos/durian/ContentView.swift
@@ -237,44 +237,7 @@ struct ContentView: View {
                 }
                 
                 if !displayEmails.isEmpty {
-                    EmailListView(
-                        emails: displayEmails,
-                        emailListGeneration: accountManager.emailListGeneration,
-                        cursorId: $cursorEmailId,
-                        selection: $markedEmails,
-                        onEmailAppear: { email in
-                            // Only prefetch body for currently selected email (avoids request storm on scroll)
-                            guard email.id == cursorEmailId else { return }
-                            switch email.bodyState {
-                            case .notLoaded, .failed:
-                                Task {
-                                    await accountManager.fetchEmailBody(id: email.id)
-                                }
-                            case .loading, .loaded:
-                                break
-                            }
-                        },
-                        onTogglePin: { emailId in
-                            Task {
-                                await accountManager.togglePin(id: emailId)
-                            }
-                        },
-                        onToggleRead: { emailId in
-                            Task {
-                                await accountManager.toggleRead(id: emailId)
-                            }
-                        },
-                        onDelete: { emailId in
-                            Task {
-                                await accountManager.deleteMessage(id: emailId)
-                                await MainActor.run {
-                                    // Clear selection after delete
-                                    markedEmails = []
-                                    detailMode = .empty
-                                }
-                            }
-                        }
-                    )
+                    emailListView
                 } else if !isSearchMode && accountManager.isLoadingEmails {
                     VStack {
                         ProgressView()
@@ -285,16 +248,13 @@ struct ContentView: View {
                     }
                     .frame(maxWidth: .infinity, minHeight: 240, maxHeight: .infinity)
                 } else {
-                    Text(isSearchMode ? "No results" : "No emails")
-                        .font(.largeTitle)
-                        .foregroundStyle(.secondary)
-                        .frame(maxWidth: .infinity, minHeight: 240, maxHeight: .infinity)
+                    emptyStateView
                 }
             }
             .navigationTitle("Durian")
             .navigationSubtitle(isSearchMode ? "Search: \(lastSearchQuery)" : accountManager.selectedFolder)
             .toolbar {
-                // Mitte: Compose + Email Aktionen
+                // Center: Compose + Email Actions
                 ToolbarItemGroup(placement: .principal) {
                     Button(action: { openNewCompose() }) {
                         Image(systemName: "square.and.pencil")
@@ -340,7 +300,7 @@ struct ContentView: View {
                     .disabled(markedEmails.isEmpty)
                 }
                 
-                // Rechts: Search & Sync
+                // Right: Search & Sync
                 ToolbarItemGroup(placement: .automatic) {
                     Button(action: { showSearchPopup = true }) {
                         Image(systemName: "magnifyingglass")
@@ -502,6 +462,86 @@ struct ContentView: View {
                           ?? searchResults.first(where: { $0.id == emailId }),
               let messages = email.threadMessages else { return 1 }
         return max(messages.count, 1)
+    }
+
+    // MARK: - Email List
+
+    private var emailListView: some View {
+        EmailListView(
+            emails: displayEmails,
+            emailListGeneration: accountManager.emailListGeneration,
+            cursorId: $cursorEmailId,
+            selection: $markedEmails,
+            onEmailAppear: { email in
+                guard email.id == cursorEmailId else { return }
+                switch email.bodyState {
+                case .notLoaded, .failed:
+                    Task { await accountManager.fetchEmailBody(id: email.id) }
+                case .loading, .loaded:
+                    break
+                }
+            },
+            onTogglePin: { emailId in
+                Task { await accountManager.togglePin(id: emailId) }
+            },
+            onToggleRead: { emailId in
+                Task { await accountManager.toggleRead(id: emailId) }
+            },
+            onDelete: { emailId in
+                Task {
+                    await accountManager.deleteMessage(id: emailId)
+                    await MainActor.run {
+                        markedEmails = []
+                        detailMode = .empty
+                    }
+                }
+            },
+            onReply: { emailId in
+                handleEmailSelection(emailId)
+                Task {
+                    await accountManager.fetchEmailBody(id: emailId)
+                    await MainActor.run { replyToSelected() }
+                }
+            },
+            onForward: { emailId in
+                handleEmailSelection(emailId)
+                Task {
+                    await accountManager.fetchEmailBody(id: emailId)
+                    await MainActor.run { forwardSelected() }
+                }
+            },
+            onShowTagPicker: { _ in
+                Task {
+                    allTags = await accountManager.fetchAllTags()
+                    showTagPicker = true
+                }
+            }
+        )
+    }
+
+    // MARK: - Empty State
+
+    @ViewBuilder
+    private var emptyStateView: some View {
+        if isSearchMode {
+            ContentUnavailableView("No Results", systemImage: "magnifyingglass",
+                                   description: Text("No emails match your search."))
+        } else if ConfigManager.shared.getAccounts().isEmpty {
+            ContentUnavailableView {
+                Label("No Accounts", systemImage: "person.crop.circle.badge.exclamationmark")
+            } description: {
+                Text("Add an account in\n~/.config/durian/config.toml\nthen run durian auth login <account>")
+            }
+        } else if syncManager.lastSyncTime == nil {
+            ContentUnavailableView {
+                Label("No Emails Yet", systemImage: "tray")
+            } description: {
+                Text("Run durian sync from the terminal to fetch your emails.")
+            }
+        } else {
+            ContentUnavailableView("No Emails", systemImage: "tray",
+                                   description: Text("This folder is empty."))
+        }
     }
 
     // MARK: - Display Emails (Search Mode vs Normal)

--- a/macos/durian/Views/AvatarView.swift
+++ b/macos/durian/Views/AvatarView.swift
@@ -38,6 +38,8 @@ struct AvatarView: View {
             }
         }
         .frame(width: size, height: size)
+        .accessibilityLabel("Avatar for \(extractDisplayName(from: name))")
+        .accessibilityHidden(true)
         .task(id: email) {
             await loadAvatarImage()
         }

--- a/macos/durian/Views/BannerView.swift
+++ b/macos/durian/Views/BannerView.swift
@@ -58,6 +58,7 @@ struct BannerView: View {
                     .foregroundStyle(.secondary)
             }
             .buttonStyle(.plain)
+            .accessibilityLabel("Dismiss")
         }
         .padding(12)
         .background(
@@ -65,5 +66,8 @@ struct BannerView: View {
                 .fill(Color(nsColor: .windowBackgroundColor))
                 .shadow(color: .black.opacity(0.2), radius: 8, y: 4)
         )
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel("\(banner.title): \(banner.message)")
+        .accessibilityAddTraits(.isStaticText)
     }
 }

--- a/macos/durian/Views/EmailDetailView.swift
+++ b/macos/durian/Views/EmailDetailView.swift
@@ -360,24 +360,24 @@ struct EmailDetailView: View {
             // Yesterday
             let formatter = DateFormatter()
             formatter.dateFormat = "HH:mm"
-            return "Gestern, \(formatter.string(from: date))"
+            return "Yesterday, \(formatter.string(from: date))"
         } else if let daysAgo = calendar.dateComponents([.day], from: date, to: now).day, daysAgo < 7 {
             // Within last week: show day name
             let formatter = DateFormatter()
-            formatter.locale = Locale(identifier: "de_DE")
+            formatter.locale = Locale(identifier: "en_US")
             formatter.dateFormat = "EEEE, HH:mm"
             return formatter.string(from: date)
         } else if calendar.component(.year, from: date) == calendar.component(.year, from: now) {
             // This year: show date without year
             let formatter = DateFormatter()
-            formatter.locale = Locale(identifier: "de_DE")
-            formatter.dateFormat = "d. MMM, HH:mm"
+            formatter.locale = Locale(identifier: "en_US")
+            formatter.dateFormat = "MMM d, HH:mm"
             return formatter.string(from: date)
         } else {
             // Older: show full date
             let formatter = DateFormatter()
-            formatter.locale = Locale(identifier: "de_DE")
-            formatter.dateFormat = "d. MMM yyyy, HH:mm"
+            formatter.locale = Locale(identifier: "en_US")
+            formatter.dateFormat = "MMM d, yyyy, HH:mm"
             return formatter.string(from: date)
         }
     }

--- a/macos/durian/Views/EmailListView.swift
+++ b/macos/durian/Views/EmailListView.swift
@@ -31,7 +31,7 @@ enum DateGrouping: Hashable, Comparable {
         case .thisWeek: return 2
         case .lastWeek: return 3
         case .month(let year, let month): 
-            // Muss > 3 sein (nach lastWeek), neuere Monate = kleinerer Wert
+            // Must be > 3 (after lastWeek), newer months = smaller value
             return 100 + (2100 - year) * 12 + (12 - month)
         }
     }
@@ -52,6 +52,9 @@ struct EmailListView: View {
     var onTogglePin: ((String) -> Void)?
     var onToggleRead: ((String) -> Void)?
     var onDelete: ((String) -> Void)?
+    var onReply: ((String) -> Void)?
+    var onForward: ((String) -> Void)?
+    var onShowTagPicker: ((String) -> Void)?
 
     @State private var cachedItems: [ListItem] = []
 
@@ -201,6 +204,21 @@ struct EmailListView: View {
                 cursorId = email.id
                 selection = [email.id]
                 onDelete?(email.id)
+            },
+            onReply: {
+                cursorId = email.id
+                selection = [email.id]
+                onReply?(email.id)
+            },
+            onForward: {
+                cursorId = email.id
+                selection = [email.id]
+                onForward?(email.id)
+            },
+            onShowTagPicker: {
+                cursorId = email.id
+                selection = [email.id]
+                onShowTagPicker?(email.id)
             }
         ))
         .id(email.id)
@@ -230,7 +248,7 @@ struct EmailListView: View {
             if groups[group] == nil { groups[group] = [] }
             groups[group]?.append(email)
         }
-        // Innerhalb jeder Gruppe nach timestamp sortieren (neueste zuerst)
+        // Sort within each group by timestamp (newest first)
         return groups.map { ($0.key, $0.value.sorted { $0.timestamp > $1.timestamp }) }
             .sorted { $0.0 < $1.0 }
     }

--- a/macos/durian/Views/EmailRowView.swift
+++ b/macos/durian/Views/EmailRowView.swift
@@ -11,6 +11,9 @@ struct EmailRowView: View, Equatable {
     var onTogglePin: (() -> Void)?
     var onToggleRead: (() -> Void)?
     var onDelete: (() -> Void)?
+    var onReply: (() -> Void)?
+    var onForward: (() -> Void)?
+    var onShowTagPicker: (() -> Void)?
 
     static func == (lhs: EmailRowView, rhs: EmailRowView) -> Bool {
         lhs.email.id == rhs.email.id &&
@@ -98,6 +101,10 @@ struct EmailRowView: View, Equatable {
             .fill(isSelected ? ProfileManager.shared.resolvedAccentColor : Color.clear)
         )
         .padding(.horizontal, 8)
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel(emailAccessibilityLabel)
+        .accessibilityAddTraits(isSelected ? .isSelected : [])
+        .accessibilityAddTraits(!email.isRead ? .isHeader : [])
         .drawingGroup()
         .contextMenu {
             Button(action: { onTogglePin?() }) {
@@ -111,22 +118,19 @@ struct EmailRowView: View, Equatable {
             
             Divider()
             
-            Button(action: {}) {
+            Button(action: { onReply?() }) {
                 Label("Reply", systemImage: "arrowshape.turn.up.left")
             }
-            .disabled(true)
-            
-            Button(action: {}) {
+
+            Button(action: { onForward?() }) {
                 Label("Forward", systemImage: "arrowshape.turn.up.right")
             }
-            .disabled(true)
-            
+
             Divider()
-            
-            Button(action: {}) {
+
+            Button(action: { onShowTagPicker?() }) {
                 Label("Tags...", systemImage: "tag")
             }
-            .disabled(true)
             
             Divider()
             
@@ -134,6 +138,21 @@ struct EmailRowView: View, Equatable {
                 Label("Delete", systemImage: "trash")
             }
         }
+    }
+
+    // MARK: - Accessibility
+
+    private var emailAccessibilityLabel: String {
+        var parts: [String] = []
+        if !email.isRead { parts.append("Unread") }
+        if email.isPinned { parts.append("Pinned") }
+        let sender = cachedCounterparties.map(\.name).joined(separator: ", ")
+        parts.append(sender.isEmpty ? Self.extractName(from: email.from) : sender)
+        parts.append(email.subject.isEmpty ? "No Subject" : email.subject)
+        parts.append(email.date)
+        if email.hasAttachment { parts.append("Has attachment") }
+        if !visibleTags.isEmpty { parts.append("Tags: \(visibleTags.joined(separator: ", "))") }
+        return parts.joined(separator: ", ")
     }
 
     // MARK: - Tag Row
@@ -353,6 +372,7 @@ private struct TruncatedTagsView: View {
                 Text("+\(result.overflow)")
                     .font(.caption2)
                     .foregroundStyle(isSelected ? Color.white.opacity(0.5) : Color.secondary)
+                    .accessibilityLabel("\(result.overflow) more tags")
             }
         }
     }

--- a/macos/durian/Views/TagChipsView.swift
+++ b/macos/durian/Views/TagChipsView.swift
@@ -40,6 +40,7 @@ struct TagChipsView: View {
                     .foregroundColor(.white.opacity(0.7))
             }
             .buttonStyle(.plain)
+            .accessibilityLabel("Remove tag \(tag)")
         }
         .padding(.horizontal, 8)
         .padding(.vertical, 4)
@@ -87,6 +88,7 @@ struct TagChipsView: View {
                     .foregroundColor(Color.Detail.textTertiary)
             }
             .buttonStyle(.plain)
+            .accessibilityLabel("Add tag")
             .padding(.horizontal, 6)
             .padding(.vertical, 4)
             .background(Color(NSColor.controlBackgroundColor))

--- a/macos/durian/Views/ThreadMessageCardView.swift
+++ b/macos/durian/Views/ThreadMessageCardView.swift
@@ -633,24 +633,24 @@ struct ThreadMessageCardView: View {
             // Yesterday
             let formatter = DateFormatter()
             formatter.dateFormat = "HH:mm"
-            return "Gestern, \(formatter.string(from: date))"
+            return "Yesterday, \(formatter.string(from: date))"
         } else if let daysAgo = calendar.dateComponents([.day], from: date, to: now).day, daysAgo < 7 {
             // Within last week: show day name
             let formatter = DateFormatter()
-            formatter.locale = Locale(identifier: "de_DE")
+            formatter.locale = Locale(identifier: "en_US")
             formatter.dateFormat = "EEEE, HH:mm"
             return formatter.string(from: date)
         } else if calendar.component(.year, from: date) == calendar.component(.year, from: now) {
             // This year: show date without year
             let formatter = DateFormatter()
-            formatter.locale = Locale(identifier: "de_DE")
-            formatter.dateFormat = "d. MMM, HH:mm"
+            formatter.locale = Locale(identifier: "en_US")
+            formatter.dateFormat = "MMM d, HH:mm"
             return formatter.string(from: date)
         } else {
             // Older: show full date
             let formatter = DateFormatter()
-            formatter.locale = Locale(identifier: "de_DE")
-            formatter.dateFormat = "d. MMM yyyy, HH:mm"
+            formatter.locale = Locale(identifier: "en_US")
+            formatter.dateFormat = "MMM d, yyyy, HH:mm"
             return formatter.string(from: date)
         }
     }


### PR DESCRIPTION
## Summary
- **i18n**: Replace hardcoded German strings ("Gestern", `de_DE` locale) with English in date formatting across EmailDetailView and ThreadMessageCardView
- **Empty states**: Show contextual `ContentUnavailableView` messages — no accounts configured, never synced, empty folder, no search results
- **Context menu**: Wire up Reply, Forward, Tags actions in email row context menu (previously disabled placeholders)
- **Accessibility**: Add VoiceOver labels for email rows (combined unread/pinned/sender/subject), banner announcements, tag chip buttons, tag overflow counts

## Test plan
- [x] Date formatting shows "Yesterday" instead of "Gestern", English day/month names
- [x] Empty inbox shows "No Emails Yet — run durian sync..." message
- [x] Empty search shows "No Results"
- [x] Right-click email row → Reply/Forward/Tags all work
- [x] Enable VoiceOver → navigate email list, verify row announcements include unread/sender/subject
- [x] VoiceOver on banner → announces title and message