### PR TITLE
fix(go-smtp): use sender domain as EHLO hostname

### DIFF
--- a/cli/internal/smtp/client.go
+++ b/cli/internal/smtp/client.go
@@ -125,8 +125,14 @@ func (c *Client) Send(msg *Message) error {
 	}
 	defer client.Close()
 
-	// Say hello
-	if err := client.Hello("localhost"); err != nil {
+	// Say hello with sender's domain (some providers like GMX reject "localhost")
+	ehloHost := "localhost"
+	if from, err := ParseAddress(msg.From); err == nil {
+		if at := strings.LastIndex(from, "@"); at != -1 {
+			ehloHost = from[at+1:]
+		}
+	}
+	if err := client.Hello(ehloHost); err != nil {
 		return fmt.Errorf("HELO failed: %w", err)
 	}
 


### PR DESCRIPTION
## Summary
- EHLO hostname changed from hardcoded `localhost` to the sender's email domain
- Fixes GMX/web.de 554 "Reject due to policy restrictions" errors
- Other providers (Gmail, Microsoft) were tolerant of `localhost` but this is more RFC-compliant

## Context
GMX rejects SMTP transactions when the client identifies as `localhost` in the EHLO greeting — it's a common anti-spam heuristic. Using the sender's domain (e.g. `gmx.de`) resolves this.

## Test plan
- [ ] Send email from GMX account → no more 554 rejection
- [ ] Send email from Gmail/Microsoft account → still works
- [ ] `bazel test //cli/...` passes (15/15)