### PR TITLE
feat: contact groups, rules engine, tag operations, sidebar sections

### DIFF
--- a/cli/cmd/durian/BUILD.bazel
+++ b/cli/cmd/durian/BUILD.bazel
@@ -7,6 +7,7 @@ go_library(
         "auth.go",
         "contacts.go",
         "draft.go",
+        "group.go",
         "main.go",
         "root.go",
         "rules.go",

--- a/cli/cmd/durian/group.go
+++ b/cli/cmd/durian/group.go
@@ -1,0 +1,134 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"sort"
+	"text/tabwriter"
+
+	"github.com/durian-dev/durian/cli/internal/config"
+	"github.com/spf13/cobra"
+)
+
+var groupCmd = &cobra.Command{
+	Use:   "group",
+	Short: "Manage contact groups",
+	Long: `Manage contact groups defined in groups.toml.
+
+Groups map roles (investor, advisor, press) to email addresses or domain
+wildcards. Use group:NAME in search queries for automatic expansion.
+
+Edit ~/.config/durian/groups.toml directly to add or modify groups.`,
+}
+
+var groupListCmd = &cobra.Command{
+	Use:   "list",
+	Short: "List all contact groups",
+	RunE:  runGroupList,
+}
+
+var groupMembersCmd = &cobra.Command{
+	Use:   "members <name>",
+	Short: "List members of a group",
+	Args:  cobra.ExactArgs(1),
+	RunE:  runGroupMembers,
+}
+
+func init() {
+	rootCmd.AddCommand(groupCmd)
+	groupCmd.AddCommand(groupListCmd)
+	groupCmd.AddCommand(groupMembersCmd)
+}
+
+func loadGroups() (map[string]config.GroupEntry, error) {
+	groups, err := config.LoadGroups("")
+	if err != nil {
+		return nil, err
+	}
+	if groups == nil {
+		return nil, fmt.Errorf("groups.toml not found at %s", config.GroupsPath())
+	}
+	return groups, nil
+}
+
+func runGroupList(cmd *cobra.Command, args []string) error {
+	groups, err := loadGroups()
+	if err != nil {
+		return err
+	}
+
+	if jsonOutput {
+		enc := json.NewEncoder(os.Stdout)
+		enc.SetIndent("", "  ")
+		return enc.Encode(groups)
+	}
+
+	if len(groups) == 0 {
+		fmt.Println("No groups defined. Edit groups.toml to add groups.")
+		return nil
+	}
+
+	// Sort group names for stable output
+	names := make([]string, 0, len(groups))
+	for name := range groups {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+
+	w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
+	fmt.Fprintln(w, "GROUP\tMEMBERS\tDESCRIPTION")
+	fmt.Fprintln(w, "-----\t-------\t-----------")
+	for _, name := range names {
+		group := groups[name]
+		desc := group.Description
+		if desc == "" {
+			desc = "-"
+		}
+		fmt.Fprintf(w, "%s\t%d\t%s\n", name, len(group.Members), desc)
+	}
+	w.Flush()
+
+	return nil
+}
+
+func runGroupMembers(cmd *cobra.Command, args []string) error {
+	groups, err := loadGroups()
+	if err != nil {
+		return err
+	}
+
+	name := args[0]
+	group, ok := groups[name]
+	if !ok {
+		available := make([]string, 0, len(groups))
+		for n := range groups {
+			available = append(available, n)
+		}
+		sort.Strings(available)
+		return fmt.Errorf("group %q not found (available: %v)", name, available)
+	}
+
+	if jsonOutput {
+		enc := json.NewEncoder(os.Stdout)
+		enc.SetIndent("", "  ")
+		return enc.Encode(group)
+	}
+
+	if group.Description != "" {
+		fmt.Printf("%s — %s\n", name, group.Description)
+	} else {
+		fmt.Println(name)
+	}
+
+	if len(group.Members) == 0 {
+		fmt.Println("  (no members)")
+		return nil
+	}
+
+	for _, member := range group.Members {
+		fmt.Printf("  %s\n", member)
+	}
+
+	return nil
+}

--- a/cli/cmd/durian/group.go
+++ b/cli/cmd/durian/group.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"sort"
+	"strings"
 	"text/tabwriter"
 
 	"github.com/durian-dev/durian/cli/internal/config"
@@ -126,8 +127,12 @@ func runGroupMembers(cmd *cobra.Command, args []string) error {
 		return nil
 	}
 
-	for _, member := range group.Members {
-		fmt.Printf("  %s\n", member)
+	for _, person := range group.Members {
+		if len(person) == 1 {
+			fmt.Printf("  %s\n", person[0])
+		} else {
+			fmt.Printf("  %s\n", strings.Join(person, ", "))
+		}
 	}
 
 	return nil

--- a/cli/cmd/durian/rules.go
+++ b/cli/cmd/durian/rules.go
@@ -67,9 +67,9 @@ func runRulesApply(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("load headers: %w", err)
 	}
 
-	attachCounts, err := emailDB.AttachmentCounts()
+	attachments, err := emailDB.AttachmentsByMessage()
 	if err != nil {
-		return fmt.Errorf("load attachment counts: %w", err)
+		return fmt.Errorf("load attachments: %w", err)
 	}
 
 	groups, _ := config.LoadGroups("")
@@ -92,10 +92,9 @@ func runRulesApply(cmd *cobra.Command, args []string) error {
 
 	for _, msg := range msgs {
 		hdr := mail.Header(headers[msg.ID])
-		// Build attachment metadata from stored counts (no content-type for retroactive apply)
 		var atts []imap.RuleAttachment
-		for i := 0; i < attachCounts[msg.ID]; i++ {
-			atts = append(atts, imap.RuleAttachment{})
+		for _, a := range attachments[msg.ID] {
+			atts = append(atts, imap.RuleAttachment{ContentType: a.ContentType, Filename: a.Filename})
 		}
 		matched := imap.MatchingRules(rules, msg, atts, hdr, msg.Account, groups)
 

--- a/cli/cmd/durian/rules.go
+++ b/cli/cmd/durian/rules.go
@@ -72,6 +72,8 @@ func runRulesApply(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("load attachment counts: %w", err)
 	}
 
+	groups, _ := config.LoadGroups("")
+
 	fmt.Fprintf(os.Stderr, "Processing %d messages...\n\n", len(msgs))
 
 	// Track per-rule stats
@@ -90,7 +92,12 @@ func runRulesApply(cmd *cobra.Command, args []string) error {
 
 	for _, msg := range msgs {
 		hdr := mail.Header(headers[msg.ID])
-		matched := imap.MatchingRules(rules, msg, attachCounts[msg.ID], hdr, msg.Account)
+		// Build attachment metadata from stored counts (no content-type for retroactive apply)
+		var atts []imap.RuleAttachment
+		for i := 0; i < attachCounts[msg.ID]; i++ {
+			atts = append(atts, imap.RuleAttachment{})
+		}
+		matched := imap.MatchingRules(rules, msg, atts, hdr, msg.Account, groups)
 
 		for _, rule := range matched {
 			for _, tag := range rule.AddTags {

--- a/cli/cmd/durian/search.go
+++ b/cli/cmd/durian/search.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"text/tabwriter"
 
+	"github.com/durian-dev/durian/cli/internal/config"
 	"github.com/durian-dev/durian/cli/internal/handler"
 	"github.com/durian-dev/durian/cli/internal/protocol"
 	"github.com/spf13/cobra"
@@ -24,10 +25,12 @@ The query follows notmuch search syntax. Common examples:
   tag:unread         - all unread emails
   from:alice@ex.com  - emails from Alice
   subject:meeting    - emails with "meeting" in subject
-  date:yesterday..   - emails from yesterday onwards`,
+  date:yesterday..   - emails from yesterday onwards
+  group:investor     - emails from contact group (expands to from: OR-chain)`,
 	Example: `  durian search "tag:inbox"
   durian search "tag:inbox AND tag:unread"
   durian search "from:alice@example.com" --limit 10
+  durian search "group:investor AND date:month"
   durian search "tag:unread" --json`,
 	Args: cobra.MinimumNArgs(1),
 	RunE: runSearch,
@@ -49,6 +52,12 @@ func runSearch(cmd *cobra.Command, args []string) error {
 	defer emailDB.Close()
 
 	h := handler.New(emailDB, nil)
+
+	// Load contact groups for group: query expansion
+	if groups, err := config.LoadGroups(""); err == nil && len(groups) > 0 {
+		h.SetGroups(groups)
+	}
+
 	resp := h.Search(query, searchLimit, 0)
 
 	if !resp.OK {

--- a/cli/cmd/durian/search.go
+++ b/cli/cmd/durian/search.go
@@ -36,9 +36,20 @@ The query follows notmuch search syntax. Common examples:
 	RunE: runSearch,
 }
 
+var countCmd = &cobra.Command{
+	Use:   "count <query>",
+	Short: "Count threads matching a query",
+	Example: `  durian count "tag:inbox"
+  durian count "tag:unread AND from:alice"
+  durian count "group:investor AND date:month"`,
+	Args: cobra.MinimumNArgs(1),
+	RunE: runCount,
+}
+
 func init() {
 	searchCmd.Flags().IntVarP(&searchLimit, "limit", "l", 50, "maximum number of results")
 	rootCmd.AddCommand(searchCmd)
+	rootCmd.AddCommand(countCmd)
 }
 
 func runSearch(cmd *cobra.Command, args []string) error {
@@ -100,6 +111,33 @@ func outputSearchTable(resp protocol.Response) error {
 	}
 
 	return w.Flush()
+}
+
+func runCount(cmd *cobra.Command, args []string) error {
+	query := strings.Join(args, " ")
+
+	emailDB, err := openEmailDB()
+	if err != nil {
+		return fmt.Errorf("email store unavailable: %w", err)
+	}
+	defer emailDB.Close()
+
+	// Expand groups before counting
+	if groups, err := config.LoadGroups(""); err == nil && len(groups) > 0 {
+		expanded, err := config.ExpandGroupsInQuery(query, groups)
+		if err != nil {
+			return fmt.Errorf("expand groups: %w", err)
+		}
+		query = expanded
+	}
+
+	count, err := emailDB.SearchCount(query)
+	if err != nil {
+		return fmt.Errorf("count: %w", err)
+	}
+
+	fmt.Println(count)
+	return nil
 }
 
 func truncate(s string, maxLen int) string {

--- a/cli/cmd/durian/serve.go
+++ b/cli/cmd/durian/serve.go
@@ -119,6 +119,7 @@ func runServe(cmd *cobra.Command, args []string) {
 	r.HandleFunc("/api/v1/threads/{thread_id}/tags", h.TagThreadHandler).Methods("POST")
 	r.HandleFunc("/api/v1/message/body", h.ShowMessageBodyHandler).Methods("GET")
 	r.HandleFunc("/api/v1/messages/{message_id}/attachments/{part_id}", h.DownloadAttachmentHandler).Methods("GET")
+	r.HandleFunc("/api/v1/groups", h.ListGroupsHandler).Methods("GET")
 	r.HandleFunc("/api/v1/contacts/search", h.SearchContactsHandler).Methods("GET")
 	r.HandleFunc("/api/v1/contacts/usage", h.IncrementContactUsageHandler).Methods("POST")
 	r.HandleFunc("/api/v1/contacts", h.ListContactsHandler).Methods("GET")
@@ -145,6 +146,15 @@ func runServe(cmd *cobra.Command, args []string) {
 		slog.Warn("Could not load filter rules", "module", "SERVE", "err", rulesErr)
 	} else if len(rules) > 0 {
 		slog.Info("Loaded filter rules", "module", "SERVE", "count", len(rules))
+	}
+
+	// Load contact groups (non-fatal if missing)
+	groups, groupsErr := config.LoadGroups("")
+	if groupsErr != nil {
+		slog.Warn("Could not load contact groups", "module", "SERVE", "err", groupsErr)
+	} else if len(groups) > 0 {
+		h.SetGroups(groups)
+		slog.Info("Loaded contact groups", "module", "SERVE", "count", len(groups))
 	}
 
 	cfg, err := config.Load(cfgFile)

--- a/cli/cmd/durian/serve.go
+++ b/cli/cmd/durian/serve.go
@@ -177,7 +177,7 @@ func runServe(cmd *cobra.Command, args []string) {
 		if len(accounts) == 0 {
 			slog.Info("No IMAP accounts configured, skipping watchers", "module", "SERVE")
 		} else {
-			watcher := handler.NewWatcherManager(eventHub, emailDB, rules)
+			watcher := handler.NewWatcherManager(eventHub, emailDB, rules, groups)
 			h.SetFetcher(watcher)
 			h.SetSyncTrigger(watcher)
 			go watcher.Start(watcherCtx, accounts)

--- a/cli/cmd/durian/sync.go
+++ b/cli/cmd/durian/sync.go
@@ -104,6 +104,7 @@ func runSync(cmd *cobra.Command, args []string) error {
 		Store:           emailDB,
 		FilterRules:     rules,
 		BackfillHeaders: syncBackfillHeaders,
+		Groups:          func() map[string]config.GroupEntry { g, _ := config.LoadGroups(""); return g }(),
 	}
 
 	// Determine which accounts to sync

--- a/cli/cmd/durian/tag.go
+++ b/cli/cmd/durian/tag.go
@@ -1,13 +1,26 @@
 package main
 
 import (
+	"encoding/json"
 	"fmt"
 	"os"
 	"strings"
 
 	"github.com/durian-dev/durian/cli/internal/handler"
+	"github.com/durian-dev/durian/cli/internal/protocol"
 	"github.com/spf13/cobra"
 )
+
+var tagAccountFilter string
+
+var tagListCmd = &cobra.Command{
+	Use:   "list",
+	Short: "List all tags",
+	Example: `  durian tag list
+  durian tag list --account work
+  durian tag list --account work,personal`,
+	RunE: runTagList,
+}
 
 var tagCmd = &cobra.Command{
 	Use:   "tag <query> <tags...>",
@@ -26,7 +39,40 @@ Multiple tags can be specified.`,
 
 func init() {
 	tagCmd.Flags().SetInterspersed(false)
+	tagListCmd.Flags().StringVar(&tagAccountFilter, "account", "", "filter by account (comma-separated)")
+	tagCmd.AddCommand(tagListCmd)
 	rootCmd.AddCommand(tagCmd)
+}
+
+func runTagList(cmd *cobra.Command, args []string) error {
+	emailDB, err := openEmailDB()
+	if err != nil {
+		return fmt.Errorf("email store unavailable: %w", err)
+	}
+	defer emailDB.Close()
+
+	h := handler.New(emailDB, nil)
+
+	var resp protocol.Response
+	if tagAccountFilter != "" {
+		resp = h.ListTagsForAccounts(strings.Split(tagAccountFilter, ","))
+	} else {
+		resp = h.ListTags()
+	}
+
+	if !resp.OK {
+		fmt.Fprintf(os.Stderr, "Error: %s\n", resp.Error)
+		os.Exit(1)
+	}
+
+	if jsonOutput {
+		return json.NewEncoder(os.Stdout).Encode(resp)
+	}
+
+	for _, tag := range resp.Tags {
+		fmt.Println(tag)
+	}
+	return nil
 }
 
 func runTag(cmd *cobra.Command, args []string) error {

--- a/cli/cmd/durian/validate.go
+++ b/cli/cmd/durian/validate.go
@@ -20,7 +20,8 @@ Without arguments, validates all files. Pass a name to validate just one.`,
 	Example: `  durian validate
   durian validate config
   durian validate rules
-  durian validate profiles`,
+  durian validate profiles
+  durian validate groups`,
 	Args: cobra.MaximumNArgs(1),
 	RunE: runValidate,
 }
@@ -34,9 +35,9 @@ func runValidate(cmd *cobra.Command, args []string) error {
 	if len(args) > 0 {
 		target = strings.ToLower(args[0])
 		switch target {
-		case "config", "rules", "profiles", "keymaps":
+		case "config", "rules", "profiles", "keymaps", "groups":
 		default:
-			return fmt.Errorf("unknown target %q (valid: config, rules, profiles, keymaps)", target)
+			return fmt.Errorf("unknown target %q (valid: config, rules, profiles, keymaps, groups)", target)
 		}
 	}
 
@@ -119,6 +120,22 @@ func runValidate(cmd *cobra.Command, args []string) error {
 		} else {
 			errs := config.ValidateKeymaps(keymaps)
 			if printResults("keymaps.toml", errs, fmt.Sprintf("%d bindings", len(keymaps.Keymaps))) {
+				hasErrors = true
+			}
+		}
+	}
+
+	// Validate groups.toml
+	if target == "" || target == "groups" {
+		groups, err := config.LoadGroups("")
+		if err != nil {
+			printError("groups.toml", fmt.Sprintf("failed to parse: %v", err))
+			hasErrors = true
+		} else if groups == nil {
+			printSkipped("groups.toml", "not found (optional)")
+		} else {
+			errs := config.ValidateGroups(groups)
+			if printResults("groups.toml", errs, fmt.Sprintf("%d groups", len(groups))) {
 				hasErrors = true
 			}
 		}

--- a/cli/internal/config/BUILD.bazel
+++ b/cli/internal/config/BUILD.bazel
@@ -4,6 +4,7 @@ go_library(
     name = "config",
     srcs = [
         "config.go",
+        "groups.go",
         "helpers.go",
         "keymaps.go",
         "profiles.go",
@@ -19,7 +20,10 @@ go_library(
 go_test(
     name = "config_test",
     size = "small",
-    srcs = ["config_test.go"],
+    srcs = [
+        "config_test.go",
+        "groups_test.go",
+    ],
     data = glob(["testdata/**"]),
     embed = [":config"],
 )

--- a/cli/internal/config/groups.go
+++ b/cli/internal/config/groups.go
@@ -1,0 +1,138 @@
+package config
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+
+	"github.com/BurntSushi/toml"
+)
+
+// GroupEntry defines a single contact group.
+type GroupEntry struct {
+	Description string   `toml:"description"`
+	Members     []string `toml:"members"`
+}
+
+// groupsFile is the top-level structure of groups.toml.
+type groupsFile struct {
+	Groups map[string]GroupEntry `toml:"groups"`
+}
+
+// LoadGroups loads contact groups from the given path.
+// Returns nil if the file doesn't exist.
+func LoadGroups(path string) (map[string]GroupEntry, error) {
+	if path == "" {
+		path = GroupsPath()
+	}
+	path = ExpandPath(path)
+
+	if _, err := os.Stat(path); os.IsNotExist(err) {
+		return nil, nil
+	}
+
+	var f groupsFile
+	if _, err := toml.DecodeFile(path, &f); err != nil {
+		return nil, fmt.Errorf("failed to load groups: %w", err)
+	}
+
+	return f.Groups, nil
+}
+
+// GroupsPath returns the default groups.toml path.
+func GroupsPath() string {
+	return filepath.Join(filepath.Dir(DefaultPath()), "groups.toml")
+}
+
+// groupRef matches group:name tokens in a query string.
+var groupRef = regexp.MustCompile(`\bgroup:([a-zA-Z0-9_-]+)`)
+
+// ExpandGroupsInQuery replaces all group:NAME references in a query string
+// with equivalent (from:member1 OR from:member2 ...) expressions.
+// Wildcard members (*@domain.com) are expanded to from:@domain.com
+// which matches via the existing LIKE '%@domain.com%' SQL pattern.
+func ExpandGroupsInQuery(query string, groups map[string]GroupEntry) (string, error) {
+	if len(groups) == 0 {
+		return query, nil
+	}
+
+	var expandErr error
+	result := groupRef.ReplaceAllStringFunc(query, func(match string) string {
+		if expandErr != nil {
+			return match
+		}
+		name := match[len("group:"):]
+		group, ok := groups[name]
+		if !ok {
+			expandErr = fmt.Errorf("unknown group: %q", name)
+			return match
+		}
+		if len(group.Members) == 0 {
+			expandErr = fmt.Errorf("group %q has no members", name)
+			return match
+		}
+
+		parts := make([]string, len(group.Members))
+		for i, member := range group.Members {
+			if strings.HasPrefix(member, "*") {
+				// Wildcard: *@domain.com → from:@domain.com
+				parts[i] = "from:" + member[1:]
+			} else {
+				parts[i] = "from:" + member
+			}
+		}
+
+		if len(parts) == 1 {
+			return parts[0]
+		}
+		return "(" + strings.Join(parts, " OR ") + ")"
+	})
+
+	if expandErr != nil {
+		return "", expandErr
+	}
+	return result, nil
+}
+
+// ValidateGroups validates groups.toml entries.
+func ValidateGroups(groups map[string]GroupEntry) []ValidationError {
+	var errs []ValidationError
+	add := func(field, msg string) {
+		errs = append(errs, ValidationError{File: "groups.toml", Field: field, Message: msg, Severity: "error"})
+	}
+	warn := func(field, msg string) {
+		errs = append(errs, ValidationError{File: "groups.toml", Field: field, Message: msg, Severity: "warning"})
+	}
+
+	for name, group := range groups {
+		prefix := "groups." + name
+
+		if len(group.Members) == 0 {
+			warn(prefix+".members", "group has no members")
+			continue
+		}
+
+		for i, member := range group.Members {
+			field := fmt.Sprintf("%s.members[%d]", prefix, i)
+			if member == "" {
+				add(field, "empty member entry")
+				continue
+			}
+			if strings.HasPrefix(member, "*@") {
+				// Domain wildcard — check domain part
+				domain := member[2:]
+				if !strings.Contains(domain, ".") {
+					warn(field, fmt.Sprintf("domain wildcard %q has no dot — may match too broadly", member))
+				}
+			} else if strings.HasPrefix(member, "*") {
+				add(field, fmt.Sprintf("invalid wildcard pattern %q (only *@domain is supported)", member))
+			} else if !strings.Contains(member, "@") {
+				add(field, fmt.Sprintf("invalid member %q (expected email or *@domain)", member))
+			}
+		}
+	}
+
+	return errs
+}

--- a/cli/internal/config/groups.go
+++ b/cli/internal/config/groups.go
@@ -11,9 +11,11 @@ import (
 )
 
 // GroupEntry defines a single contact group.
+// Members is a list of people, where each person can have multiple addresses.
+// Example: [["alice@work.com", "alice@gmail.com"], ["bob@vc.com"], ["*@fund.com"]]
 type GroupEntry struct {
-	Description string   `toml:"description"`
-	Members     []string `toml:"members"`
+	Description string     `toml:"description"`
+	Members     [][]string `toml:"members"`
 }
 
 // groupsFile is the top-level structure of groups.toml.
@@ -46,13 +48,20 @@ func GroupsPath() string {
 	return filepath.Join(filepath.Dir(DefaultPath()), "groups.toml")
 }
 
-// groupRef matches group:name tokens in a query string.
-var groupRef = regexp.MustCompile(`\bgroup:([a-zA-Z0-9_-]+)`)
+// groupRef matches group:name and group:name/modifier tokens in a query string.
+// Supported modifiers: /from, /to. Default (no modifier) expands both directions.
+var groupRef = regexp.MustCompile(`\bgroup:([a-zA-Z0-9_-]+)(?:/(from|to))?`)
 
 // ExpandGroupsInQuery replaces all group:NAME references in a query string
-// with equivalent (from:member1 OR from:member2 ...) expressions.
-// Wildcard members (*@domain.com) are expanded to from:@domain.com
-// which matches via the existing LIKE '%@domain.com%' SQL pattern.
+// with equivalent address expressions.
+//
+// Default (bidirectional): group:X → (from:a OR to:a OR from:b OR to:b ...)
+// Directed: group:X/from → (from:a OR from:b ...) — only incoming
+//
+//	group:X/to   → (to:a OR to:b ...)   — only outgoing
+//
+// Wildcard members (*@domain.com) expand to @domain.com which matches
+// via the existing LIKE '%@domain.com%' SQL pattern.
 func ExpandGroupsInQuery(query string, groups map[string]GroupEntry) (string, error) {
 	if len(groups) == 0 {
 		return query, nil
@@ -63,7 +72,11 @@ func ExpandGroupsInQuery(query string, groups map[string]GroupEntry) (string, er
 		if expandErr != nil {
 			return match
 		}
-		name := match[len("group:"):]
+
+		sub := groupRef.FindStringSubmatch(match)
+		name := sub[1]
+		modifier := sub[2] // "", "from", or "to"
+
 		group, ok := groups[name]
 		if !ok {
 			expandErr = fmt.Errorf("unknown group: %q", name)
@@ -74,13 +87,15 @@ func ExpandGroupsInQuery(query string, groups map[string]GroupEntry) (string, er
 			return match
 		}
 
-		parts := make([]string, len(group.Members))
-		for i, member := range group.Members {
-			if strings.HasPrefix(member, "*") {
-				// Wildcard: *@domain.com → from:@domain.com
-				parts[i] = "from:" + member[1:]
-			} else {
-				parts[i] = "from:" + member
+		var parts []string
+		for _, person := range group.Members {
+			for _, addr := range person {
+				// Strip wildcard prefix for LIKE matching
+				a := addr
+				if strings.HasPrefix(a, "*") {
+					a = a[1:]
+				}
+				parts = append(parts, expandAddr(a, modifier)...)
 			}
 		}
 
@@ -94,6 +109,18 @@ func ExpandGroupsInQuery(query string, groups map[string]GroupEntry) (string, er
 		return "", expandErr
 	}
 	return result, nil
+}
+
+// expandAddr returns the from:/to: terms for a single address based on modifier.
+func expandAddr(addr, modifier string) []string {
+	switch modifier {
+	case "from":
+		return []string{"from:" + addr}
+	case "to":
+		return []string{"to:" + addr}
+	default:
+		return []string{"from:" + addr, "to:" + addr}
+	}
 }
 
 // ValidateGroups validates groups.toml entries.
@@ -114,22 +141,27 @@ func ValidateGroups(groups map[string]GroupEntry) []ValidationError {
 			continue
 		}
 
-		for i, member := range group.Members {
-			field := fmt.Sprintf("%s.members[%d]", prefix, i)
-			if member == "" {
-				add(field, "empty member entry")
+		for i, person := range group.Members {
+			if len(person) == 0 {
+				add(fmt.Sprintf("%s.members[%d]", prefix, i), "empty member entry")
 				continue
 			}
-			if strings.HasPrefix(member, "*@") {
-				// Domain wildcard — check domain part
-				domain := member[2:]
-				if !strings.Contains(domain, ".") {
-					warn(field, fmt.Sprintf("domain wildcard %q has no dot — may match too broadly", member))
+			for j, addr := range person {
+				field := fmt.Sprintf("%s.members[%d][%d]", prefix, i, j)
+				if addr == "" {
+					add(field, "empty address")
+					continue
 				}
-			} else if strings.HasPrefix(member, "*") {
-				add(field, fmt.Sprintf("invalid wildcard pattern %q (only *@domain is supported)", member))
-			} else if !strings.Contains(member, "@") {
-				add(field, fmt.Sprintf("invalid member %q (expected email or *@domain)", member))
+				if strings.HasPrefix(addr, "*@") {
+					domain := addr[2:]
+					if !strings.Contains(domain, ".") {
+						warn(field, fmt.Sprintf("domain wildcard %q has no dot — may match too broadly", addr))
+					}
+				} else if strings.HasPrefix(addr, "*") {
+					add(field, fmt.Sprintf("invalid wildcard pattern %q (only *@domain is supported)", addr))
+				} else if !strings.Contains(addr, "@") {
+					add(field, fmt.Sprintf("invalid address %q (expected email or *@domain)", addr))
+				}
 			}
 		}
 	}

--- a/cli/internal/config/groups.go
+++ b/cli/internal/config/groups.go
@@ -12,15 +12,23 @@ import (
 
 // GroupEntry defines a single contact group.
 // Members is a list of people, where each person can have multiple addresses.
-// Example: [["alice@work.com", "alice@gmail.com"], ["bob@vc.com"], ["*@fund.com"]]
 type GroupEntry struct {
-	Description string     `toml:"description"`
-	Members     [][]string `toml:"members"`
+	Description string
+	Members     [][]string
 }
 
-// groupsFile is the top-level structure of groups.toml.
-type groupsFile struct {
-	Groups map[string]GroupEntry `toml:"groups"`
+// groupEntryRaw is the intermediate TOML representation that accepts both
+// plain strings and arrays for members:
+//
+//	members = ["alice@x.com", ["bob@x.com", "bob@y.com"], "*@fund.com"]
+type groupEntryRaw struct {
+	Description string      `toml:"description"`
+	Members     interface{} `toml:"members"`
+}
+
+// groupsFileRaw is the top-level structure of groups.toml.
+type groupsFileRaw struct {
+	Groups map[string]groupEntryRaw `toml:"groups"`
 }
 
 // LoadGroups loads contact groups from the given path.
@@ -35,12 +43,61 @@ func LoadGroups(path string) (map[string]GroupEntry, error) {
 		return nil, nil
 	}
 
-	var f groupsFile
-	if _, err := toml.DecodeFile(path, &f); err != nil {
+	var raw groupsFileRaw
+	if _, err := toml.DecodeFile(path, &raw); err != nil {
 		return nil, fmt.Errorf("failed to load groups: %w", err)
 	}
 
-	return f.Groups, nil
+	groups := make(map[string]GroupEntry, len(raw.Groups))
+	for name, entry := range raw.Groups {
+		members, err := normalizeMembers(entry.Members)
+		if err != nil {
+			return nil, fmt.Errorf("groups.%s.members: %w", name, err)
+		}
+		groups[name] = GroupEntry{
+			Description: entry.Description,
+			Members:     members,
+		}
+	}
+
+	return groups, nil
+}
+
+// normalizeMembers converts the flexible TOML members format into [][]string.
+// Accepts: plain strings (single address), arrays of strings (multi-email person),
+// or a mix of both.
+func normalizeMembers(raw interface{}) ([][]string, error) {
+	if raw == nil {
+		return nil, nil
+	}
+
+	arr, ok := raw.([]interface{})
+	if !ok {
+		return nil, fmt.Errorf("must be an array")
+	}
+
+	result := make([][]string, 0, len(arr))
+	for _, item := range arr {
+		switch v := item.(type) {
+		case string:
+			// Plain string → single-address person
+			result = append(result, []string{v})
+		case []interface{}:
+			// Array → multi-address person
+			strs := make([]string, 0, len(v))
+			for _, s := range v {
+				str, ok := s.(string)
+				if !ok {
+					return nil, fmt.Errorf("address must be a string, got %T", s)
+				}
+				strs = append(strs, str)
+			}
+			result = append(result, strs)
+		default:
+			return nil, fmt.Errorf("member must be a string or array of strings, got %T", item)
+		}
+	}
+	return result, nil
 }
 
 // GroupsPath returns the default groups.toml path.
@@ -90,7 +147,6 @@ func ExpandGroupsInQuery(query string, groups map[string]GroupEntry) (string, er
 		var parts []string
 		for _, person := range group.Members {
 			for _, addr := range person {
-				// Strip wildcard prefix for LIKE matching
 				a := addr
 				if strings.HasPrefix(a, "*") {
 					a = a[1:]

--- a/cli/internal/config/groups_test.go
+++ b/cli/internal/config/groups_test.go
@@ -21,6 +21,10 @@ func TestLoadGroups(t *testing.T) {
 	if len(inv.Members) != 3 {
 		t.Errorf("investor.Members count = %d, want 3", len(inv.Members))
 	}
+	// First member has two addresses
+	if len(inv.Members[0]) != 2 {
+		t.Errorf("investor.Members[0] addresses = %d, want 2", len(inv.Members[0]))
+	}
 }
 
 func TestLoadGroups_NotFound(t *testing.T) {
@@ -35,9 +39,20 @@ func TestLoadGroups_NotFound(t *testing.T) {
 
 func TestExpandGroupsInQuery(t *testing.T) {
 	groups := map[string]GroupEntry{
-		"investor": {Members: []string{"alice@sequoia.com", "bob@index.vc"}},
-		"press":    {Members: []string{"*@spiegel.de", "*@handelsblatt.com"}},
-		"solo":     {Members: []string{"carol@example.org"}},
+		"investor": {Members: [][]string{
+			{"alice@sequoia.com"},
+			{"bob@index.vc"},
+		}},
+		"press": {Members: [][]string{
+			{"*@spiegel.de"},
+			{"*@handelsblatt.com"},
+		}},
+		"solo": {Members: [][]string{
+			{"carol@example.org"},
+		}},
+		"multi": {Members: [][]string{
+			{"alice@work.com", "alice@gmail.com"},
+		}},
 	}
 
 	tests := []struct {
@@ -47,28 +62,48 @@ func TestExpandGroupsInQuery(t *testing.T) {
 		wantErr bool
 	}{
 		{
-			name:  "single group with multiple members",
+			name:  "bidirectional default — two members",
 			query: "group:investor",
+			want:  "(from:alice@sequoia.com OR to:alice@sequoia.com OR from:bob@index.vc OR to:bob@index.vc)",
+		},
+		{
+			name:  "domain wildcards — bidirectional",
+			query: "group:press",
+			want:  "(from:@spiegel.de OR to:@spiegel.de OR from:@handelsblatt.com OR to:@handelsblatt.com)",
+		},
+		{
+			name:  "single member — no parens",
+			query: "group:solo",
+			want:  "(from:carol@example.org OR to:carol@example.org)",
+		},
+		{
+			name:  "modifier /from — incoming only",
+			query: "group:investor/from",
 			want:  "(from:alice@sequoia.com OR from:bob@index.vc)",
 		},
 		{
-			name:  "group with domain wildcards",
-			query: "group:press",
-			want:  "(from:@spiegel.de OR from:@handelsblatt.com)",
+			name:  "modifier /to — outgoing only",
+			query: "group:investor/to",
+			want:  "(to:alice@sequoia.com OR to:bob@index.vc)",
 		},
 		{
-			name:  "single member group — no parens",
-			query: "group:solo",
-			want:  "from:carol@example.org",
+			name:  "multi-email person — all addresses expanded",
+			query: "group:multi",
+			want:  "(from:alice@work.com OR to:alice@work.com OR from:alice@gmail.com OR to:alice@gmail.com)",
+		},
+		{
+			name:  "multi-email with /from modifier",
+			query: "group:multi/from",
+			want:  "(from:alice@work.com OR from:alice@gmail.com)",
 		},
 		{
 			name:  "group with AND clause",
 			query: "group:investor AND date:month",
-			want:  "(from:alice@sequoia.com OR from:bob@index.vc) AND date:month",
+			want:  "(from:alice@sequoia.com OR to:alice@sequoia.com OR from:bob@index.vc OR to:bob@index.vc) AND date:month",
 		},
 		{
 			name:  "multiple groups in query",
-			query: "group:investor OR group:press",
+			query: "group:investor/from OR group:press/from",
 			want:  "(from:alice@sequoia.com OR from:bob@index.vc) OR (from:@spiegel.de OR from:@handelsblatt.com)",
 		},
 		{
@@ -92,9 +127,9 @@ func TestExpandGroupsInQuery(t *testing.T) {
 			wantErr: true,
 		},
 		{
-			name:  "group in parentheses",
-			query: "(group:investor) AND tag:inbox",
-			want:  "((from:alice@sequoia.com OR from:bob@index.vc)) AND tag:inbox",
+			name:  "sent review pattern",
+			query: "group:investor/to AND tag:sent AND date:week",
+			want:  "(to:alice@sequoia.com OR to:bob@index.vc) AND tag:sent AND date:week",
 		},
 	}
 
@@ -137,7 +172,15 @@ func TestValidateGroups(t *testing.T) {
 		{
 			name: "valid groups",
 			groups: map[string]GroupEntry{
-				"investor": {Members: []string{"alice@vc.com", "*@fund.com"}},
+				"investor": {Members: [][]string{{"alice@vc.com"}, {"*@fund.com"}}},
+			},
+			wantErrs:  0,
+			wantWarns: 0,
+		},
+		{
+			name: "multi-email valid",
+			groups: map[string]GroupEntry{
+				"multi": {Members: [][]string{{"alice@work.com", "alice@gmail.com"}}},
 			},
 			wantErrs:  0,
 			wantWarns: 0,
@@ -145,7 +188,7 @@ func TestValidateGroups(t *testing.T) {
 		{
 			name: "empty members — warning",
 			groups: map[string]GroupEntry{
-				"empty": {Members: []string{}},
+				"empty": {Members: [][]string{}},
 			},
 			wantErrs:  0,
 			wantWarns: 1,
@@ -153,28 +196,35 @@ func TestValidateGroups(t *testing.T) {
 		{
 			name: "invalid member — no @",
 			groups: map[string]GroupEntry{
-				"bad": {Members: []string{"notanemail"}},
+				"bad": {Members: [][]string{{"notanemail"}}},
 			},
 			wantErrs: 1,
 		},
 		{
 			name: "invalid wildcard pattern",
 			groups: map[string]GroupEntry{
-				"bad": {Members: []string{"*notdomain"}},
+				"bad": {Members: [][]string{{"*notdomain"}}},
 			},
 			wantErrs: 1,
 		},
 		{
 			name: "domain wildcard without dot — warning",
 			groups: map[string]GroupEntry{
-				"broad": {Members: []string{"*@localhost"}},
+				"broad": {Members: [][]string{{"*@localhost"}}},
 			},
 			wantWarns: 1,
 		},
 		{
-			name: "empty member string — error",
+			name: "empty person array — error",
 			groups: map[string]GroupEntry{
-				"bad": {Members: []string{""}},
+				"bad": {Members: [][]string{{}}},
+			},
+			wantErrs: 1,
+		},
+		{
+			name: "empty address string — error",
+			groups: map[string]GroupEntry{
+				"bad": {Members: [][]string{{""}}},
 			},
 			wantErrs: 1,
 		},

--- a/cli/internal/config/groups_test.go
+++ b/cli/internal/config/groups_test.go
@@ -21,9 +21,13 @@ func TestLoadGroups(t *testing.T) {
 	if len(inv.Members) != 3 {
 		t.Errorf("investor.Members count = %d, want 3", len(inv.Members))
 	}
-	// First member has two addresses
-	if len(inv.Members[0]) != 2 {
-		t.Errorf("investor.Members[0] addresses = %d, want 2", len(inv.Members[0]))
+	// First member: plain string "alice@sequoia.com" → normalized to ["alice@sequoia.com"]
+	if len(inv.Members[0]) != 1 || inv.Members[0][0] != "alice@sequoia.com" {
+		t.Errorf("investor.Members[0] = %v, want [alice@sequoia.com]", inv.Members[0])
+	}
+	// Second member: array ["bob@index.vc", "bob.personal@gmail.com"]
+	if len(inv.Members[1]) != 2 {
+		t.Errorf("investor.Members[1] addresses = %d, want 2", len(inv.Members[1]))
 	}
 }
 

--- a/cli/internal/config/groups_test.go
+++ b/cli/internal/config/groups_test.go
@@ -1,0 +1,203 @@
+package config
+
+import (
+	"testing"
+)
+
+func TestLoadGroups(t *testing.T) {
+	groups, err := LoadGroups("testdata/valid_groups.toml")
+	if err != nil {
+		t.Fatalf("LoadGroups() error: %v", err)
+	}
+
+	if len(groups) != 4 {
+		t.Fatalf("got %d groups, want 4", len(groups))
+	}
+
+	inv := groups["investor"]
+	if inv.Description != "Cap Table members" {
+		t.Errorf("investor.Description = %q, want %q", inv.Description, "Cap Table members")
+	}
+	if len(inv.Members) != 3 {
+		t.Errorf("investor.Members count = %d, want 3", len(inv.Members))
+	}
+}
+
+func TestLoadGroups_NotFound(t *testing.T) {
+	groups, err := LoadGroups("testdata/nonexistent_groups.toml")
+	if err != nil {
+		t.Fatalf("LoadGroups() error: %v", err)
+	}
+	if groups != nil {
+		t.Errorf("expected nil for missing file, got %v", groups)
+	}
+}
+
+func TestExpandGroupsInQuery(t *testing.T) {
+	groups := map[string]GroupEntry{
+		"investor": {Members: []string{"alice@sequoia.com", "bob@index.vc"}},
+		"press":    {Members: []string{"*@spiegel.de", "*@handelsblatt.com"}},
+		"solo":     {Members: []string{"carol@example.org"}},
+	}
+
+	tests := []struct {
+		name    string
+		query   string
+		want    string
+		wantErr bool
+	}{
+		{
+			name:  "single group with multiple members",
+			query: "group:investor",
+			want:  "(from:alice@sequoia.com OR from:bob@index.vc)",
+		},
+		{
+			name:  "group with domain wildcards",
+			query: "group:press",
+			want:  "(from:@spiegel.de OR from:@handelsblatt.com)",
+		},
+		{
+			name:  "single member group — no parens",
+			query: "group:solo",
+			want:  "from:carol@example.org",
+		},
+		{
+			name:  "group with AND clause",
+			query: "group:investor AND date:month",
+			want:  "(from:alice@sequoia.com OR from:bob@index.vc) AND date:month",
+		},
+		{
+			name:  "multiple groups in query",
+			query: "group:investor OR group:press",
+			want:  "(from:alice@sequoia.com OR from:bob@index.vc) OR (from:@spiegel.de OR from:@handelsblatt.com)",
+		},
+		{
+			name:  "no group reference — passthrough",
+			query: "from:alice tag:inbox",
+			want:  "from:alice tag:inbox",
+		},
+		{
+			name:  "empty query — passthrough",
+			query: "",
+			want:  "",
+		},
+		{
+			name:  "star query — passthrough",
+			query: "*",
+			want:  "*",
+		},
+		{
+			name:    "unknown group — error",
+			query:   "group:unknown",
+			wantErr: true,
+		},
+		{
+			name:  "group in parentheses",
+			query: "(group:investor) AND tag:inbox",
+			want:  "((from:alice@sequoia.com OR from:bob@index.vc)) AND tag:inbox",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ExpandGroupsInQuery(tt.query, groups)
+			if tt.wantErr {
+				if err == nil {
+					t.Error("expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != tt.want {
+				t.Errorf("ExpandGroupsInQuery(%q)\n  got  %q\n  want %q", tt.query, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestExpandGroupsInQuery_NilGroups(t *testing.T) {
+	got, err := ExpandGroupsInQuery("group:anything", nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != "group:anything" {
+		t.Errorf("expected passthrough, got %q", got)
+	}
+}
+
+func TestValidateGroups(t *testing.T) {
+	tests := []struct {
+		name      string
+		groups    map[string]GroupEntry
+		wantErrs  int
+		wantWarns int
+	}{
+		{
+			name: "valid groups",
+			groups: map[string]GroupEntry{
+				"investor": {Members: []string{"alice@vc.com", "*@fund.com"}},
+			},
+			wantErrs:  0,
+			wantWarns: 0,
+		},
+		{
+			name: "empty members — warning",
+			groups: map[string]GroupEntry{
+				"empty": {Members: []string{}},
+			},
+			wantErrs:  0,
+			wantWarns: 1,
+		},
+		{
+			name: "invalid member — no @",
+			groups: map[string]GroupEntry{
+				"bad": {Members: []string{"notanemail"}},
+			},
+			wantErrs: 1,
+		},
+		{
+			name: "invalid wildcard pattern",
+			groups: map[string]GroupEntry{
+				"bad": {Members: []string{"*notdomain"}},
+			},
+			wantErrs: 1,
+		},
+		{
+			name: "domain wildcard without dot — warning",
+			groups: map[string]GroupEntry{
+				"broad": {Members: []string{"*@localhost"}},
+			},
+			wantWarns: 1,
+		},
+		{
+			name: "empty member string — error",
+			groups: map[string]GroupEntry{
+				"bad": {Members: []string{""}},
+			},
+			wantErrs: 1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			errs := ValidateGroups(tt.groups)
+			errors := 0
+			warnings := 0
+			for _, e := range errs {
+				if e.Severity == "error" {
+					errors++
+				} else {
+					warnings++
+				}
+			}
+			if errors != tt.wantErrs {
+				t.Errorf("errors = %d, want %d (errs: %v)", errors, tt.wantErrs, errs)
+			}
+			if tt.wantWarns > 0 && warnings != tt.wantWarns {
+				t.Errorf("warnings = %d, want %d (errs: %v)", warnings, tt.wantWarns, errs)
+			}
+		})
+	}
+}

--- a/cli/internal/config/testdata/valid_groups.toml
+++ b/cli/internal/config/testdata/valid_groups.toml
@@ -1,21 +1,16 @@
 [groups.investor]
 description = "Cap Table members"
 members = [
-  ["alice@sequoia.com", "alice.personal@gmail.com"],
-  ["bob@index.vc"],
-  ["*@fund-xyz.com"],
+  "alice@sequoia.com",
+  ["bob@index.vc", "bob.personal@gmail.com"],
+  "*@fund-xyz.com",
 ]
 
 [groups.press]
-members = [
-  ["*@spiegel.de"],
-  ["*@handelsblatt.com"],
-]
+members = ["*@spiegel.de", "*@handelsblatt.com"]
 
 [groups.solo]
-members = [
-  ["carol@example.org"],
-]
+members = ["carol@example.org"]
 
 [groups.empty]
 description = "No members yet"

--- a/cli/internal/config/testdata/valid_groups.toml
+++ b/cli/internal/config/testdata/valid_groups.toml
@@ -1,0 +1,13 @@
+[groups.investor]
+description = "Cap Table members"
+members = ["alice@sequoia.com", "bob@index.vc", "*@fund-xyz.com"]
+
+[groups.press]
+members = ["*@spiegel.de", "*@handelsblatt.com"]
+
+[groups.solo]
+members = ["carol@example.org"]
+
+[groups.empty]
+description = "No members yet"
+members = []

--- a/cli/internal/config/testdata/valid_groups.toml
+++ b/cli/internal/config/testdata/valid_groups.toml
@@ -1,12 +1,21 @@
 [groups.investor]
 description = "Cap Table members"
-members = ["alice@sequoia.com", "bob@index.vc", "*@fund-xyz.com"]
+members = [
+  ["alice@sequoia.com", "alice.personal@gmail.com"],
+  ["bob@index.vc"],
+  ["*@fund-xyz.com"],
+]
 
 [groups.press]
-members = ["*@spiegel.de", "*@handelsblatt.com"]
+members = [
+  ["*@spiegel.de"],
+  ["*@handelsblatt.com"],
+]
 
 [groups.solo]
-members = ["carol@example.org"]
+members = [
+  ["carol@example.org"],
+]
 
 [groups.empty]
 description = "No members yet"

--- a/cli/internal/config/validate.go
+++ b/cli/internal/config/validate.go
@@ -237,8 +237,9 @@ func ValidateProfiles(profiles []ProfileConfig, cfg *Config) []ValidationError {
 			if folder.Icon == "" {
 				warn(fp+".icon", "empty (will show no icon)")
 			}
-			if folder.Query == "" {
-				add(fp+".query", "required")
+			if folder.Query == "" && folder.Icon != "" {
+				// Section headers have no query (and typically no icon)
+				add(fp+".query", "required (omit query only for section headers)")
 			}
 		}
 	}

--- a/cli/internal/config/validate.go
+++ b/cli/internal/config/validate.go
@@ -257,7 +257,7 @@ var (
 		"next_email": true, "prev_email": true, "first_email": true, "last_email": true,
 		"page_down": true, "page_up": true,
 		"archive": true, "compose": true, "reply": true, "reply_all": true, "forward": true,
-		"toggle_read": true, "toggle_star": true, "delete": true,
+		"toggle_read": true, "toggle_star": true, "delete": true, "tag_op": true,
 		"go_inbox": true, "go_sent": true, "go_drafts": true, "go_archive": true,
 		"search": true, "close_detail": true, "reload_inbox": true, "tag_picker": true,
 		"enter_visual_mode": true, "enter_toggle_mode": true, "toggle_selection": true, "exit_visual_mode": true,

--- a/cli/internal/handler/handler.go
+++ b/cli/internal/handler/handler.go
@@ -31,7 +31,8 @@ type Handler struct {
 	store       *store.DB // SQLite store (primary read backend)
 	parser      *mail.Parser
 	contacts    *contacts.DB
-	cfg         *config.Config    // application config (for outbox worker)
+	cfg         *config.Config                // application config (for outbox worker)
+	groups      map[string]config.GroupEntry   // contact groups for query expansion
 	fetcher        AttachmentFetcher // optional IMAP attachment fetcher
 	syncTrigger    SyncTrigger       // optional sync trigger for tag changes
 	tagSync        *tagsync.Client   // optional remote tag sync client
@@ -67,6 +68,21 @@ func (h *Handler) SetTagSync(c *tagsync.Client) {
 // Used by CLI commands that modify tags when tag sync is configured.
 func (h *Handler) EnableTagJournal() {
 	h.tagSyncEnabled = true
+}
+
+// SetGroups sets the contact groups for query expansion.
+func (h *Handler) SetGroups(groups map[string]config.GroupEntry) {
+	h.groups = groups
+}
+
+// Groups returns the loaded contact groups.
+func (h *Handler) Groups() map[string]config.GroupEntry {
+	return h.groups
+}
+
+// expandGroups replaces group:NAME references in a query with from: OR-chains.
+func (h *Handler) expandGroups(query string) (string, error) {
+	return config.ExpandGroupsInQuery(query, h.groups)
 }
 
 // SetConfig sets the application config (needed by outbox worker for account lookup).

--- a/cli/internal/handler/handler_test.go
+++ b/cli/internal/handler/handler_test.go
@@ -295,15 +295,15 @@ func TestStoreTag(t *testing.T) {
 	}
 }
 
-func TestStoreTagNonThreadRejects(t *testing.T) {
+func TestStoreTagBySearchQuery(t *testing.T) {
 	db := newTestStore(t)
 	seedStoreData(t, db)
 
 	h := New(db, nil)
 	resp := h.Tag("tag:inbox", "+archived")
 
-	if resp.OK {
-		t.Error("non-thread tag query should fail")
+	if !resp.OK {
+		t.Errorf("tag by search query should succeed, got error: %s", resp.Error)
 	}
 }
 

--- a/cli/internal/handler/http.go
+++ b/cli/internal/handler/http.go
@@ -5,6 +5,7 @@ import (
 	"log/slog"
 	"net/http"
 	"path/filepath"
+	"sort"
 	"strconv"
 	"strings"
 	"unicode"
@@ -64,7 +65,14 @@ func (h *Handler) SearchCountHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	count, err := h.store.SearchCount(query)
+	expanded, err := h.expandGroups(query)
+	if err != nil {
+		slog.Error("Group expansion failed", "module", "HANDLER", "query", query, "err", err)
+		http.Error(w, "invalid group reference: "+err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	count, err := h.store.SearchCount(expanded)
 	if err != nil {
 		slog.Error("Search count failed", "module", "HANDLER", "query", query, "err", err)
 		http.Error(w, "internal error", http.StatusInternalServerError)
@@ -134,6 +142,36 @@ func sanitizeFilename(name string) string {
 		return "attachment"
 	}
 	return name
+}
+
+// ListGroupsHandler handles GET /api/v1/groups
+// Returns all configured contact groups for GUI autocomplete.
+func (h *Handler) ListGroupsHandler(w http.ResponseWriter, r *http.Request) {
+	type groupResponse struct {
+		Name        string   `json:"name"`
+		Description string   `json:"description,omitempty"`
+		Members     []string `json:"members"`
+	}
+
+	groups := h.Groups()
+	result := make([]groupResponse, 0, len(groups))
+	for name, entry := range groups {
+		members := entry.Members
+		if members == nil {
+			members = []string{}
+		}
+		result = append(result, groupResponse{
+			Name:        name,
+			Description: entry.Description,
+			Members:     members,
+		})
+	}
+
+	sort.Slice(result, func(i, j int) bool {
+		return result[i].Name < result[j].Name
+	})
+
+	writeJSON(w, map[string]any{"groups": result, "ok": true})
 }
 
 func (h *Handler) TagThreadHandler(w http.ResponseWriter, r *http.Request) {

--- a/cli/internal/handler/http.go
+++ b/cli/internal/handler/http.go
@@ -148,9 +148,9 @@ func sanitizeFilename(name string) string {
 // Returns all configured contact groups for GUI autocomplete.
 func (h *Handler) ListGroupsHandler(w http.ResponseWriter, r *http.Request) {
 	type groupResponse struct {
-		Name        string   `json:"name"`
-		Description string   `json:"description,omitempty"`
-		Members     []string `json:"members"`
+		Name        string     `json:"name"`
+		Description string     `json:"description,omitempty"`
+		Members     [][]string `json:"members"`
 	}
 
 	groups := h.Groups()
@@ -158,7 +158,7 @@ func (h *Handler) ListGroupsHandler(w http.ResponseWriter, r *http.Request) {
 	for name, entry := range groups {
 		members := entry.Members
 		if members == nil {
-			members = []string{}
+			members = [][]string{}
 		}
 		result = append(result, groupResponse{
 			Name:        name,

--- a/cli/internal/handler/search.go
+++ b/cli/internal/handler/search.go
@@ -15,7 +15,12 @@ func (h *Handler) Search(query string, limit int, enrichLimit int) protocol.Resp
 		limit = 50
 	}
 
-	results, err := h.store.Search(query, limit)
+	expanded, err := h.expandGroups(query)
+	if err != nil {
+		return protocol.FailWithMessage(protocol.ErrBackendError, "expand groups: "+err.Error())
+	}
+
+	results, err := h.store.Search(expanded, limit)
 	if err != nil {
 		return protocol.Fail(protocol.ErrBackendError, err)
 	}

--- a/cli/internal/handler/tag.go
+++ b/cli/internal/handler/tag.go
@@ -18,16 +18,38 @@ func (h *Handler) Tag(query string, tags string) protocol.Response {
 
 	add, remove := splitTagOps(tagList)
 
-	if strings.HasPrefix(query, "thread:") {
-		threadID := strings.TrimPrefix(query, "thread:")
+	// Expand group references
+	expanded, err := h.expandGroups(query)
+	if err != nil {
+		return protocol.FailWithMessage(protocol.ErrBackendError, "expand groups: "+err.Error())
+	}
+
+	// Collect thread IDs to modify
+	var threadIDs []string
+	if strings.HasPrefix(expanded, "thread:") {
+		threadIDs = []string{strings.TrimPrefix(expanded, "thread:")}
+	} else {
+		// Search for matching threads
+		results, err := h.store.Search(expanded, 1000000)
+		if err != nil {
+			return protocol.Fail(protocol.ErrBackendError, err)
+		}
+		for _, r := range results {
+			threadIDs = append(threadIDs, r.Thread)
+		}
+	}
+
+	if len(threadIDs) == 0 {
+		return protocol.Success()
+	}
+
+	for _, threadID := range threadIDs {
 		if err := h.store.ModifyTagsByThread(threadID, add, remove); err != nil {
 			return protocol.Fail(protocol.ErrBackendError, err)
 		}
-		// Record in journal for tag sync (only if tag sync is configured)
 		if h.tagSync != nil || h.tagSyncEnabled {
 			h.journalTagChanges(threadID, add, remove)
 		}
-		// Trigger IMAP sync for affected accounts to push folder moves
 		if h.syncTrigger != nil {
 			accounts, err := h.store.GetAccountsByThread(threadID)
 			if err != nil {
@@ -37,14 +59,13 @@ func (h *Handler) Tag(query string, tags string) protocol.Response {
 				h.syncTrigger.TriggerSync(account)
 			}
 		}
-		// Push tag changes to remote sync server (best-effort)
 		if h.tagSync != nil {
 			go h.pushTagChanges(threadID, add, remove)
 		}
-		return protocol.Success()
 	}
 
-	return protocol.FailWithMessage(protocol.ErrBackendError, "only thread: queries are supported for tag modifications")
+	slog.Info("Tag operation complete", "module", "TAG", "threads", len(threadIDs), "add", add, "remove", remove)
+	return protocol.Success()
 }
 
 // journalTagChanges records tag changes in the local journal for later sync.

--- a/cli/internal/handler/watcher.go
+++ b/cli/internal/handler/watcher.go
@@ -49,13 +49,14 @@ type WatcherManager struct {
 	log         *slog.Logger
 	locks       map[string]*sync.Mutex // per-account sync locks keyed by email
 	locksMu     sync.Mutex             // protects the locks map
-	watchers    map[string]*accountWatcher // keyed by account identifier (e.g. "work")
-	filterRules []config.RuleConfig        // user-defined filter rules applied at sync time
+	watchers    map[string]*accountWatcher           // keyed by account identifier (e.g. "work")
+	filterRules []config.RuleConfig                  // user-defined filter rules applied at sync time
+	groups      map[string]config.GroupEntry          // contact groups for group: expansion in rules
 }
 
 // NewWatcherManager creates a WatcherManager wired to the given EventHub
 // and SQLite store.
-func NewWatcherManager(hub *EventHub, db *store.DB, rules []config.RuleConfig) *WatcherManager {
+func NewWatcherManager(hub *EventHub, db *store.DB, rules []config.RuleConfig, groups map[string]config.GroupEntry) *WatcherManager {
 	return &WatcherManager{
 		hub:         hub,
 		store:       db,
@@ -63,6 +64,7 @@ func NewWatcherManager(hub *EventHub, db *store.DB, rules []config.RuleConfig) *
 		locks:       make(map[string]*sync.Mutex),
 		watchers:    make(map[string]*accountWatcher),
 		filterRules: rules,
+		groups:      groups,
 	}
 }
 
@@ -151,7 +153,7 @@ func (w *WatcherManager) watchAccount(ctx context.Context, aw *accountWatcher) {
 		// Initial sync on the watcher's connection (catch-up, no SSE notification).
 		// If this kills the connection, SELECT below will fail and the
 		// outer loop reconnects with 30s backoff.
-		initOpts := &imap.SyncOptions{Quiet: true, Mailboxes: []string{"INBOX"}, Store: w.store, FilterRules: w.filterRules}
+		initOpts := &imap.SyncOptions{Quiet: true, Mailboxes: []string{"INBOX"}, Store: w.store, FilterRules: w.filterRules, Groups: w.groups}
 		initSyncer := imap.NewSyncerWithClient(account, client, initOpts)
 		if _, err := initSyncer.Sync(); err != nil {
 			w.log.Error("Initial sync failed", "account", account.Email, "err", err)
@@ -477,7 +479,7 @@ func (w *WatcherManager) syncAndNotify(account *config.AccountConfig, client *im
 
 	// Build syncer: reuse caller's IDLE connection, only sync INBOX.
 	// Iterating other mailboxes triggers rate-limiting on M365.
-	opts := &imap.SyncOptions{Quiet: true, Mailboxes: []string{"INBOX"}, Store: w.store, FilterRules: w.filterRules}
+	opts := &imap.SyncOptions{Quiet: true, Mailboxes: []string{"INBOX"}, Store: w.store, FilterRules: w.filterRules, Groups: w.groups}
 	syncer := imap.NewSyncerWithClient(account, client, opts)
 
 	// Run sync with timeout so a flaky server can't block the watcher forever.

--- a/cli/internal/handler/watcher_test.go
+++ b/cli/internal/handler/watcher_test.go
@@ -314,7 +314,7 @@ func TestFindAttachmentSection_NoMatch(t *testing.T) {
 
 func TestNewWatcherManager(t *testing.T) {
 	db := newTestStore(t)
-	w := NewWatcherManager(nil, db, nil)
+	w := NewWatcherManager(nil, db, nil, nil)
 	if w == nil {
 		t.Fatal("nil watcher manager")
 	}
@@ -331,7 +331,7 @@ func TestNewWatcherManager(t *testing.T) {
 
 func TestWatcherManager_AccountLock_SameEmailSameLock(t *testing.T) {
 	db := newTestStore(t)
-	w := NewWatcherManager(nil, db, nil)
+	w := NewWatcherManager(nil, db, nil, nil)
 
 	a := w.accountLock("alice@example.com")
 	b := w.accountLock("alice@example.com")
@@ -342,7 +342,7 @@ func TestWatcherManager_AccountLock_SameEmailSameLock(t *testing.T) {
 
 func TestWatcherManager_AccountLock_DifferentEmailsDifferentLocks(t *testing.T) {
 	db := newTestStore(t)
-	w := NewWatcherManager(nil, db, nil)
+	w := NewWatcherManager(nil, db, nil, nil)
 
 	a := w.accountLock("alice@example.com")
 	b := w.accountLock("bob@example.com")
@@ -353,7 +353,7 @@ func TestWatcherManager_AccountLock_DifferentEmailsDifferentLocks(t *testing.T) 
 
 func TestWatcherManager_AccountLock_ConcurrentSafe(t *testing.T) {
 	db := newTestStore(t)
-	w := NewWatcherManager(nil, db, nil)
+	w := NewWatcherManager(nil, db, nil, nil)
 
 	// Hammer accountLock from multiple goroutines — should not race
 	// when run under `bazel test --test_arg=-race` (go_test has race
@@ -377,7 +377,7 @@ func TestWatcherManager_AccountLock_ConcurrentSafe(t *testing.T) {
 
 func TestWatcherManager_TriggerSync_UnknownAccount(t *testing.T) {
 	db := newTestStore(t)
-	w := NewWatcherManager(nil, db, nil)
+	w := NewWatcherManager(nil, db, nil, nil)
 
 	// Must not panic when the account has no registered watcher
 	w.TriggerSync("unknown-account")

--- a/cli/internal/imap/rules.go
+++ b/cli/internal/imap/rules.go
@@ -10,6 +10,13 @@ import (
 	"github.com/durian-dev/durian/cli/internal/store"
 )
 
+// RuleAttachment holds the attachment metadata needed for rule evaluation.
+// Kept minimal to avoid importing cli/internal/mail.
+type RuleAttachment struct {
+	ContentType string
+	Filename    string
+}
+
 // ValidateRuleQuery checks if a rule match expression is syntactically valid.
 func ValidateRuleQuery(query string) error {
 	_, err := parseRuleQuery(query)
@@ -18,18 +25,31 @@ func ValidateRuleQuery(query string) error {
 
 // MatchingRules returns the rules whose match expression matches the message.
 // account is the account identifier (e.g. alias); header is the parsed mail header.
-func MatchingRules(rules []config.RuleConfig, msg *store.Message, attachmentCount int, header mail.Header, account string) []config.RuleConfig {
+// groups enables group: expansion in rule match expressions.
+func MatchingRules(rules []config.RuleConfig, msg *store.Message, attachments []RuleAttachment, header mail.Header, account string, groups map[string]config.GroupEntry) []config.RuleConfig {
 	var matched []config.RuleConfig
 	for _, rule := range rules {
 		if len(rule.Accounts) > 0 && !accountMatches(rule.Accounts, account) {
 			continue
 		}
-		expr, err := parseRuleQuery(rule.Match)
+
+		// Expand group: references in match expression
+		matchExpr := rule.Match
+		if len(groups) > 0 {
+			expanded, err := config.ExpandGroupsInQuery(matchExpr, groups)
+			if err != nil {
+				slog.Warn("Group expansion failed in rule", "module", "RULES", "name", rule.Name, "err", err)
+			} else {
+				matchExpr = expanded
+			}
+		}
+
+		expr, err := parseRuleQuery(matchExpr)
 		if err != nil {
-			slog.Warn("Skipping malformed rule", "module", "RULES", "name", rule.Name, "match", rule.Match, "err", err)
+			slog.Warn("Skipping malformed rule", "module", "RULES", "name", rule.Name, "match", matchExpr, "err", err)
 			continue
 		}
-		if evalExpr(expr, msg, attachmentCount, header) {
+		if evalExpr(expr, msg, attachments, header) {
 			matched = append(matched, rule)
 		}
 	}
@@ -255,26 +275,42 @@ func (p *ruleParser) parsePrimary() (ruleNode, error) {
 
 // --- In-memory evaluation ---
 
-func evalExpr(node ruleNode, msg *store.Message, attachmentCount int, header mail.Header) bool {
+func evalExpr(node ruleNode, msg *store.Message, attachments []RuleAttachment, header mail.Header) bool {
 	switch n := node.(type) {
 	case *ruleBinaryNode:
 		if n.op == "OR" {
-			return evalExpr(n.left, msg, attachmentCount, header) || evalExpr(n.right, msg, attachmentCount, header)
+			return evalExpr(n.left, msg, attachments, header) || evalExpr(n.right, msg, attachments, header)
 		}
-		return evalExpr(n.left, msg, attachmentCount, header) && evalExpr(n.right, msg, attachmentCount, header)
+		return evalExpr(n.left, msg, attachments, header) && evalExpr(n.right, msg, attachments, header)
 	case *ruleNotNode:
-		return !evalExpr(n.child, msg, attachmentCount, header)
+		return !evalExpr(n.child, msg, attachments, header)
 	case *ruleFieldNode:
 		switch n.field {
 		case "from":
 			return strings.Contains(strings.ToLower(msg.FromAddr), strings.ToLower(n.value))
 		case "to":
 			return strings.Contains(strings.ToLower(msg.ToAddrs), strings.ToLower(n.value))
+		case "cc":
+			return strings.Contains(strings.ToLower(msg.CCAddrs), strings.ToLower(n.value))
 		case "subject":
 			return strings.Contains(strings.ToLower(msg.Subject), strings.ToLower(n.value))
 		case "has":
-			if strings.EqualFold(n.value, "attachment") {
-				return attachmentCount > 0
+			val := strings.ToLower(n.value)
+			if val == "attachment" {
+				return len(attachments) > 0
+			}
+			// has:attachment:TYPE — match on attachment content type
+			if strings.HasPrefix(val, "attachment:") {
+				wantType := val[len("attachment:"):]
+				for _, att := range attachments {
+					if strings.Contains(strings.ToLower(att.ContentType), wantType) {
+						return true
+					}
+					if strings.HasSuffix(strings.ToLower(att.Filename), "."+wantType) {
+						return true
+					}
+				}
+				return false
 			}
 			return false
 		case "header":

--- a/cli/internal/imap/rules_test.go
+++ b/cli/internal/imap/rules_test.go
@@ -11,12 +11,12 @@ import (
 func TestEvalExpr_FieldFrom(t *testing.T) {
 	msg := &store.Message{FromAddr: "alice@work.test"}
 	expr, _ := parseRuleQuery("from:@work.test")
-	if !evalExpr(expr, msg, 0, nil) {
+	if !evalExpr(expr, msg, nil, nil) {
 		t.Error("expected from:@work.test to match")
 	}
 
 	expr2, _ := parseRuleQuery("from:@example.com")
-	if evalExpr(expr2, msg, 0, nil) {
+	if evalExpr(expr2, msg, nil, nil) {
 		t.Error("expected from:@example.com to NOT match")
 	}
 }
@@ -24,7 +24,7 @@ func TestEvalExpr_FieldFrom(t *testing.T) {
 func TestEvalExpr_FieldTo(t *testing.T) {
 	msg := &store.Message{ToAddrs: "newsletter@example.com, bob@test.com"}
 	expr, _ := parseRuleQuery("to:newsletter@")
-	if !evalExpr(expr, msg, 0, nil) {
+	if !evalExpr(expr, msg, nil, nil) {
 		t.Error("expected to:newsletter@ to match")
 	}
 }
@@ -32,7 +32,7 @@ func TestEvalExpr_FieldTo(t *testing.T) {
 func TestEvalExpr_FieldSubject(t *testing.T) {
 	msg := &store.Message{Subject: "Weekly Status Report"}
 	expr, _ := parseRuleQuery("subject:status")
-	if !evalExpr(expr, msg, 0, nil) {
+	if !evalExpr(expr, msg, nil, nil) {
 		t.Error("expected subject:status to match (case-insensitive)")
 	}
 }
@@ -40,28 +40,67 @@ func TestEvalExpr_FieldSubject(t *testing.T) {
 func TestEvalExpr_HasAttachment(t *testing.T) {
 	msg := &store.Message{}
 	expr, _ := parseRuleQuery("has:attachment")
-	if evalExpr(expr, msg, 0, nil) {
+	if evalExpr(expr, msg, nil, nil) {
 		t.Error("expected has:attachment to NOT match with 0 attachments")
 	}
-	if !evalExpr(expr, msg, 2, nil) {
-		t.Error("expected has:attachment to match with 2 attachments")
+	atts := []RuleAttachment{{ContentType: "application/pdf", Filename: "doc.pdf"}}
+	if !evalExpr(expr, msg, atts, nil) {
+		t.Error("expected has:attachment to match with attachments")
+	}
+}
+
+func TestEvalExpr_HasAttachmentType(t *testing.T) {
+	msg := &store.Message{}
+	atts := []RuleAttachment{
+		{ContentType: "application/pdf", Filename: "contract.pdf"},
+		{ContentType: "image/jpeg", Filename: "photo.jpg"},
+	}
+
+	expr, _ := parseRuleQuery("has:attachment:pdf")
+	if !evalExpr(expr, msg, atts, nil) {
+		t.Error("expected has:attachment:pdf to match")
+	}
+
+	expr2, _ := parseRuleQuery("has:attachment:xlsx")
+	if evalExpr(expr2, msg, atts, nil) {
+		t.Error("expected has:attachment:xlsx to NOT match")
+	}
+
+	// Match by file extension when content-type is generic
+	atts2 := []RuleAttachment{{ContentType: "application/octet-stream", Filename: "data.csv"}}
+	expr3, _ := parseRuleQuery("has:attachment:csv")
+	if !evalExpr(expr3, msg, atts2, nil) {
+		t.Error("expected has:attachment:csv to match by filename")
+	}
+}
+
+func TestEvalExpr_CC(t *testing.T) {
+	msg := &store.Message{CCAddrs: "alice@example.com, bob@work.test"}
+	expr, _ := parseRuleQuery("cc:@work.test")
+	if !evalExpr(expr, msg, nil, nil) {
+		t.Error("expected cc:@work.test to match")
+	}
+
+	expr2, _ := parseRuleQuery("cc:@other.com")
+	if evalExpr(expr2, msg, nil, nil) {
+		t.Error("expected cc:@other.com to NOT match")
 	}
 }
 
 func TestEvalExpr_BareWord(t *testing.T) {
 	msg := &store.Message{Subject: "Invoice for January", BodyText: "Please find attached."}
 	expr, _ := parseRuleQuery("invoice")
-	if !evalExpr(expr, msg, 0, nil) {
+	if !evalExpr(expr, msg, nil, nil) {
 		t.Error("expected bare word 'invoice' to match subject")
 	}
 
 	expr2, _ := parseRuleQuery("attached")
-	if !evalExpr(expr2, msg, 0, nil) {
+	if !evalExpr(expr2, msg, nil, nil) {
 		t.Error("expected bare word 'attached' to match body")
 	}
 
 	expr3, _ := parseRuleQuery("missing")
-	if evalExpr(expr3, msg, 0, nil) {
+	if evalExpr(expr3, msg, nil, nil) {
 		t.Error("expected bare word 'missing' to NOT match")
 	}
 }
@@ -69,12 +108,12 @@ func TestEvalExpr_BareWord(t *testing.T) {
 func TestEvalExpr_BooleanAND(t *testing.T) {
 	msg := &store.Message{FromAddr: "alice@work.test", Subject: "Report"}
 	expr, _ := parseRuleQuery("from:@work.test subject:report")
-	if !evalExpr(expr, msg, 0, nil) {
+	if !evalExpr(expr, msg, nil, nil) {
 		t.Error("expected implicit AND to match")
 	}
 
 	msg2 := &store.Message{FromAddr: "alice@work.test", Subject: "Hello"}
-	if evalExpr(expr, msg2, 0, nil) {
+	if evalExpr(expr, msg2, nil, nil) {
 		t.Error("expected implicit AND to NOT match when subject differs")
 	}
 }
@@ -82,12 +121,12 @@ func TestEvalExpr_BooleanAND(t *testing.T) {
 func TestEvalExpr_BooleanOR(t *testing.T) {
 	msg := &store.Message{FromAddr: "alice@work.test"}
 	expr, _ := parseRuleQuery("from:@work.test OR from:@example.com")
-	if !evalExpr(expr, msg, 0, nil) {
+	if !evalExpr(expr, msg, nil, nil) {
 		t.Error("expected OR to match first branch")
 	}
 
 	msg2 := &store.Message{FromAddr: "bob@other.com"}
-	if evalExpr(expr, msg2, 0, nil) {
+	if evalExpr(expr, msg2, nil, nil) {
 		t.Error("expected OR to NOT match when neither branch matches")
 	}
 }
@@ -95,12 +134,12 @@ func TestEvalExpr_BooleanOR(t *testing.T) {
 func TestEvalExpr_BooleanNOT(t *testing.T) {
 	msg := &store.Message{FromAddr: "alice@work.test"}
 	expr, _ := parseRuleQuery("NOT from:@example.com")
-	if !evalExpr(expr, msg, 0, nil) {
+	if !evalExpr(expr, msg, nil, nil) {
 		t.Error("expected NOT to match when inner doesn't match")
 	}
 
 	expr2, _ := parseRuleQuery("NOT from:@work.test")
-	if evalExpr(expr2, msg, 0, nil) {
+	if evalExpr(expr2, msg, nil, nil) {
 		t.Error("expected NOT to NOT match when inner matches")
 	}
 }
@@ -108,7 +147,7 @@ func TestEvalExpr_BooleanNOT(t *testing.T) {
 func TestEvalExpr_Parentheses(t *testing.T) {
 	msg := &store.Message{FromAddr: "alice@work.test", Subject: "Report"}
 	expr, _ := parseRuleQuery("(from:@work.test OR from:@example.com) subject:report")
-	if !evalExpr(expr, msg, 0, nil) {
+	if !evalExpr(expr, msg, nil, nil) {
 		t.Error("expected grouped OR + AND to match")
 	}
 }
@@ -116,7 +155,7 @@ func TestEvalExpr_Parentheses(t *testing.T) {
 func TestEvalExpr_CaseInsensitive(t *testing.T) {
 	msg := &store.Message{FromAddr: "Alice@WORK.TEST"}
 	expr, _ := parseRuleQuery("from:@work.test")
-	if !evalExpr(expr, msg, 0, nil) {
+	if !evalExpr(expr, msg, nil, nil) {
 		t.Error("expected case-insensitive match on from")
 	}
 }
@@ -126,12 +165,12 @@ func TestEvalExpr_Header(t *testing.T) {
 	hdr := mail.Header{"List-Id": []string{"<python-dev.python.org>"}}
 
 	expr, _ := parseRuleQuery("header:list-id:python-dev")
-	if !evalExpr(expr, msg, 0, hdr) {
+	if !evalExpr(expr, msg, nil, hdr) {
 		t.Error("expected header:list-id to match")
 	}
 
 	expr2, _ := parseRuleQuery("header:list-id:ruby")
-	if evalExpr(expr2, msg, 0, hdr) {
+	if evalExpr(expr2, msg, nil, hdr) {
 		t.Error("expected header:list-id:ruby to NOT match")
 	}
 }
@@ -141,7 +180,7 @@ func TestEvalExpr_HeaderReturnPath(t *testing.T) {
 	hdr := mail.Header{"Return-Path": []string{"<bounces@lists.test>"}}
 
 	expr, _ := parseRuleQuery("header:return-path:bounces@")
-	if !evalExpr(expr, msg, 0, hdr) {
+	if !evalExpr(expr, msg, nil, hdr) {
 		t.Error("expected header:return-path to match")
 	}
 }
@@ -152,18 +191,18 @@ func TestEvalExpr_HeaderExistence(t *testing.T) {
 	// Header present → should match
 	hdr := mail.Header{"List-Unsubscribe": []string{"<mailto:unsub@test.com>"}}
 	expr, _ := parseRuleQuery("header:list-unsubscribe:")
-	if !evalExpr(expr, msg, 0, hdr) {
+	if !evalExpr(expr, msg, nil, hdr) {
 		t.Error("expected header:list-unsubscribe: to match when header exists")
 	}
 
 	// Header absent → should NOT match
 	hdrEmpty := mail.Header{}
-	if evalExpr(expr, msg, 0, hdrEmpty) {
+	if evalExpr(expr, msg, nil, hdrEmpty) {
 		t.Error("expected header:list-unsubscribe: to NOT match when header is absent")
 	}
 
 	// Nil header → should NOT match
-	if evalExpr(expr, msg, 0, nil) {
+	if evalExpr(expr, msg, nil, nil) {
 		t.Error("expected header:list-unsubscribe: to NOT match with nil header")
 	}
 }
@@ -180,7 +219,7 @@ func TestMatchingRules(t *testing.T) {
 		ToAddrs:  "newsletter@work.test",
 	}
 
-	matched := MatchingRules(rules, msg, 0, nil, "myaccount")
+	matched := MatchingRules(rules, msg, nil, nil, "myaccount", nil)
 	if len(matched) != 2 {
 		t.Errorf("expected 2 matched rules, got %d", len(matched))
 	}
@@ -192,7 +231,7 @@ func TestWildcardMatchesEverything(t *testing.T) {
 	}
 
 	msg := &store.Message{FromAddr: "anyone@anywhere.com", Subject: "Whatever"}
-	matched := MatchingRules(rules, msg, 0, nil, "test")
+	matched := MatchingRules(rules, msg, nil, nil, "test", nil)
 	if len(matched) != 1 {
 		t.Errorf("wildcard * should match everything, got %d matches", len(matched))
 	}
@@ -207,13 +246,13 @@ func TestMatchingRules_AccountScope(t *testing.T) {
 	msg := &store.Message{FromAddr: "alice@work.test"}
 
 	// Should match only the global rule when account doesn't match
-	matched := MatchingRules(rules, msg, 0, nil, "office")
+	matched := MatchingRules(rules, msg, nil, nil, "office", nil)
 	if len(matched) != 1 || matched[0].Name != "Global" {
 		t.Errorf("expected only Global rule, got %v", matched)
 	}
 
 	// Should match both when account matches
-	matched2 := MatchingRules(rules, msg, 0, nil, "personal")
+	matched2 := MatchingRules(rules, msg, nil, nil, "personal", nil)
 	if len(matched2) != 2 {
 		t.Errorf("expected 2 rules for matching account, got %d", len(matched2))
 	}

--- a/cli/internal/imap/sync.go
+++ b/cli/internal/imap/sync.go
@@ -54,8 +54,9 @@ type SyncOptions struct {
 	Mode             SyncMode            // Sync direction
 	Mailboxes        []string            // Specific mailboxes to sync (empty = all)
 	Store            *store.DB           // SQLite store (required)
-	FilterRules      []config.RuleConfig // User-defined filter rules applied at insert time
-	BackfillHeaders  bool                // Fetch and store headers for existing messages
+	FilterRules      []config.RuleConfig          // User-defined filter rules applied at insert time
+	Groups           map[string]config.GroupEntry // Contact groups for group: expansion in rules
+	BackfillHeaders  bool                         // Fetch and store headers for existing messages
 }
 
 // SyncResult contains the results of a sync operation

--- a/cli/internal/imap/sync_store.go
+++ b/cli/internal/imap/sync_store.go
@@ -132,7 +132,11 @@ func (s *Syncer) storeInsertMessage(mailboxName string, imapMsg *goimap.Message,
 
 	// Apply user-defined filter rules
 	if len(s.options.FilterRules) > 0 {
-		matched := MatchingRules(s.options.FilterRules, storeMsg, len(content.Attachments), parsed.Header, s.accountName())
+		atts := make([]RuleAttachment, len(content.Attachments))
+		for i, a := range content.Attachments {
+			atts[i] = RuleAttachment{ContentType: a.ContentType, Filename: a.Filename}
+		}
+		matched := MatchingRules(s.options.FilterRules, storeMsg, atts, parsed.Header, s.accountName(), s.options.Groups)
 		slog.Debug("Filter rules matched", "module", "RULES", "matched", len(matched), "total", len(s.options.FilterRules), "message_id", messageID)
 		for _, rule := range matched {
 			addTags := rule.AddTags

--- a/cli/internal/store/headers.go
+++ b/cli/internal/store/headers.go
@@ -56,7 +56,7 @@ func (d *DB) GetMessageDBID(messageID, account string) (int64, error) {
 // AllMessages returns all messages with fields needed for rule matching.
 func (d *DB) AllMessages() ([]*Message, error) {
 	rows, err := d.db.Query(
-		"SELECT id, message_id, subject, from_addr, to_addrs, body_text, account FROM messages")
+		"SELECT id, message_id, subject, from_addr, to_addrs, cc_addrs, body_text, account FROM messages")
 	if err != nil {
 		return nil, fmt.Errorf("query messages: %w", err)
 	}
@@ -65,7 +65,7 @@ func (d *DB) AllMessages() ([]*Message, error) {
 	var msgs []*Message
 	for rows.Next() {
 		m := &Message{}
-		if err := rows.Scan(&m.ID, &m.MessageID, &m.Subject, &m.FromAddr, &m.ToAddrs, &m.BodyText, &m.Account); err != nil {
+		if err := rows.Scan(&m.ID, &m.MessageID, &m.Subject, &m.FromAddr, &m.ToAddrs, &m.CCAddrs, &m.BodyText, &m.Account); err != nil {
 			return nil, fmt.Errorf("scan message: %w", err)
 		}
 		msgs = append(msgs, m)
@@ -114,6 +114,32 @@ func (d *DB) AttachmentCounts() (map[int64]int, error) {
 			return nil, fmt.Errorf("scan attachment count: %w", err)
 		}
 		result[msgID] = count
+	}
+	return result, rows.Err()
+}
+
+// AttachmentMeta holds minimal attachment info for rule matching.
+type AttachmentMeta struct {
+	ContentType string
+	Filename    string
+}
+
+// AttachmentsByMessage returns attachment metadata grouped by message DB ID.
+func (d *DB) AttachmentsByMessage() (map[int64][]AttachmentMeta, error) {
+	rows, err := d.db.Query("SELECT message_db_id, content_type, filename FROM attachments")
+	if err != nil {
+		return nil, fmt.Errorf("query attachments: %w", err)
+	}
+	defer rows.Close()
+
+	result := make(map[int64][]AttachmentMeta)
+	for rows.Next() {
+		var msgID int64
+		var ct, fn string
+		if err := rows.Scan(&msgID, &ct, &fn); err != nil {
+			return nil, fmt.Errorf("scan attachment: %w", err)
+		}
+		result[msgID] = append(result[msgID], AttachmentMeta{ContentType: ct, Filename: fn})
 	}
 	return result, rows.Err()
 }

--- a/cli/internal/store/search.go
+++ b/cli/internal/store/search.go
@@ -424,6 +424,9 @@ func fieldToSQL(f *fieldExpr) (string, []interface{}, error) {
 	case "to":
 		return "m.to_addrs LIKE ?", []interface{}{"%" + f.value + "%"}, nil
 
+	case "cc":
+		return "m.cc_addrs LIKE ?", []interface{}{"%" + f.value + "%"}, nil
+
 	case "subject":
 		return "m.id IN (SELECT rowid FROM messages_fts WHERE messages_fts MATCH ?)",
 			[]interface{}{"subject:" + f.value}, nil

--- a/cli/internal/store/search.go
+++ b/cli/internal/store/search.go
@@ -445,6 +445,9 @@ func fieldToSQL(f *fieldExpr) (string, []interface{}, error) {
 	case "folder", "thread", "id", "mimetype":
 		return "1=1", nil, nil
 
+	case "group":
+		return "", nil, fmt.Errorf("group:%s was not expanded — check groups.toml", f.value)
+
 	default:
 		return "", nil, fmt.Errorf("unknown query field: %q", f.field)
 	}

--- a/cli/internal/store/search.go
+++ b/cli/internal/store/search.go
@@ -445,6 +445,18 @@ func fieldToSQL(f *fieldExpr) (string, []interface{}, error) {
 		}
 		return "1=1", nil, nil
 
+	case "has":
+		val := strings.ToLower(f.value)
+		if val == "attachment" {
+			return "EXISTS (SELECT 1 FROM attachments WHERE attachments.message_db_id = m.id)", nil, nil
+		}
+		if strings.HasPrefix(val, "attachment:") {
+			wantType := val[len("attachment:"):]
+			return "EXISTS (SELECT 1 FROM attachments WHERE attachments.message_db_id = m.id AND (LOWER(attachments.content_type) LIKE ? OR LOWER(attachments.filename) LIKE ?))",
+				[]interface{}{"%" + wantType + "%", "%." + wantType}, nil
+		}
+		return "", nil, fmt.Errorf("unknown has: value %q (try: attachment, attachment:pdf)", f.value)
+
 	case "folder", "thread", "id", "mimetype":
 		return "1=1", nil, nil
 

--- a/cli/internal/store/search.go
+++ b/cli/internal/store/search.go
@@ -2,6 +2,7 @@ package store
 
 import (
 	"fmt"
+	"strconv"
 	"strings"
 	"time"
 )
@@ -468,11 +469,12 @@ func fieldToSQL(f *fieldExpr) (string, []interface{}, error) {
 	}
 }
 
-// parseDateRange parses date queries into a SQL BETWEEN clause.
+// parseDateRange parses date queries into a SQL BETWEEN/comparison clause.
 // Supports:
 //   - Relative keywords: date:today, date:yesterday, date:week, date:2week,
-//     date:month, date:2month, date:year, date:2year
+//     date:month, date:2month, date:year, date:2year, date:30d, date:90d
 //   - Ranges: date:2024-01..2024-02, date:2024-01-15..2024-02-28
+//   - Open ranges: date:..month (older than 1 month), date:month.. (since 1 month ago)
 func parseDateRange(value string) (string, []interface{}, error) {
 	// Try relative keyword first (no ".." separator)
 	if !strings.Contains(value, "..") {
@@ -488,16 +490,56 @@ func parseDateRange(value string) (string, []interface{}, error) {
 		return "", nil, fmt.Errorf("date range must be FROM..TO, got %q", value)
 	}
 
-	from, err := parseDate(parts[0])
+	now := time.Now()
+	endOfDay := time.Date(now.Year(), now.Month(), now.Day(), 23, 59, 59, 0, now.Location())
+
+	// Open start: date:..X (older than X)
+	if parts[0] == "" {
+		to, err := resolveDateBound(parts[1], false)
+		if err != nil {
+			return "", nil, fmt.Errorf("parse date to: %w", err)
+		}
+		return "m.date <= ?", []interface{}{to}, nil
+	}
+
+	// Open end: date:X.. (since X)
+	if parts[1] == "" {
+		from, err := resolveDateBound(parts[0], true)
+		if err != nil {
+			return "", nil, fmt.Errorf("parse date from: %w", err)
+		}
+		return "m.date BETWEEN ? AND ?", []interface{}{from, endOfDay.Unix()}, nil
+	}
+
+	from, err := resolveDateBound(parts[0], true)
 	if err != nil {
 		return "", nil, fmt.Errorf("parse date from: %w", err)
 	}
-	to, err := parseDateEnd(parts[1])
+	to, err := resolveDateBound(parts[1], false)
 	if err != nil {
 		return "", nil, fmt.Errorf("parse date to: %w", err)
 	}
 
 	return "m.date BETWEEN ? AND ?", []interface{}{from, to}, nil
+}
+
+// resolveDateBound resolves a date string as either an absolute date or relative keyword.
+// isStart controls whether to return the start or end of the resolved period.
+func resolveDateBound(s string, isStart bool) (int64, error) {
+	// Try relative keyword first
+	from, to, err := resolveRelativeDate(s)
+	if err == nil {
+		if isStart {
+			return from, nil
+		}
+		return to, nil
+	}
+
+	// Try absolute date
+	if isStart {
+		return parseDate(s)
+	}
+	return parseDateEnd(s)
 }
 
 // resolveRelativeDate converts a relative keyword to a (from, to) Unix timestamp pair.
@@ -525,7 +567,25 @@ func resolveRelativeDate(keyword string) (int64, int64, error) {
 	case "2year":
 		return today.AddDate(-2, 0, 0).Unix(), endOfDay.Unix(), nil
 	default:
-		return 0, 0, fmt.Errorf("unknown date keyword: %q (try: today, yesterday, week, 2week, month, 2month, year, 2year)", keyword)
+		// Try relative offset syntax: Nd (days), Nw (weeks), Nm (months), Ny (years)
+		kw := strings.ToLower(keyword)
+		if len(kw) >= 2 {
+			suffix := kw[len(kw)-1]
+			n, err := strconv.Atoi(kw[:len(kw)-1])
+			if err == nil && n > 0 {
+				switch suffix {
+				case 'd':
+					return today.AddDate(0, 0, -n).Unix(), endOfDay.Unix(), nil
+				case 'w':
+					return today.AddDate(0, 0, -n*7).Unix(), endOfDay.Unix(), nil
+				case 'm':
+					return today.AddDate(0, -n, 0).Unix(), endOfDay.Unix(), nil
+				case 'y':
+					return today.AddDate(-n, 0, 0).Unix(), endOfDay.Unix(), nil
+				}
+			}
+		}
+		return 0, 0, fmt.Errorf("unknown date keyword: %q (try: today, yesterday, week, month, year, 30d, 2w, 6m, 1y)", keyword)
 	}
 }
 

--- a/docs/groups-example.toml
+++ b/docs/groups-example.toml
@@ -1,52 +1,42 @@
 # Contact Groups — ~/.config/durian/groups.toml
 #
 # Groups map roles to email addresses or domain wildcards (*@domain.com).
-# Each member is an array of addresses (for people with multiple emails).
+# Single-address members are plain strings. Multi-email people use arrays:
+#
+#   members = [
+#     "alice@work.com",                          # single address
+#     ["bob@work.com", "bob@personal.com"],      # same person, two addresses
+#     "*@fund-xyz.com",                          # domain wildcard
+#   ]
 #
 # Query syntax:
 #   group:investor              — all communication with group (from + to)
 #   group:investor/from         — only mail FROM the group (incoming)
 #   group:investor/to           — only mail TO the group (outgoing/sent)
-#   group:investor AND date:month
-#
-# Examples:
-#   durian search "group:investor AND date:month"
-#   durian search "group:investor/to AND tag:sent AND date:week"
 
 [groups.investor]
 description = "Cap Table members"
 members = [
   ["alice@sequoia.com", "alice.smith@gmail.com"],
-  ["bob@index.vc"],
-  ["*@fund-xyz.com"],
+  "bob@index.vc",
+  "*@fund-xyz.com",
 ]
 
 [groups.advisor]
 members = [
   ["carol@example.org", "carol.personal@icloud.com"],
+  "mentor@university.edu",
 ]
 
 [groups.press]
-members = [
-  ["*@spiegel.de"],
-  ["*@handelsblatt.com"],
-  ["*@techcrunch.com"],
-]
+members = ["*@spiegel.de", "*@handelsblatt.com", "*@techcrunch.com"]
 
 [groups.legal]
-members = [
-  ["*@kanzlei-mueller.de"],
-  ["notar@xy.de"],
-]
+members = ["*@kanzlei-mueller.de", "notar@xy.de"]
 
 [groups.ngo]
-members = [
-  ["*@greenpeace.org"],
-]
+members = ["*@greenpeace.org"]
 
 [groups.vip]
-description = "Always-surface contacts, any channel"
-members = [
-  ["cofounder@firma.de"],
-  ["lead@sequoia.com"],
-]
+description = "Always-surface contacts"
+members = ["cofounder@firma.de", "lead@sequoia.com"]

--- a/docs/groups-example.toml
+++ b/docs/groups-example.toml
@@ -1,49 +1,52 @@
 # Contact Groups — ~/.config/durian/groups.toml
 #
 # Groups map roles to email addresses or domain wildcards (*@domain.com).
-# Use group:NAME in search queries for automatic expansion:
+# Each member is an array of addresses (for people with multiple emails).
 #
+# Query syntax:
+#   group:investor              — all communication with group (from + to)
+#   group:investor/from         — only mail FROM the group (incoming)
+#   group:investor/to           — only mail TO the group (outgoing/sent)
+#   group:investor AND date:month
+#
+# Examples:
 #   durian search "group:investor AND date:month"
-#   → expands to: (from:alice@sequoia.com OR from:@fund-xyz.com) AND date:month
-#
-# Members support two patterns:
-#   "alice@example.com"   — exact email match
-#   "*@example.com"       — matches any address at that domain
+#   durian search "group:investor/to AND tag:sent AND date:week"
 
 [groups.investor]
 description = "Cap Table members"
 members = [
-  "alice@sequoia.com",
-  "bob@index.vc",
-  "*@fund-xyz.com",
+  ["alice@sequoia.com", "alice.smith@gmail.com"],
+  ["bob@index.vc"],
+  ["*@fund-xyz.com"],
 ]
 
 [groups.advisor]
 members = [
-  "carol@example.org",
+  ["carol@example.org", "carol.personal@icloud.com"],
 ]
 
 [groups.press]
 members = [
-  "*@spiegel.de",
-  "*@handelsblatt.com",
-  "*@techcrunch.com",
+  ["*@spiegel.de"],
+  ["*@handelsblatt.com"],
+  ["*@techcrunch.com"],
 ]
 
 [groups.legal]
 members = [
-  "*@kanzlei-mueller.de",
-  "notar@xy.de",
+  ["*@kanzlei-mueller.de"],
+  ["notar@xy.de"],
 ]
 
 [groups.ngo]
 members = [
-  "*@greenpeace.org",
+  ["*@greenpeace.org"],
 ]
 
 [groups.vip]
 description = "Always-surface contacts, any channel"
 members = [
-  "cofounder@firma.de",
-  "lead@sequoia.com",
+  ["cofounder@firma.de"],
+  ["lead@sequoia.com"],
 ]

--- a/docs/groups-example.toml
+++ b/docs/groups-example.toml
@@ -1,0 +1,49 @@
+# Contact Groups — ~/.config/durian/groups.toml
+#
+# Groups map roles to email addresses or domain wildcards (*@domain.com).
+# Use group:NAME in search queries for automatic expansion:
+#
+#   durian search "group:investor AND date:month"
+#   → expands to: (from:alice@sequoia.com OR from:@fund-xyz.com) AND date:month
+#
+# Members support two patterns:
+#   "alice@example.com"   — exact email match
+#   "*@example.com"       — matches any address at that domain
+
+[groups.investor]
+description = "Cap Table members"
+members = [
+  "alice@sequoia.com",
+  "bob@index.vc",
+  "*@fund-xyz.com",
+]
+
+[groups.advisor]
+members = [
+  "carol@example.org",
+]
+
+[groups.press]
+members = [
+  "*@spiegel.de",
+  "*@handelsblatt.com",
+  "*@techcrunch.com",
+]
+
+[groups.legal]
+members = [
+  "*@kanzlei-mueller.de",
+  "notar@xy.de",
+]
+
+[groups.ngo]
+members = [
+  "*@greenpeace.org",
+]
+
+[groups.vip]
+description = "Always-surface contacts, any channel"
+members = [
+  "cofounder@firma.de",
+  "lead@sequoia.com",
+]

--- a/docs/keymaps-example.toml
+++ b/docs/keymaps-example.toml
@@ -78,6 +78,36 @@ action = "tag_picker"
 key = "t"
 description = "Open tag picker"
 
+# ── Tag Operations (configurable tag shortcuts) ───────────────────────
+# tag_op applies +/- tag operations defined in the "tags" field.
+# Add your own shortcuts for any tag workflow.
+
+[[keymaps]]
+action = "tag_op"
+key = "T"
+tags = "+todo -inbox"
+description = "Mark as todo"
+
+[[keymaps]]
+action = "tag_op"
+key = "W"
+tags = "+waiting -inbox"
+description = "Mark as waiting"
+
+# More examples:
+# [[keymaps]]
+# action = "tag_op"
+# key = "!"
+# tags = "+urgent"
+# description = "Mark urgent"
+#
+# [[keymaps]]
+# action = "tag_op"
+# key = "ge"
+# sequence = true
+# tags = "+ephemeral"
+# description = "Mark as ephemeral"
+
 # ── Compose ────────────────────────────────────────────────────────────
 
 [[keymaps]]

--- a/docs/profiles-example.toml
+++ b/docs/profiles-example.toml
@@ -5,7 +5,10 @@
 # Profiles group accounts and define sidebar folders.
 # Switch profiles via Cmd+1, Cmd+2, etc.
 # accounts = ["*"] matches all accounts.
-# Folder queries use the search syntax (tag:, from:, date:, path:).
+# Folder queries use the search syntax (tag:, from:, date:, path:, group:).
+#
+# Section headers: omit the query field to create a non-clickable header.
+# This visually groups folders in the sidebar.
 
 # ── All Accounts ───────────────────────────────────────────────────────
 
@@ -44,13 +47,12 @@ name = "Trash"
 icon = "trash"
 query = "tag:trash"
 
-# ── Work Profile (single account) ─────────────────────────────────────
+# ── Work Profile (with section headers) ──────────────────────────────
 
 [[profile]]
 name = "Work"
 accounts = ["work"]
-color = "#EF4444"                 # Optional: per-profile accent color (hex).
-                                  # Overrides settings.accent_color when this profile is active.
+color = "#EF4444"
 
 [[profile.folders]]
 name = "Inbox"
@@ -62,15 +64,50 @@ name = "Sent"
 icon = "paperplane"
 query = "tag:sent"
 
+# Section header — no query, renders as non-clickable label
 [[profile.folders]]
-name = "Drafts"
-icon = "doc.text"
-query = "tag:draft"
+name = "Triage"
+
+[[profile.folders]]
+name = "To-Do"
+icon = "checklist"
+query = "tag:todo"
+
+[[profile.folders]]
+name = "Waiting"
+icon = "clock"
+query = "tag:waiting"
+
+[[profile.folders]]
+name = "Smart Views"
+
+[[profile.folders]]
+name = "VIP Unread"
+icon = "star"
+query = "group:vip AND tag:unread"
+
+[[profile.folders]]
+name = "Legal"
+icon = "building.columns"
+query = "tag:legal AND date:6m.."
+
+[[profile.folders]]
+name = "Calendar"
+icon = "calendar"
+query = "tag:cal AND date:2w.."
+
+[[profile.folders]]
+name = "System"
 
 [[profile.folders]]
 name = "Archive"
 icon = "archivebox"
 query = "tag:archive"
+
+[[profile.folders]]
+name = "Trash"
+icon = "trash"
+query = "tag:trash"
 
 # ── Shared Mailboxes (multiple accounts, per-account inboxes) ─────────
 

--- a/docs/rules-example.toml
+++ b/docs/rules-example.toml
@@ -1,38 +1,107 @@
 # Filter rules — applied automatically when syncing new messages.
+# Rules are evaluated sequentially: order matters for overlapping matches.
 # Copy to ~/.config/durian/rules.toml and customize.
 # Validate with: durian validate rules
 
-# ── Static tag rules ──────────────────────────────────────────────────
+# ============================================================
+# MAILING LISTS & NEWSLETTERS
+# ============================================================
 
 [[rules]]
-name = "Work emails"
-match = "from:@work.test"
-add_tags = ["work"]
+name = "Mailing lists"
+match = "header:list-id:"
+add_tags = ["list"]
 
 [[rules]]
-name = "Newsletters"
-match = "to:newsletter@"
-add_tags = ["newsletter"]
+name = "Newsletters (commercial)"
+match = "header:list-unsubscribe: NOT header:list-id:"
+add_tags = ["newsletter", "ephemeral"]
+remove_tags = ["inbox"]
+
+# ============================================================
+# GITHUB (split by reason — different priority levels)
+# ============================================================
+
+[[rules]]
+name = "GitHub mentions"
+match = "to:mention@noreply.github.com OR header:x-github-reason:mention"
+add_tags = ["gh", "gh/mention"]
+
+[[rules]]
+name = "GitHub review requested"
+match = "to:review_requested@noreply.github.com OR header:x-github-reason:review_requested"
+add_tags = ["gh", "gh/review"]
+
+[[rules]]
+name = "GitHub assigned"
+match = "to:assign@noreply.github.com OR header:x-github-reason:assign"
+add_tags = ["gh", "gh/assigned"]
+
+[[rules]]
+name = "GitHub subscribed (noise)"
+match = "to:subscribed@noreply.github.com OR header:x-github-reason:subscribed"
+add_tags = ["gh", "gh/subscribed", "ephemeral"]
 remove_tags = ["inbox"]
 
 [[rules]]
-name = "Invoices with attachments"
-match = "subject:invoice has:attachment"
-add_tags = ["invoice"]
+name = "GitHub CI activity"
+match = "to:ci_activity@noreply.github.com OR header:x-github-reason:ci_activity"
+add_tags = ["gh", "gh/ci", "ephemeral"]
+remove_tags = ["inbox"]
+
+# ============================================================
+# AUTOMATED / BULK (must run AFTER list/gh rules)
+# ============================================================
 
 [[rules]]
-name = "Mailing list"
-match = "header:list-id:dev-list"
-accounts = ["personal"]                    # Only apply to this account
-add_tags = ["mailing-list"]
+name = "Bulk notifications"
+match = "(header:precedence:bulk OR header:auto-submitted:auto-generated) NOT header:list-unsubscribe: NOT header:list-id: NOT header:x-github-reason:"
+add_tags = ["notification", "ephemeral"]
 remove_tags = ["inbox"]
 
 [[rules]]
-name = "Bounce detection"
-match = "header:return-path:bounces@"
-add_tags = ["bounce"]
+name = "Shipping & tracking"
+match = "(subject:Versand OR subject:Lieferung OR subject:tracking OR subject:Bestellung OR subject:shipment OR subject:delivered)"
+add_tags = ["notification", "ephemeral"]
+remove_tags = ["inbox"]
 
-# ── Exec hook (external command) ──────────────────────────────────────
+# ============================================================
+# ADDRESSING (customize per account!)
+# ============================================================
+
+# [[rules]]
+# name = "Direct to me (work)"
+# match = "to:you@company.com"
+# add_tags = ["to-me"]
+# accounts = ["work"]
+
+# [[rules]]
+# name = "CC only (work)"
+# match = "cc:you@company.com NOT to:you@company.com"
+# add_tags = ["cc-only"]
+# accounts = ["work"]
+
+# ============================================================
+# LONGTERM TYPE TAGS (10+ years retrieval)
+# ============================================================
+
+# group: in rules ONLY for persistent type tags.
+# NEVER for investor/advisor/press — those must stay query-time
+# expansion so role changes don't require backfilling old mails.
+
+# [[rules]]
+# name = "Legal (persistent tag via group)"
+# match = "group:legal"
+# add_tags = ["legal"]
+
+[[rules]]
+name = "Contracts"
+match = "(subject:Vertrag OR subject:contract OR subject:NDA OR subject:agreement OR subject:Vereinbarung OR subject:MoU) has:attachment:pdf"
+add_tags = ["finance/contract"]
+
+# ============================================================
+# EXEC HOOKS (external commands)
+# ============================================================
 # Runs a command for each matching email. The command receives email
 # data as JSON on stdin and returns tag operations on stdout.
 #
@@ -44,25 +113,32 @@ add_tags = ["bounce"]
 # used as fallback if set).
 
 # [[rules]]
-# name = "ML Classifier"
-# match = "*"                              # Wildcard: matches every email
-# exec = "durian-classify"                 # Command in PATH (or full path)
-# exec_timeout = 5                         # Seconds (default: 10)
-# accounts = ["work", "uni"]              # Optional: limit to accounts
-# allowed_tags = ["finance", "spam", "newsletter"]  # Optional: restrict exec output tags
+# name = "LLM triage"
+# match = "tag:inbox NOT tag:list NOT tag:newsletter NOT tag:notification NOT tag:gh"
+# exec = "durian-classify"
+# exec_timeout = 15
+# allowed_tags = ["urgent", "action-required", "fyi"]
 
-# ── Match syntax reference ────────────────────────────────────────────
+# ============================================================
+# MATCH SYNTAX REFERENCE
+# ============================================================
 #   *                         — wildcard, matches everything
 #   from:value                — case-insensitive contains on sender
 #   to:value                  — case-insensitive contains on recipients
+#   cc:value                  — case-insensitive contains on CC
 #   subject:value             — case-insensitive contains on subject
 #   header:Name:value         — case-insensitive contains on any header
 #   has:attachment            — message has at least one attachment
+#   has:attachment:pdf        — attachment with content-type or extension
+#   group:name                — expands to (from:X OR to:X ...) via groups.toml
 #   bare words                — case-insensitive contains on subject + body
 #   AND (implicit)            — adjacent terms are ANDed
 #   OR                        — explicit OR
 #   NOT                       — negates the next term
 #   ( )                       — grouping
+#
+# Note: subject:(X OR Y) does NOT work. Use (subject:X OR subject:Y).
+# Note: cal tag is set automatically for text/calendar content.
 #
 # Optional fields:
 #   accounts = ["alias"]      — only apply to specific accounts

--- a/macos/durian/ContentView+Keymaps.swift
+++ b/macos/durian/ContentView+Keymaps.swift
@@ -159,6 +159,35 @@ extension ContentView {
             await accountManager.syncAndRefresh()
         }
 
+        // Tag Op: configurable tag operations (e.g. T → +todo -inbox, W → +waiting -inbox)
+        keymapHandler.registerSimpleHandler(for: .tagOp) { [self] in
+            let seq = keymapHandler.engine.lastMatchedSequence
+            guard let tagsStr = SequenceMatcher.shared.tagOpTags(for: seq, context: keymapHandler.engine.activeContext) else { return }
+
+            // Parse "+tag1 -tag2" into add/remove arrays
+            let parts = tagsStr.split(separator: " ").map(String.init)
+            let add = parts.filter { $0.hasPrefix("+") }.map { String($0.dropFirst()) }
+            let remove = parts.filter { $0.hasPrefix("-") }.map { String($0.dropFirst()) }
+
+            let ids = await MainActor.run { () -> Set<String> in
+                let ids = markedEmails
+                guard !ids.isEmpty else { return [] }
+                // If removing inbox, advance cursor (like archive)
+                if remove.contains("inbox") {
+                    let next = nextEmailId(after: ids)
+                    visualModeAnchor = nil
+                    keymapHandler.engine.exitVisualMode()
+                    accountManager.removeLocally(ids: ids)
+                    advanceCursor(to: next)
+                }
+                return ids
+            }
+            for id in ids {
+                await accountManager.modifyTagsWithoutSync(id: id, add: add, remove: remove)
+            }
+            await accountManager.syncAndRefresh()
+        }
+
         // Delete: dd - works with multi-selection
         keymapHandler.registerSimpleHandler(for: .deleteEmail) { [self] in
             let ids = await MainActor.run { () -> Set<String> in

--- a/macos/durian/ContentView.swift
+++ b/macos/durian/ContentView.swift
@@ -523,26 +523,46 @@ struct ContentView: View {
 
     @ViewBuilder
     private var emptyStateView: some View {
-        if isSearchMode {
+        if accountManager.isLoadingEmails {
+            // Don't flash empty state while loading
+            Color.clear
+        } else if isSearchMode {
             ContentUnavailableView("No Results", systemImage: "magnifyingglass",
-                                   description: Text("No emails match your search."))
+                                   description: Text(Self.stableMessage(from: Self.searchEmptyMessages, seed: selectedTagID ?? "search")))
         } else if ConfigManager.shared.getAccounts().isEmpty {
             ContentUnavailableView {
                 Label("No Accounts", systemImage: "person.crop.circle.badge.exclamationmark")
             } description: {
                 Text("Add an account in\n~/.config/durian/config.toml\nthen run durian auth login <account>")
             }
-        } else if syncManager.lastSyncTime == nil {
-            ContentUnavailableView {
-                Label("No Emails Yet", systemImage: "tray")
-            } description: {
-                Text("Run durian sync from the terminal to fetch your emails.")
-            }
         } else {
-            ContentUnavailableView("No Emails", systemImage: "tray",
-                                   description: Text("This folder is empty."))
+            ContentUnavailableView("Inbox Zero", systemImage: "tray",
+                                   description: Text(Self.stableMessage(from: Self.emptyFolderMessages, seed: selectedTagID ?? "default")))
         }
     }
+
+    /// Pick a message deterministically based on seed (stable per folder, varies between folders)
+    private static func stableMessage(from messages: [String], seed: String) -> String {
+        let hash = seed.utf8.reduce(0) { $0 &+ Int($1) }
+        return messages[abs(hash) % messages.count]
+    }
+
+    private static let emptyFolderMessages = [
+        "Nothing here. Suspicious.",
+        "You've read everything. Now what.",
+        "Empty. Go build something.",
+        "Inbox zero. Enjoy the 4 seconds.",
+        ":q! executed on your inbox.",
+        "/dev/null successfully achieved.",
+        "Achievement unlocked: not drowning.",
+    ]
+
+    private static let searchEmptyMessages = [
+        "No mails match. Tighten your query or loosen your expectations.",
+        "Zero results. Either very specific or very wrong.",
+        "Nothing found. Try from: + date: — it's always from: + date:.",
+        "No matches. Your query or your luck.",
+    ]
 
     // MARK: - Display Emails (Search Mode vs Normal)
 

--- a/macos/durian/ContentView.swift
+++ b/macos/durian/ContentView.swift
@@ -392,9 +392,20 @@ struct ContentView: View {
                 isSearchMode = false
                 searchResults = []
                 lastSearchQuery = ""
+                isThreadFocused = false
+                keymapHandler.engine.setContext(.list)
+                cursorEmailId = nil
+                markedEmails = []
                 Task {
                     await accountManager.selectTag(tagId)
                 }
+            }
+        }
+        .onChange(of: accountManager.emailListGeneration) { _, _ in
+            // Auto-select first email when list data arrives and cursor is empty
+            if cursorEmailId == nil, let firstId = accountManager.mailMessages.first?.id {
+                cursorEmailId = firstId
+                markedEmails = [firstId]
             }
         }
         .onChange(of: markedEmails) { _, newSelection in

--- a/macos/durian/Keymaps/KeySequenceEngine.swift
+++ b/macos/durian/Keymaps/KeySequenceEngine.swift
@@ -44,6 +44,9 @@ class KeySequenceEngine: ObservableObject {
     /// Whether engine is waiting for more keys
     @Published private(set) var isWaitingForMore: Bool = false
 
+    /// Last matched sequence string (for tag_op lookups)
+    private(set) var lastMatchedSequence: String = ""
+
     /// Current visual mode type (none, line, toggle)
     @Published private(set) var visualModeType: VisualModeType = .none
 
@@ -184,6 +187,8 @@ class KeySequenceEngine: ObservableObject {
 
         switch result {
         case .match(let action, let count):
+            let (_, seq) = matcher.parseCountAndSequence(bufferStr)
+            lastMatchedSequence = seq
             executeAction(action, count: count)
             buffer.clear()
             currentSequence = ""

--- a/macos/durian/Keymaps/KeymapHandler.swift
+++ b/macos/durian/Keymaps/KeymapHandler.swift
@@ -152,8 +152,6 @@ class KeymapHandler: ObservableObject {
     }
     
     private func handleKeyEvent(_ event: NSEvent) -> Bool {
-        let key = event.charactersIgnoringModifiers ?? "?"
-        Log.debug("KEYMAPS", "Key event: \(key) code=\(event.keyCode) textFocused=\(isTextInputFocused()) appFg=\(isAppInForeground) enabled=\(keymapsManager.keymaps.globalSettings.keymapsEnabled) seqs=\(SequenceMatcher.shared.allSequences.count)")
         let isPopupContext = sequenceEngine.activeContext == .search || sequenceEngine.activeContext == .tagPicker
 
         // When text input is focused: let Ctrl+ keys through to engine in popup contexts

--- a/macos/durian/Keymaps/KeymapHandler.swift
+++ b/macos/durian/Keymaps/KeymapHandler.swift
@@ -194,7 +194,7 @@ class KeymapHandler: ObservableObject {
         
         // Check keymaps.toml entries
         for keymapEntry in keymapsManager.keymaps.keymaps {
-            guard keymapEntry.enabled else { continue }
+            // Legacy entries require modifiers
             guard !keymapEntry.modifiers.isEmpty else { continue } // Skip no-modifier entries
             
             if keymapEntry.key.lowercased() == key && Set(keymapEntry.modifiers) == Set(modifiers) {

--- a/macos/durian/Keymaps/KeymapHandler.swift
+++ b/macos/durian/Keymaps/KeymapHandler.swift
@@ -152,6 +152,8 @@ class KeymapHandler: ObservableObject {
     }
     
     private func handleKeyEvent(_ event: NSEvent) -> Bool {
+        let key = event.charactersIgnoringModifiers ?? "?"
+        Log.debug("KEYMAPS", "Key event: \(key) code=\(event.keyCode) textFocused=\(isTextInputFocused()) appFg=\(isAppInForeground) enabled=\(keymapsManager.keymaps.globalSettings.keymapsEnabled) seqs=\(SequenceMatcher.shared.allSequences.count)")
         let isPopupContext = sequenceEngine.activeContext == .search || sequenceEngine.activeContext == .tagPicker
 
         // When text input is focused: let Ctrl+ keys through to engine in popup contexts

--- a/macos/durian/Keymaps/KeymapTypes.swift
+++ b/macos/durian/Keymaps/KeymapTypes.swift
@@ -37,6 +37,7 @@ enum KeymapAction: String, CaseIterable {
     case forward = "forward"
     case deleteEmail = "delete"
     case archiveEmail = "archive"
+    case tagOp = "tag_op"
     case toggleRead = "toggle_read"
     case toggleStar = "toggle_star"
 

--- a/macos/durian/Keymaps/KeymapsManager.swift
+++ b/macos/durian/Keymaps/KeymapsManager.swift
@@ -487,6 +487,7 @@ struct KeymapEntry: Codable {
     var sequence: Bool
     var supportsCount: Bool
     var context: String
+    var tags: String?  // For tag_op action: "+todo -inbox"
 
     enum CodingKeys: String, CodingKey {
         case action
@@ -497,6 +498,7 @@ struct KeymapEntry: Codable {
         case sequence
         case supportsCount = "supports_count"
         case context
+        case tags
     }
 
     // Custom init for backwards compatibility with old configs
@@ -507,14 +509,14 @@ struct KeymapEntry: Codable {
         modifiers = try container.decode([String].self, forKey: .modifiers)
         description = try container.decode(String.self, forKey: .description)
         enabled = try container.decode(Bool.self, forKey: .enabled)
-        // Defaults for old configs without these fields
         sequence = try container.decodeIfPresent(Bool.self, forKey: .sequence) ?? false
         supportsCount = try container.decodeIfPresent(Bool.self, forKey: .supportsCount) ?? false
         context = try container.decodeIfPresent(String.self, forKey: .context) ?? "list"
+        tags = try container.decodeIfPresent(String.self, forKey: .tags)
     }
 
     // Memberwise init for creating entries programmatically
-    init(action: String, key: String, modifiers: [String], description: String, enabled: Bool, sequence: Bool = false, supportsCount: Bool = false, context: String = "list") {
+    init(action: String, key: String, modifiers: [String], description: String, enabled: Bool, sequence: Bool = false, supportsCount: Bool = false, context: String = "list", tags: String? = nil) {
         self.action = action
         self.key = key
         self.modifiers = modifiers
@@ -523,6 +525,7 @@ struct KeymapEntry: Codable {
         self.sequence = sequence
         self.supportsCount = supportsCount
         self.context = context
+        self.tags = tags
     }
 }
 

--- a/macos/durian/Keymaps/KeymapsManager.swift
+++ b/macos/durian/Keymaps/KeymapsManager.swift
@@ -105,67 +105,67 @@ class KeymapsManager: ObservableObject {
     private func getDefaultKeymaps() -> [KeymapEntry] {
         return [
             // Navigation
-            KeymapEntry(action: "next_email", key: "j", modifiers: [], description: "Next email (vim j)", enabled: true, sequence: false, supportsCount: true),
-            KeymapEntry(action: "prev_email", key: "k", modifiers: [], description: "Previous email (vim k)", enabled: true, sequence: false, supportsCount: true),
-            KeymapEntry(action: "next_email", key: "Down", modifiers: [], description: "Next email (arrow)", enabled: true, sequence: false, supportsCount: false),
-            KeymapEntry(action: "prev_email", key: "Up", modifiers: [], description: "Previous email (arrow)", enabled: true, sequence: false, supportsCount: false),
-            KeymapEntry(action: "last_email", key: "G", modifiers: [], description: "Last email (Shift+G)", enabled: true, sequence: false, supportsCount: false),
-            KeymapEntry(action: "first_email", key: "gg", modifiers: [], description: "First email (vim gg)", enabled: true, sequence: true, supportsCount: false),
-            KeymapEntry(action: "page_down", key: "d", modifiers: ["ctrl"], description: "Half-page down (Ctrl+d)", enabled: true, sequence: false, supportsCount: true),
-            KeymapEntry(action: "page_up", key: "u", modifiers: ["ctrl"], description: "Half-page up (Ctrl+u)", enabled: true, sequence: false, supportsCount: true),
-            KeymapEntry(action: "archive", key: "a", modifiers: [], description: "Archive email (remove inbox)", enabled: true, sequence: false, supportsCount: false),
-            KeymapEntry(action: "compose", key: "c", modifiers: [], description: "Compose new email", enabled: true, sequence: false, supportsCount: false),
-            KeymapEntry(action: "reply", key: "r", modifiers: [], description: "Reply to email", enabled: true, sequence: false, supportsCount: false),
-            KeymapEntry(action: "reply_all", key: "R", modifiers: [], description: "Reply to all (Shift+R)", enabled: true, sequence: false, supportsCount: false),
-            KeymapEntry(action: "forward", key: "f", modifiers: [], description: "Forward email", enabled: true, sequence: false, supportsCount: false),
-            KeymapEntry(action: "toggle_read", key: "u", modifiers: [], description: "Toggle read/unread", enabled: true, sequence: false, supportsCount: false),
-            KeymapEntry(action: "toggle_star", key: "s", modifiers: [], description: "Toggle star", enabled: true, sequence: false, supportsCount: false),
-            KeymapEntry(action: "delete", key: "dd", modifiers: [], description: "Delete email (vim dd)", enabled: true, sequence: true, supportsCount: true),
+            KeymapEntry(action: "next_email", key: "j", modifiers: [], description: "Next email (vim j)", sequence: false, supportsCount: true),
+            KeymapEntry(action: "prev_email", key: "k", modifiers: [], description: "Previous email (vim k)", sequence: false, supportsCount: true),
+            KeymapEntry(action: "next_email", key: "Down", modifiers: [], description: "Next email (arrow)", sequence: false, supportsCount: false),
+            KeymapEntry(action: "prev_email", key: "Up", modifiers: [], description: "Previous email (arrow)", sequence: false, supportsCount: false),
+            KeymapEntry(action: "last_email", key: "G", modifiers: [], description: "Last email (Shift+G)", sequence: false, supportsCount: false),
+            KeymapEntry(action: "first_email", key: "gg", modifiers: [], description: "First email (vim gg)", sequence: true, supportsCount: false),
+            KeymapEntry(action: "page_down", key: "d", modifiers: ["ctrl"], description: "Half-page down (Ctrl+d)", sequence: false, supportsCount: true),
+            KeymapEntry(action: "page_up", key: "u", modifiers: ["ctrl"], description: "Half-page up (Ctrl+u)", sequence: false, supportsCount: true),
+            KeymapEntry(action: "archive", key: "a", modifiers: [], description: "Archive email (remove inbox)", sequence: false, supportsCount: false),
+            KeymapEntry(action: "compose", key: "c", modifiers: [], description: "Compose new email", sequence: false, supportsCount: false),
+            KeymapEntry(action: "reply", key: "r", modifiers: [], description: "Reply to email", sequence: false, supportsCount: false),
+            KeymapEntry(action: "reply_all", key: "R", modifiers: [], description: "Reply to all (Shift+R)", sequence: false, supportsCount: false),
+            KeymapEntry(action: "forward", key: "f", modifiers: [], description: "Forward email", sequence: false, supportsCount: false),
+            KeymapEntry(action: "toggle_read", key: "u", modifiers: [], description: "Toggle read/unread", sequence: false, supportsCount: false),
+            KeymapEntry(action: "toggle_star", key: "s", modifiers: [], description: "Toggle star", sequence: false, supportsCount: false),
+            KeymapEntry(action: "delete", key: "dd", modifiers: [], description: "Delete email (vim dd)", sequence: true, supportsCount: true),
             // Folder Navigation
-            KeymapEntry(action: "go_inbox", key: "gi", modifiers: [], description: "Go to inbox", enabled: true, sequence: true, supportsCount: false),
-            KeymapEntry(action: "go_sent", key: "gs", modifiers: [], description: "Go to sent", enabled: true, sequence: true, supportsCount: false),
-            KeymapEntry(action: "go_drafts", key: "gd", modifiers: [], description: "Go to drafts", enabled: true, sequence: true, supportsCount: false),
-            KeymapEntry(action: "go_archive", key: "ga", modifiers: [], description: "Go to archive", enabled: true, sequence: true, supportsCount: false),
+            KeymapEntry(action: "go_inbox", key: "gi", modifiers: [], description: "Go to inbox", sequence: true, supportsCount: false),
+            KeymapEntry(action: "go_sent", key: "gs", modifiers: [], description: "Go to sent", sequence: true, supportsCount: false),
+            KeymapEntry(action: "go_drafts", key: "gd", modifiers: [], description: "Go to drafts", sequence: true, supportsCount: false),
+            KeymapEntry(action: "go_archive", key: "ga", modifiers: [], description: "Go to archive", sequence: true, supportsCount: false),
             // Search
-            KeymapEntry(action: "search", key: "/", modifiers: [], description: "Search emails (vim /)", enabled: true, sequence: false, supportsCount: false),
-            KeymapEntry(action: "search", key: "/", modifiers: ["cmd"], description: "Search emails (Cmd+/)", enabled: true, sequence: false, supportsCount: false),
+            KeymapEntry(action: "search", key: "/", modifiers: [], description: "Search emails (vim /)", sequence: false, supportsCount: false),
+            KeymapEntry(action: "search", key: "/", modifiers: ["cmd"], description: "Search emails (Cmd+/)", sequence: false, supportsCount: false),
             // Tag Picker
-            KeymapEntry(action: "tag_picker", key: "t", modifiers: [], description: "Open tag picker", enabled: true, sequence: false, supportsCount: false),
+            KeymapEntry(action: "tag_picker", key: "t", modifiers: [], description: "Open tag picker", sequence: false, supportsCount: false),
             // View Control
-            KeymapEntry(action: "close_detail", key: "q", modifiers: [], description: "Close/back (vim q)", enabled: true, sequence: false, supportsCount: false),
-            KeymapEntry(action: "close_detail", key: "Escape", modifiers: [], description: "Close/back (Escape)", enabled: true, sequence: false, supportsCount: false),
-            KeymapEntry(action: "reload_inbox", key: "r", modifiers: ["cmd"], description: "Reload inbox (Cmd+r)", enabled: true, sequence: false, supportsCount: false),
+            KeymapEntry(action: "close_detail", key: "q", modifiers: [], description: "Close/back (vim q)", sequence: false, supportsCount: false),
+            KeymapEntry(action: "close_detail", key: "Escape", modifiers: [], description: "Close/back (Escape)", sequence: false, supportsCount: false),
+            KeymapEntry(action: "reload_inbox", key: "r", modifiers: ["cmd"], description: "Reload inbox (Cmd+r)", sequence: false, supportsCount: false),
             // Visual Mode
-            KeymapEntry(action: "enter_visual_mode", key: "v", modifiers: [], description: "Enter line visual mode (range select)", enabled: true, sequence: false, supportsCount: false),
-            KeymapEntry(action: "enter_toggle_mode", key: "V", modifiers: [], description: "Enter toggle visual mode (Shift+V)", enabled: true, sequence: false, supportsCount: false),
-            KeymapEntry(action: "toggle_selection", key: " ", modifiers: [], description: "Toggle current email (only in toggle mode)", enabled: true, sequence: false, supportsCount: false),
-            KeymapEntry(action: "exit_visual_mode", key: "Escape", modifiers: [], description: "Exit visual mode and clear selection", enabled: true, sequence: false, supportsCount: false),
+            KeymapEntry(action: "enter_visual_mode", key: "v", modifiers: [], description: "Enter line visual mode (range select)", sequence: false, supportsCount: false),
+            KeymapEntry(action: "enter_toggle_mode", key: "V", modifiers: [], description: "Enter toggle visual mode (Shift+V)", sequence: false, supportsCount: false),
+            KeymapEntry(action: "toggle_selection", key: " ", modifiers: [], description: "Toggle current email (only in toggle mode)", sequence: false, supportsCount: false),
+            KeymapEntry(action: "exit_visual_mode", key: "Escape", modifiers: [], description: "Exit visual mode and clear selection", sequence: false, supportsCount: false),
             // Search context
-            KeymapEntry(action: "select_next", key: "j", modifiers: ["ctrl"], description: "Next search result (Ctrl+j)", enabled: true, sequence: false, supportsCount: false, context: "search"),
-            KeymapEntry(action: "select_prev", key: "k", modifiers: ["ctrl"], description: "Previous search result (Ctrl+k)", enabled: true, sequence: false, supportsCount: false, context: "search"),
-            KeymapEntry(action: "select_next", key: "n", modifiers: ["ctrl"], description: "Next search result (Ctrl+n)", enabled: true, sequence: false, supportsCount: false, context: "search"),
-            KeymapEntry(action: "select_prev", key: "p", modifiers: ["ctrl"], description: "Previous search result (Ctrl+p)", enabled: true, sequence: false, supportsCount: false, context: "search"),
+            KeymapEntry(action: "select_next", key: "j", modifiers: ["ctrl"], description: "Next search result (Ctrl+j)", sequence: false, supportsCount: false, context: "search"),
+            KeymapEntry(action: "select_prev", key: "k", modifiers: ["ctrl"], description: "Previous search result (Ctrl+k)", sequence: false, supportsCount: false, context: "search"),
+            KeymapEntry(action: "select_next", key: "n", modifiers: ["ctrl"], description: "Next search result (Ctrl+n)", sequence: false, supportsCount: false, context: "search"),
+            KeymapEntry(action: "select_prev", key: "p", modifiers: ["ctrl"], description: "Previous search result (Ctrl+p)", sequence: false, supportsCount: false, context: "search"),
             // Tag picker context
-            KeymapEntry(action: "select_next", key: "j", modifiers: ["ctrl"], description: "Next tag (Ctrl+j)", enabled: true, sequence: false, supportsCount: false, context: "tag_picker"),
-            KeymapEntry(action: "select_prev", key: "k", modifiers: ["ctrl"], description: "Previous tag (Ctrl+k)", enabled: true, sequence: false, supportsCount: false, context: "tag_picker"),
-            KeymapEntry(action: "select_next", key: "n", modifiers: ["ctrl"], description: "Next tag (Ctrl+n)", enabled: true, sequence: false, supportsCount: false, context: "tag_picker"),
-            KeymapEntry(action: "select_prev", key: "p", modifiers: ["ctrl"], description: "Previous tag (Ctrl+p)", enabled: true, sequence: false, supportsCount: false, context: "tag_picker"),
+            KeymapEntry(action: "select_next", key: "j", modifiers: ["ctrl"], description: "Next tag (Ctrl+j)", sequence: false, supportsCount: false, context: "tag_picker"),
+            KeymapEntry(action: "select_prev", key: "k", modifiers: ["ctrl"], description: "Previous tag (Ctrl+k)", sequence: false, supportsCount: false, context: "tag_picker"),
+            KeymapEntry(action: "select_next", key: "n", modifiers: ["ctrl"], description: "Next tag (Ctrl+n)", sequence: false, supportsCount: false, context: "tag_picker"),
+            KeymapEntry(action: "select_prev", key: "p", modifiers: ["ctrl"], description: "Previous tag (Ctrl+p)", sequence: false, supportsCount: false, context: "tag_picker"),
             // Compose normal context
-            KeymapEntry(action: "exit_insert", key: "jk", modifiers: [], description: "Exit insert mode (jk)", enabled: true, sequence: true, supportsCount: false, context: "compose_normal"),
+            KeymapEntry(action: "exit_insert", key: "jk", modifiers: [], description: "Exit insert mode (jk)", sequence: true, supportsCount: false, context: "compose_normal"),
             // List context: enter thread
-            KeymapEntry(action: "enter_thread", key: "l", modifiers: [], description: "Enter thread view (l)", enabled: true, sequence: false, supportsCount: false),
+            KeymapEntry(action: "enter_thread", key: "l", modifiers: [], description: "Enter thread view (l)", sequence: false, supportsCount: false),
             // Thread context
-            KeymapEntry(action: "scroll_down", key: "j", modifiers: [], description: "Scroll down in thread", enabled: true, sequence: false, supportsCount: true, context: "thread"),
-            KeymapEntry(action: "scroll_up", key: "k", modifiers: [], description: "Scroll up in thread", enabled: true, sequence: false, supportsCount: true, context: "thread"),
-            KeymapEntry(action: "page_down", key: "d", modifiers: ["ctrl"], description: "Half-page down in thread", enabled: true, sequence: false, supportsCount: true, context: "thread"),
-            KeymapEntry(action: "page_up", key: "u", modifiers: ["ctrl"], description: "Half-page up in thread", enabled: true, sequence: false, supportsCount: true, context: "thread"),
-            KeymapEntry(action: "next_message", key: "n", modifiers: [], description: "Next message in thread", enabled: true, sequence: false, supportsCount: true, context: "thread"),
-            KeymapEntry(action: "prev_message", key: "N", modifiers: [], description: "Previous message in thread", enabled: true, sequence: false, supportsCount: true, context: "thread"),
-            KeymapEntry(action: "first_email", key: "gg", modifiers: [], description: "First message in thread", enabled: true, sequence: true, supportsCount: false, context: "thread"),
-            KeymapEntry(action: "last_email", key: "G", modifiers: [], description: "Last message in thread", enabled: true, sequence: false, supportsCount: false, context: "thread"),
-            KeymapEntry(action: "close_detail", key: "h", modifiers: [], description: "Back to email list", enabled: true, sequence: false, supportsCount: false, context: "thread"),
-            KeymapEntry(action: "close_detail", key: "Escape", modifiers: [], description: "Back to email list", enabled: true, sequence: false, supportsCount: false, context: "thread"),
-            KeymapEntry(action: "reply", key: "r", modifiers: [], description: "Reply to email", enabled: true, sequence: false, supportsCount: false, context: "thread"),
+            KeymapEntry(action: "scroll_down", key: "j", modifiers: [], description: "Scroll down in thread", sequence: false, supportsCount: true, context: "thread"),
+            KeymapEntry(action: "scroll_up", key: "k", modifiers: [], description: "Scroll up in thread", sequence: false, supportsCount: true, context: "thread"),
+            KeymapEntry(action: "page_down", key: "d", modifiers: ["ctrl"], description: "Half-page down in thread", sequence: false, supportsCount: true, context: "thread"),
+            KeymapEntry(action: "page_up", key: "u", modifiers: ["ctrl"], description: "Half-page up in thread", sequence: false, supportsCount: true, context: "thread"),
+            KeymapEntry(action: "next_message", key: "n", modifiers: [], description: "Next message in thread", sequence: false, supportsCount: true, context: "thread"),
+            KeymapEntry(action: "prev_message", key: "N", modifiers: [], description: "Previous message in thread", sequence: false, supportsCount: true, context: "thread"),
+            KeymapEntry(action: "first_email", key: "gg", modifiers: [], description: "First message in thread", sequence: true, supportsCount: false, context: "thread"),
+            KeymapEntry(action: "last_email", key: "G", modifiers: [], description: "Last message in thread", sequence: false, supportsCount: false, context: "thread"),
+            KeymapEntry(action: "close_detail", key: "h", modifiers: [], description: "Back to email list", sequence: false, supportsCount: false, context: "thread"),
+            KeymapEntry(action: "close_detail", key: "Escape", modifiers: [], description: "Back to email list", sequence: false, supportsCount: false, context: "thread"),
+            KeymapEntry(action: "reply", key: "r", modifiers: [], description: "Reply to email", sequence: false, supportsCount: false, context: "thread"),
         ]
     }
 
@@ -188,7 +188,6 @@ class KeymapsManager: ObservableObject {
             toml += "key = \"\(entry.key)\"\n"
             toml += "modifiers = [\(entry.modifiers.map { "\"\($0)\"" }.joined(separator: ", "))]\n"
             toml += "description = \"\(entry.description)\"\n"
-            toml += "enabled = \(entry.enabled)\n"
             toml += "sequence = \(entry.sequence)\n"
             toml += "supports_count = \(entry.supportsCount)\n"
             if entry.context != "list" {
@@ -222,187 +221,187 @@ class KeymapsManager: ObservableObject {
             // NAVIGATION - Single keys
             // ═══════════════════════════════════════════════════════════
             KeymapEntry(action: "next_email", key: "j", modifiers: [],
-                       description: "Next email (vim j)", enabled: true,
+                       description: "Next email (vim j)",
                        sequence: false, supportsCount: true),
             KeymapEntry(action: "prev_email", key: "k", modifiers: [],
-                       description: "Previous email (vim k)", enabled: true,
+                       description: "Previous email (vim k)",
                        sequence: false, supportsCount: true),
             KeymapEntry(action: "next_email", key: "Down", modifiers: [],
-                       description: "Next email (arrow)", enabled: true,
+                       description: "Next email (arrow)",
                        sequence: false, supportsCount: false),
             KeymapEntry(action: "prev_email", key: "Up", modifiers: [],
-                       description: "Previous email (arrow)", enabled: true,
+                       description: "Previous email (arrow)",
                        sequence: false, supportsCount: false),
             KeymapEntry(action: "last_email", key: "G", modifiers: [],
-                       description: "Last email (Shift+G)", enabled: true,
+                       description: "Last email (Shift+G)",
                        sequence: false, supportsCount: false),
             
             // ═══════════════════════════════════════════════════════════
             // NAVIGATION - Sequences
             // ═══════════════════════════════════════════════════════════
             KeymapEntry(action: "first_email", key: "gg", modifiers: [],
-                       description: "First email (vim gg)", enabled: true,
+                       description: "First email (vim gg)",
                        sequence: true, supportsCount: false),
 
             // ═══════════════════════════════════════════════════════════
             // PAGE NAVIGATION
             // ═══════════════════════════════════════════════════════════
             KeymapEntry(action: "page_down", key: "d", modifiers: ["ctrl"],
-                       description: "Half-page down (Ctrl+d)", enabled: true,
+                       description: "Half-page down (Ctrl+d)",
                        sequence: false, supportsCount: true),
             KeymapEntry(action: "page_up", key: "u", modifiers: ["ctrl"],
-                       description: "Half-page up (Ctrl+u)", enabled: true,
+                       description: "Half-page up (Ctrl+u)",
                        sequence: false, supportsCount: true),
 
             // ═══════════════════════════════════════════════════════════
             // EMAIL ACTIONS
             // ═══════════════════════════════════════════════════════════
             KeymapEntry(action: "archive", key: "a", modifiers: [],
-                       description: "Archive email (remove inbox)", enabled: true,
+                       description: "Archive email (remove inbox)",
                        sequence: false, supportsCount: false),
             KeymapEntry(action: "compose", key: "c", modifiers: [],
-                       description: "Compose new email", enabled: true,
+                       description: "Compose new email",
                        sequence: false, supportsCount: false),
             KeymapEntry(action: "reply", key: "r", modifiers: [],
-                       description: "Reply to email", enabled: true,
+                       description: "Reply to email",
                        sequence: false, supportsCount: false),
             KeymapEntry(action: "reply_all", key: "R", modifiers: [],
-                       description: "Reply to all (Shift+R)", enabled: true,
+                       description: "Reply to all (Shift+R)",
                        sequence: false, supportsCount: false),
             KeymapEntry(action: "forward", key: "f", modifiers: [],
-                       description: "Forward email", enabled: true,
+                       description: "Forward email",
                        sequence: false, supportsCount: false),
             KeymapEntry(action: "toggle_read", key: "u", modifiers: [],
-                       description: "Toggle read/unread", enabled: true,
+                       description: "Toggle read/unread",
                        sequence: false, supportsCount: false),
             KeymapEntry(action: "toggle_star", key: "s", modifiers: [],
-                       description: "Toggle star", enabled: true,
+                       description: "Toggle star",
                        sequence: false, supportsCount: false),
             KeymapEntry(action: "delete", key: "dd", modifiers: [],
-                       description: "Delete email (vim dd)", enabled: true,
+                       description: "Delete email (vim dd)",
                        sequence: true, supportsCount: true),
             
             // ═══════════════════════════════════════════════════════════
             // FOLDER NAVIGATION (go-commands)
             // ═══════════════════════════════════════════════════════════
             KeymapEntry(action: "go_inbox", key: "gi", modifiers: [],
-                       description: "Go to inbox", enabled: true,
+                       description: "Go to inbox",
                        sequence: true, supportsCount: false),
             KeymapEntry(action: "go_sent", key: "gs", modifiers: [],
-                       description: "Go to sent", enabled: true,
+                       description: "Go to sent",
                        sequence: true, supportsCount: false),
             KeymapEntry(action: "go_drafts", key: "gd", modifiers: [],
-                       description: "Go to drafts", enabled: true,
+                       description: "Go to drafts",
                        sequence: true, supportsCount: false),
             KeymapEntry(action: "go_archive", key: "ga", modifiers: [],
-                       description: "Go to archive", enabled: true,
+                       description: "Go to archive",
                        sequence: true, supportsCount: false),
             
             // ═══════════════════════════════════════════════════════════
             // SEARCH
             // ═══════════════════════════════════════════════════════════
             KeymapEntry(action: "search", key: "/", modifiers: [],
-                       description: "Search emails (vim /)", enabled: true,
+                       description: "Search emails (vim /)",
                        sequence: false, supportsCount: false),
             KeymapEntry(action: "search", key: "/", modifiers: ["cmd"],
-                       description: "Search emails (Cmd+/)", enabled: true,
+                       description: "Search emails (Cmd+/)",
                        sequence: false, supportsCount: false),
             
             // ═══════════════════════════════════════════════════════════
             // TAG PICKER
             // ═══════════════════════════════════════════════════════════
             KeymapEntry(action: "tag_picker", key: "t", modifiers: [],
-                       description: "Open tag picker", enabled: true,
+                       description: "Open tag picker",
                        sequence: false, supportsCount: false),
 
             // ═══════════════════════════════════════════════════════════
             // VIEW CONTROL
             // ═══════════════════════════════════════════════════════════
             KeymapEntry(action: "close_detail", key: "q", modifiers: [],
-                       description: "Close/back (vim q)", enabled: true,
+                       description: "Close/back (vim q)",
                        sequence: false, supportsCount: false),
             KeymapEntry(action: "close_detail", key: "Escape", modifiers: [],
-                       description: "Close/back (Escape)", enabled: true,
+                       description: "Close/back (Escape)",
                        sequence: false, supportsCount: false),
             KeymapEntry(action: "reload_inbox", key: "r", modifiers: ["cmd"],
-                       description: "Reload inbox (Cmd+r)", enabled: true,
+                       description: "Reload inbox (Cmd+r)",
                        sequence: false, supportsCount: false),
             
             // ═══════════════════════════════════════════════════════════
             // VISUAL MODE
             // ═══════════════════════════════════════════════════════════
             KeymapEntry(action: "enter_visual_mode", key: "v", modifiers: [],
-                       description: "Enter line visual mode (range select)", enabled: true,
+                       description: "Enter line visual mode (range select)",
                        sequence: false, supportsCount: false),
             KeymapEntry(action: "enter_toggle_mode", key: "V", modifiers: [],
-                       description: "Enter toggle visual mode (Shift+V)", enabled: true,
+                       description: "Enter toggle visual mode (Shift+V)",
                        sequence: false, supportsCount: false),
             KeymapEntry(action: "toggle_selection", key: " ", modifiers: [],
-                       description: "Toggle current email (only in toggle mode)", enabled: true,
+                       description: "Toggle current email (only in toggle mode)",
                        sequence: false, supportsCount: false),
             KeymapEntry(action: "exit_visual_mode", key: "Escape", modifiers: [],
-                       description: "Exit visual mode and clear selection", enabled: true,
+                       description: "Exit visual mode and clear selection",
                        sequence: false, supportsCount: false),
 
             // ═══════════════════════════════════════════════════════════
             // SEARCH CONTEXT
             // ═══════════════════════════════════════════════════════════
             KeymapEntry(action: "select_next", key: "j", modifiers: ["ctrl"],
-                       description: "Next search result (Ctrl+j)", enabled: true,
+                       description: "Next search result (Ctrl+j)",
                        sequence: false, supportsCount: false, context: "search"),
             KeymapEntry(action: "select_prev", key: "k", modifiers: ["ctrl"],
-                       description: "Previous search result (Ctrl+k)", enabled: true,
+                       description: "Previous search result (Ctrl+k)",
                        sequence: false, supportsCount: false, context: "search"),
             KeymapEntry(action: "select_next", key: "n", modifiers: ["ctrl"],
-                       description: "Next search result (Ctrl+n)", enabled: true,
+                       description: "Next search result (Ctrl+n)",
                        sequence: false, supportsCount: false, context: "search"),
             KeymapEntry(action: "select_prev", key: "p", modifiers: ["ctrl"],
-                       description: "Previous search result (Ctrl+p)", enabled: true,
+                       description: "Previous search result (Ctrl+p)",
                        sequence: false, supportsCount: false, context: "search"),
 
             // ═══════════════════════════════════════════════════════════
             // TAG PICKER CONTEXT
             // ═══════════════════════════════════════════════════════════
             KeymapEntry(action: "select_next", key: "j", modifiers: ["ctrl"],
-                       description: "Next tag (Ctrl+j)", enabled: true,
+                       description: "Next tag (Ctrl+j)",
                        sequence: false, supportsCount: false, context: "tag_picker"),
             KeymapEntry(action: "select_prev", key: "k", modifiers: ["ctrl"],
-                       description: "Previous tag (Ctrl+k)", enabled: true,
+                       description: "Previous tag (Ctrl+k)",
                        sequence: false, supportsCount: false, context: "tag_picker"),
             KeymapEntry(action: "select_next", key: "n", modifiers: ["ctrl"],
-                       description: "Next tag (Ctrl+n)", enabled: true,
+                       description: "Next tag (Ctrl+n)",
                        sequence: false, supportsCount: false, context: "tag_picker"),
             KeymapEntry(action: "select_prev", key: "p", modifiers: ["ctrl"],
-                       description: "Previous tag (Ctrl+p)", enabled: true,
+                       description: "Previous tag (Ctrl+p)",
                        sequence: false, supportsCount: false, context: "tag_picker"),
 
             // ═══════════════════════════════════════════════════════════
             // COMPOSE NORMAL CONTEXT
             // ═══════════════════════════════════════════════════════════
             KeymapEntry(action: "exit_insert", key: "jk", modifiers: [],
-                       description: "Exit insert mode (jk)", enabled: true,
+                       description: "Exit insert mode (jk)",
                        sequence: true, supportsCount: false, context: "compose_normal"),
 
             // ═══════════════════════════════════════════════════════════
             // THREAD CONTEXT
             // ═══════════════════════════════════════════════════════════
             KeymapEntry(action: "enter_thread", key: "l", modifiers: [],
-                       description: "Enter thread view (l)", enabled: true,
+                       description: "Enter thread view (l)",
                        sequence: false, supportsCount: false),
             KeymapEntry(action: "next_message", key: "j", modifiers: [],
-                       description: "Next message in thread", enabled: true,
+                       description: "Next message in thread",
                        sequence: false, supportsCount: false, context: "thread"),
             KeymapEntry(action: "prev_message", key: "k", modifiers: [],
-                       description: "Previous message in thread", enabled: true,
+                       description: "Previous message in thread",
                        sequence: false, supportsCount: false, context: "thread"),
             KeymapEntry(action: "close_detail", key: "h", modifiers: [],
-                       description: "Back to email list", enabled: true,
+                       description: "Back to email list",
                        sequence: false, supportsCount: false, context: "thread"),
             KeymapEntry(action: "close_detail", key: "Escape", modifiers: [],
-                       description: "Back to email list", enabled: true,
+                       description: "Back to email list",
                        sequence: false, supportsCount: false, context: "thread"),
             KeymapEntry(action: "reply", key: "r", modifiers: [],
-                       description: "Reply to email", enabled: true,
+                       description: "Reply to email",
                        sequence: false, supportsCount: false, context: "thread"),
         ]
 
@@ -420,28 +419,21 @@ class KeymapsManager: ObservableObject {
         }
     }
     
-    func enableKeymap(for action: String, enabled: Bool) {
-        if let index = keymaps.keymaps.firstIndex(where: { $0.action == action }) {
-            keymaps.keymaps[index].enabled = enabled
-            Log.debug("KEYMAPS", "\(action) \(enabled ? "enabled" : "disabled")")
-        }
-    }
-    
     func getKeymap(for action: String) -> KeymapEntry? {
         return keymaps.keymaps.first(where: { $0.action == action })
     }
-    
+
     func getKeymapsForAction(_ action: String) -> [KeymapEntry] {
-        return keymaps.keymaps.filter { $0.action == action && $0.enabled }
+        return keymaps.keymaps.filter { $0.action == action }
     }
-    
+
     func isKeymapPressed(key: String, modifiers: [String], for action: String) -> Bool {
         guard keymaps.globalSettings.keymapsEnabled else {
             return false
         }
-        
-        let matchingKeymaps = keymaps.keymaps.filter { 
-            $0.action == action && $0.enabled 
+
+        let matchingKeymaps = keymaps.keymaps.filter {
+            $0.action == action
         }
         
         return matchingKeymaps.contains { keymap in
@@ -483,45 +475,34 @@ struct KeymapEntry: Codable {
     var key: String
     var modifiers: [String]
     var description: String
-    var enabled: Bool
     var sequence: Bool
     var supportsCount: Bool
     var context: String
     var tags: String?  // For tag_op action: "+todo -inbox"
 
     enum CodingKeys: String, CodingKey {
-        case action
-        case key
-        case modifiers
-        case description
-        case enabled
-        case sequence
+        case action, key, modifiers, description, sequence
         case supportsCount = "supports_count"
-        case context
-        case tags
+        case context, tags
     }
 
-    // Custom init for backwards compatibility with old configs
     init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         action = try container.decode(String.self, forKey: .action)
         key = try container.decode(String.self, forKey: .key)
-        modifiers = try container.decode([String].self, forKey: .modifiers)
-        description = try container.decode(String.self, forKey: .description)
-        enabled = try container.decode(Bool.self, forKey: .enabled)
+        modifiers = try container.decodeIfPresent([String].self, forKey: .modifiers) ?? []
+        description = try container.decodeIfPresent(String.self, forKey: .description) ?? ""
         sequence = try container.decodeIfPresent(Bool.self, forKey: .sequence) ?? false
         supportsCount = try container.decodeIfPresent(Bool.self, forKey: .supportsCount) ?? false
         context = try container.decodeIfPresent(String.self, forKey: .context) ?? "list"
         tags = try container.decodeIfPresent(String.self, forKey: .tags)
     }
 
-    // Memberwise init for creating entries programmatically
-    init(action: String, key: String, modifiers: [String], description: String, enabled: Bool, sequence: Bool = false, supportsCount: Bool = false, context: String = "list", tags: String? = nil) {
+    init(action: String, key: String, modifiers: [String] = [], description: String = "", sequence: Bool = false, supportsCount: Bool = false, context: String = "list", tags: String? = nil) {
         self.action = action
         self.key = key
         self.modifiers = modifiers
         self.description = description
-        self.enabled = enabled
         self.sequence = sequence
         self.supportsCount = supportsCount
         self.context = context

--- a/macos/durian/Keymaps/SequenceMatcher.swift
+++ b/macos/durian/Keymaps/SequenceMatcher.swift
@@ -64,7 +64,7 @@ class SequenceMatcher {
         // Entries with ctrl modifier use normalized form ("ctrl+d", "ctrl+u")
         // Other modifier entries (Cmd+r, etc.) are handled by KeymapHandler.handleLegacyKeymap()
         sequences = keymapEntries
-            .filter { $0.enabled && ($0.modifiers.isEmpty || $0.modifiers == ["ctrl"]) }
+            .filter { $0.modifiers.isEmpty || $0.modifiers == ["ctrl"] }
             .compactMap { entry -> SequenceDefinition? in
                 guard let action = KeymapAction(rawValue: entry.action) else {
                     Log.debug("SEQMATCH", "Unknown action '\(entry.action)' - skipping")
@@ -82,7 +82,7 @@ class SequenceMatcher {
 
         for context in KeymapContext.allCases {
             let contextEntries = keymapEntries.filter {
-                $0.enabled && ($0.modifiers.isEmpty || $0.modifiers == ["ctrl"])
+                $0.modifiers.isEmpty || $0.modifiers == ["ctrl"]
                 && (KeymapContext(rawValue: $0.context) ?? .list) == context
             }
 

--- a/macos/durian/Keymaps/SequenceMatcher.swift
+++ b/macos/durian/Keymaps/SequenceMatcher.swift
@@ -27,6 +27,9 @@ class SequenceMatcher {
 
     /// Per-context actions that support count prefix
     private var contextCountSupported: [KeymapContext: Set<KeymapAction>] = [:]
+
+    /// Per-context tag_op tags lookup: sequence → tags string (e.g. "+todo -inbox")
+    private var contextTagOps: [KeymapContext: [String: String]] = [:]
     
     // MARK: - Init
     
@@ -75,6 +78,7 @@ class SequenceMatcher {
         contextSequenceLookup = [:]
         contextPrefixes = [:]
         contextCountSupported = [:]
+        contextTagOps = [:]
 
         for context in KeymapContext.allCases {
             let contextEntries = keymapEntries.filter {
@@ -99,6 +103,16 @@ class SequenceMatcher {
                 }
             }
             contextPrefixes[context] = prefixes
+
+            // Tag ops lookup
+            var tagOps: [String: String] = [:]
+            for entry in contextEntries where entry.action == "tag_op" {
+                if let tags = entry.tags {
+                    let seqKey = entry.modifiers == ["ctrl"] ? "ctrl+\(entry.key.lowercased())" : entry.key
+                    tagOps[seqKey] = tags
+                }
+            }
+            contextTagOps[context] = tagOps
 
             // Count support
             contextCountSupported[context] = Set(
@@ -155,6 +169,11 @@ class SequenceMatcher {
         return .noMatch
     }
     
+    /// Get tags for a tag_op sequence in a given context
+    func tagOpTags(for sequence: String, context: KeymapContext) -> String? {
+        contextTagOps[context]?[sequence]
+    }
+
     /// Get description for a sequence
     func description(for sequence: String) -> String? {
         sequences.first { $0.sequence == sequence }?.description
@@ -179,7 +198,7 @@ class SequenceMatcher {
     
     /// Parse count prefix from buffer
     /// e.g., "5j" → (5, "j"), "12gg" → (12, "gg"), "gg" → (nil, "gg")
-    private func parseCountAndSequence(_ buffer: String) -> (count: Int?, sequence: String) {
+    func parseCountAndSequence(_ buffer: String) -> (count: Int?, sequence: String) {
         var digits = ""
         var rest = ""
         var foundNonDigit = false

--- a/macos/durian/Keymaps/SequenceMatcher.swift
+++ b/macos/durian/Keymaps/SequenceMatcher.swift
@@ -82,7 +82,7 @@ class SequenceMatcher {
 
         for context in KeymapContext.allCases {
             let contextEntries = keymapEntries.filter {
-                $0.modifiers.isEmpty || $0.modifiers == ["ctrl"]
+                ($0.modifiers.isEmpty || $0.modifiers == ["ctrl"])
                 && (KeymapContext(rawValue: $0.context) ?? .list) == context
             }
 

--- a/macos/durian/Managers/AccountManager.swift
+++ b/macos/durian/Managers/AccountManager.swift
@@ -34,9 +34,12 @@ class AccountManager: ObservableObject {
     var mailFolders: [MailFolder] {
         let profile = ProfileManager.shared.currentProfile
         let folders = profile?.folders ?? ProfileManager.defaultFolders
-        
+
         return folders.map { folder in
-            MailFolder(name: folder.name.lowercased(), displayName: folder.name, icon: folder.icon)
+            if folder.isSection {
+                return MailFolder(section: folder.name)
+            }
+            return MailFolder(name: folder.name.lowercased(), displayName: folder.name, icon: folder.icon)
         }
     }
     
@@ -80,7 +83,7 @@ class AccountManager: ObservableObject {
         guard let backend = emailBackend else { return }
 
         var counts: [String: Int] = [:]
-        for folder in mailFolders {
+        for folder in mailFolders where !folder.isSection {
             let folderQuery = ProfileManager.shared.buildQuery(folderName: folder.displayName)
             let unreadQuery = "(\(folderQuery)) AND tag:unread"
             let count = await backend.searchCount(query: unreadQuery)

--- a/macos/durian/Managers/ProfileManager.swift
+++ b/macos/durian/Managers/ProfileManager.swift
@@ -15,6 +15,7 @@ struct FolderConfig: Hashable {
     let name: String
     let icon: String?
     let query: String
+    let isSection: Bool  // true = section header, not a clickable folder
 }
 
 // MARK: - Profile
@@ -61,7 +62,7 @@ struct ProfilesConfig: Decodable {
     struct FolderEntry: Decodable {
         let name: String
         var icon: String?
-        let query: String
+        var query: String?  // nil or empty = section header
     }
 }
 
@@ -76,7 +77,7 @@ class ProfileManager: ObservableObject {
     
     /// Default folders when none are defined in config
     static let defaultFolders: [FolderConfig] = [
-        FolderConfig(name: "Inbox", icon: "tray", query: "tag:inbox")
+        FolderConfig(name: "Inbox", icon: "tray", query: "tag:inbox", isSection: false)
     ]
     
     init() {
@@ -110,7 +111,10 @@ class ProfileManager: ObservableObject {
         profiles = config.profile.map { entry in
             let folders: [FolderConfig]
             if let entryFolders = entry.folders, !entryFolders.isEmpty {
-                folders = entryFolders.map { FolderConfig(name: $0.name, icon: $0.icon, query: $0.query) }
+                folders = entryFolders.map { entry in
+                    let query = entry.query ?? ""
+                    return FolderConfig(name: entry.name, icon: entry.icon, query: query, isSection: query.isEmpty)
+                }
             } else {
                 folders = Self.defaultFolders
             }

--- a/macos/durian/Models/Mail.swift
+++ b/macos/durian/Models/Mail.swift
@@ -109,11 +109,24 @@ struct MailFolder: Identifiable, Hashable {
     let accountId: String
     let isSpecial: Bool  // true for inbox, sent, drafts, trash
     let specialType: SpecialFolderType?
+    let isSection: Bool  // true for section headers (no query, not clickable)
     
     enum SpecialFolderType: String {
         case inbox, sent, drafts, trash, archive, junk
     }
     
+    /// Create a section header (non-clickable divider in sidebar)
+    init(section title: String) {
+        self.id = "section:\(title)"
+        self.name = title
+        self.displayName = title
+        self.icon = nil
+        self.accountId = "default"
+        self.isSpecial = false
+        self.specialType = nil
+        self.isSection = true
+    }
+
     /// Create for tag-based folder
     init(tag: String, icon: String) {
         self.id = "tag:\(tag)"
@@ -121,7 +134,8 @@ struct MailFolder: Identifiable, Hashable {
         self.displayName = tag.capitalized
         self.icon = icon
         self.accountId = "default"
-        
+        self.isSection = false
+
         switch tag {
         case "inbox":
             self.isSpecial = true
@@ -151,7 +165,8 @@ struct MailFolder: Identifiable, Hashable {
         self.displayName = displayName
         self.icon = icon
         self.accountId = "default"
-        
+        self.isSection = false
+
         switch name.lowercased() {
         case "inbox":
             self.isSpecial = true

--- a/macos/durian/Views/ComposeForm.swift
+++ b/macos/durian/Views/ComposeForm.swift
@@ -461,7 +461,7 @@ struct ComposeForm: View {
                             showVimSearch = true
                         },
                         vimInsertExitKeys: KeymapsManager.shared.keymaps.keymaps
-                            .filter { $0.context == "compose_normal" && $0.action == "exit_insert" && $0.enabled }
+                            .filter { $0.context == "compose_normal" && $0.action == "exit_insert" }
                             .map { $0.key }
                     )
                     .frame(height: editorHeight)

--- a/macos/durian/Views/SidebarView.swift
+++ b/macos/durian/Views/SidebarView.swift
@@ -39,19 +39,39 @@ struct SidebarView: View {
 
                     // Rows
                     ForEach(accountManager.mailFolders) { folder in
-                        SidebarRow(
-                            folder: folder,
-                            unreadCount: accountManager.folderUnreadCounts[folder.name] ?? 0,
-                            isSelected: selectedTagID == folder.name,
-                            accentColor: profileManager.resolvedAccentColor
-                        ) {
-                            selectedTagID = folder.name
+                        if folder.isSection {
+                            SidebarSectionHeader(title: folder.displayName)
+                        } else {
+                            SidebarRow(
+                                folder: folder,
+                                unreadCount: accountManager.folderUnreadCounts[folder.name] ?? 0,
+                                isSelected: selectedTagID == folder.name,
+                                accentColor: profileManager.resolvedAccentColor
+                            ) {
+                                selectedTagID = folder.name
+                            }
                         }
                     }
                 }
                 .padding(.vertical, 4)
             }
         }
+    }
+}
+
+// MARK: - Section Header
+
+private struct SidebarSectionHeader: View {
+    let title: String
+
+    var body: some View {
+        Text(title)
+            .font(.caption)
+            .fontWeight(.semibold)
+            .foregroundStyle(.secondary)
+            .padding(.horizontal, 14)
+            .padding(.top, 12)
+            .padding(.bottom, 4)
     }
 }
 

--- a/macos/tests/ProfileTests.swift
+++ b/macos/tests/ProfileTests.swift
@@ -38,7 +38,7 @@ final class ProfileTests: XCTestCase {
     // MARK: - Helpers
 
     private static let testDefaultFolders: [FolderConfig] = [
-        FolderConfig(name: "Inbox", icon: "tray", query: "tag:inbox")
+        FolderConfig(name: "Inbox", icon: "tray", query: "tag:inbox", isSection: false)
     ]
 
     private func makeAllProfile() -> Profile {

--- a/macos/tests/SequenceMatcherTests.swift
+++ b/macos/tests/SequenceMatcherTests.swift
@@ -13,25 +13,22 @@ final class SequenceMatcherTests: XCTestCase {
         let entries: [KeymapEntry] = [
             // List context
             .init(action: "next_email", key: "j", modifiers: [], description: "",
-                  enabled: true, sequence: false, supportsCount: true, context: "list"),
+                  sequence: false, supportsCount: true, context: "list"),
             .init(action: "prev_email", key: "k", modifiers: [], description: "",
-                  enabled: true, sequence: false, supportsCount: true, context: "list"),
+                  sequence: false, supportsCount: true, context: "list"),
             .init(action: "first_email", key: "gg", modifiers: [], description: "",
-                  enabled: true, sequence: true, supportsCount: false, context: "list"),
+                  sequence: true, supportsCount: false, context: "list"),
             .init(action: "go_inbox", key: "gi", modifiers: [], description: "",
-                  enabled: true, sequence: true, supportsCount: false, context: "list"),
+                  sequence: true, supportsCount: false, context: "list"),
             .init(action: "delete", key: "dd", modifiers: [], description: "",
-                  enabled: true, sequence: true, supportsCount: true, context: "list"),
+                  sequence: true, supportsCount: true, context: "list"),
             .init(action: "page_down", key: "d", modifiers: ["ctrl"], description: "",
-                  enabled: true, sequence: false, supportsCount: true, context: "list"),
+                  sequence: false, supportsCount: true, context: "list"),
             .init(action: "compose", key: "c", modifiers: [], description: "",
-                  enabled: true, sequence: false, supportsCount: false, context: "list"),
+                  sequence: false, supportsCount: false, context: "list"),
             // Thread context (to verify context isolation)
             .init(action: "reply", key: "r", modifiers: [], description: "",
-                  enabled: true, sequence: false, supportsCount: false, context: "thread"),
-            // Disabled entry (should be ignored)
-            .init(action: "archive", key: "a", modifiers: [], description: "",
-                  enabled: false, sequence: false, supportsCount: false, context: "list"),
+                  sequence: false, supportsCount: false, context: "thread"),
         ]
 
         KeymapsManager.shared.keymaps = KeymapConfig()
@@ -80,12 +77,6 @@ final class SequenceMatcherTests: XCTestCase {
 
     func testUnknownSequenceIsNoMatch() {
         let result = SequenceMatcher.shared.match(buffer: "xyz", context: .list)
-        XCTAssertEqual(result, .noMatch)
-    }
-
-    func testDisabledEntryNotMatched() {
-        // "a" is archive but disabled in setUp — should not match
-        let result = SequenceMatcher.shared.match(buffer: "a", context: .list)
         XCTAssertEqual(result, .noMatch)
     }
 


### PR DESCRIPTION
## Summary

Contact groups as query-time expansion, rules engine enhancements, and GUI improvements for the new tag architecture.

### Contact Groups (`groups.toml`)
- TOML-based contact groups with flexible member format (plain strings + arrays for multi-email)
- Bidirectional query expansion: `group:investor` → `(from:X OR to:X ...)`
- Direction modifiers: `group:investor/from`, `group:investor/to`
- `GET /api/v1/groups` API endpoint
- CLI: `durian group list`, `durian group members <name>`
- `durian validate groups`

### Rules Engine
- `cc:` field in rules evaluator + search SQL
- `group:` expansion in rule match expressions
- `has:attachment:TYPE` — match content-type or file extension (e.g. `has:attachment:pdf`)
- Fixed `AllMessages()` missing `cc_addrs` + attachment metadata in `rules apply`

### CLI
- `durian count <query>` — thread count for diagnostics
- `durian tag list [--account X]` — list all tags
- `durian tag` now supports arbitrary search queries (not just `thread:`)

### Search
- `has:attachment` and `has:attachment:TYPE` in search SQL
- `cc:` field in search SQL
- Open date ranges: `date:..month`, `date:30d..`
- Relative day/week/month/year syntax: `date:30d`, `date:2w`, `date:6m`, `date:1y`

### GUI (Swift)
- Sidebar section headers via query-less folders in profiles.toml
- Generic `tag_op` keymap action for configurable tag shortcuts (T→+todo, W→+waiting)
- Removed redundant `enabled` field from keymaps — all fields except action+key now optional
- Fixed operator precedence bug in keymap context filter (j/k broken in list view)
- Fixed empty state showing "Run durian sync" for empty folders
- Auto-select first email on folder switch + context reset

### Docs
- `docs/groups-example.toml`, updated `rules-example.toml`, `keymaps-example.toml`, `profiles-example.toml`

## Test plan
- [x] `bazel test //cli/...` — 15/15 pass
- [x] `bazel build //macos:Durian` — clean build
- [x] `durian validate groups` / `durian validate rules` / `durian validate keymaps`
- [x] `durian count "group:investor"` / `durian search "group:investor/from AND date:month"`
- [x] `durian rules apply --dry-run` — cc-only + contracts match
- [x] `durian tag "tag:X" -X` — bulk tag operations
- [x] GUI: T/W keybinds, j/k navigation, sidebar sections, folder switch