### PR TITLE
feat(swift-sidebar): make folder icon optional

### DIFF
--- a/macos/durian/Managers/ProfileManager.swift
+++ b/macos/durian/Managers/ProfileManager.swift
@@ -13,7 +13,7 @@ import TOMLDecoder
 
 struct FolderConfig: Hashable {
     let name: String
-    let icon: String
+    let icon: String?
     let query: String
 }
 
@@ -60,7 +60,7 @@ struct ProfilesConfig: Decodable {
     
     struct FolderEntry: Decodable {
         let name: String
-        let icon: String
+        var icon: String?
         let query: String
     }
 }

--- a/macos/durian/Models/Mail.swift
+++ b/macos/durian/Models/Mail.swift
@@ -105,7 +105,7 @@ struct MailFolder: Identifiable, Hashable {
     let id: String
     let name: String
     let displayName: String
-    let icon: String
+    let icon: String?
     let accountId: String
     let isSpecial: Bool  // true for inbox, sent, drafts, trash
     let specialType: SpecialFolderType?
@@ -145,7 +145,7 @@ struct MailFolder: Identifiable, Hashable {
     }
     
     /// Create from profile folder config (name, displayName, icon)
-    init(name: String, displayName: String, icon: String) {
+    init(name: String, displayName: String, icon: String?) {
         self.id = "folder:\(name)"
         self.name = name
         self.displayName = displayName

--- a/macos/durian/Views/SidebarView.swift
+++ b/macos/durian/Views/SidebarView.swift
@@ -69,10 +69,12 @@ private struct SidebarRow: View {
     var body: some View {
         Button(action: action) {
             HStack(spacing: 10) {
-                Image(systemName: folder.icon)
-                    .font(.system(size: 14))
-                    .foregroundStyle(isSelected ? .white : .secondary)
-                    .frame(width: 20, alignment: .center)
+                if let icon = folder.icon {
+                    Image(systemName: icon)
+                        .font(.system(size: 14))
+                        .foregroundStyle(isSelected ? .white : .secondary)
+                        .frame(width: 20, alignment: .center)
+                }
 
                 Text(folder.displayName)
                     .font(.system(size: 13))


### PR DESCRIPTION
## Summary
- Make `icon` field optional across `FolderEntry`, `FolderConfig`, `MailFolder`, and `SidebarRow`
- Sidebar entries without icon skip the icon column and show only the label
- No breaking change — existing configs with icons work unchanged

## Test plan
- [ ] Existing profiles.toml with icons renders as before
- [ ] Add a folder entry without `icon` field → sidebar shows label only, no crash
- [ ] Verify alignment: icon-less rows align text with icon rows (10px spacing preserved)