### PR TITLE
fix: compose WYSIWYG, thread signature dedup, window management

### DIFF
--- a/cli/internal/handler/show.go
+++ b/cli/internal/handler/show.go
@@ -8,6 +8,7 @@ import (
 	"net/mail"
 	"os"
 	"sort"
+	"strings"
 	"time"
 
 	internmail "github.com/durian-dev/durian/cli/internal/mail"
@@ -128,6 +129,54 @@ func (h *Handler) convertThread(threadID string, msgs []*store.Message, light bo
 		return messages[i].Timestamp > messages[j].Timestamp
 	})
 
+	// Signature dedup: per sender, keep signature only in the oldest message.
+	// Uses common-suffix comparison — the identical trailing content across
+	// multiple messages from the same sender is the signature. No markers needed.
+	if !light {
+		type sigEntry struct {
+			idx       int
+			timestamp int64
+		}
+		senderGroups := make(map[string][]sigEntry)
+		for i, info := range messages {
+			email := extractSenderEmail(info.From)
+			senderGroups[email] = append(senderGroups[email], sigEntry{idx: i, timestamp: info.Timestamp})
+		}
+		for _, group := range senderGroups {
+			if len(group) < 2 {
+				continue
+			}
+			// Find common suffix across all messages from this sender
+			suffix := messages[group[0].idx].HTML
+			for _, entry := range group[1:] {
+				suffix = sanitize.CommonSuffix(suffix, messages[entry.idx].HTML)
+			}
+			// Only treat as signature if substantial (filters out trivial
+			// common endings like </div> or closing tags)
+			if len(suffix) < 100 {
+				continue
+			}
+			// Find oldest message (smallest timestamp)
+			oldest := 0
+			for j := range group {
+				if group[j].timestamp < group[oldest].timestamp {
+					oldest = j
+				}
+			}
+			// Strip common suffix from non-oldest messages, keep as hidden_signature
+			for j, entry := range group {
+				if j == oldest {
+					continue
+				}
+				html := messages[entry.idx].HTML
+				if strings.HasSuffix(html, suffix) {
+					messages[entry.idx].HTML = strings.TrimRight(html[:len(html)-len(suffix)], " \t\n\r")
+					messages[entry.idx].HiddenSignature = suffix
+				}
+			}
+		}
+	}
+
 	return &internmail.ThreadContent{
 		ThreadID: threadID,
 		Subject:  subject,
@@ -176,4 +225,16 @@ func (h *Handler) DownloadAttachment(messageID string, partID int, w http.Respon
 
 	return h.fetcher.FetchAttachment(ctx, msg.Account, msg.Mailbox,
 		msg.UID, storeAtt.Filename, storeAtt.ContentType, storeAtt.PartID, w)
+}
+
+// extractSenderEmail returns the lowercase email address from a
+// "Name <email>" or plain "email" string.
+func extractSenderEmail(from string) string {
+	lower := strings.ToLower(strings.TrimSpace(from))
+	if idx := strings.LastIndex(lower, "<"); idx != -1 {
+		if end := strings.LastIndex(lower, ">"); end > idx {
+			return lower[idx+1 : end]
+		}
+	}
+	return lower
 }

--- a/cli/internal/mail/types.go
+++ b/cli/internal/mail/types.go
@@ -33,7 +33,7 @@ type MailContent struct {
 	InReplyTo   string   `json:"in_reply_to,omitempty"`
 	References  string   `json:"references,omitempty"`
 	Body        string   `json:"body"`
-	HTML        string   `json:"html,omitempty"`
+	HTML        string           `json:"html,omitempty"`
 	Attachments []AttachmentInfo `json:"attachments,omitempty"`
 }
 
@@ -62,7 +62,8 @@ type MessageInfo struct {
 	InReplyTo   string   `json:"in_reply_to,omitempty"`
 	References  string   `json:"references,omitempty"`
 	Body        string   `json:"body"`
-	HTML        string   `json:"html,omitempty"`
-	Attachments []AttachmentInfo `json:"attachments,omitempty"`
-	Tags        []string         `json:"tags,omitempty"`
+	HTML             string           `json:"html,omitempty"`
+	HiddenSignature  string           `json:"hidden_signature,omitempty"`
+	Attachments      []AttachmentInfo `json:"attachments,omitempty"`
+	Tags             []string         `json:"tags,omitempty"`
 }

--- a/cli/internal/sanitize/BUILD.bazel
+++ b/cli/internal/sanitize/BUILD.bazel
@@ -5,6 +5,7 @@ go_library(
     srcs = [
         "quote.go",
         "sanitize.go",
+        "signature.go",
     ],
     importpath = "github.com/durian-dev/durian/cli/internal/sanitize",
     visibility = ["//cli:__subpackages__"],
@@ -18,6 +19,7 @@ go_test(
         "fixture_test.go",
         "quote_test.go",
         "sanitize_test.go",
+        "signature_test.go",
     ],
     data = glob(["testdata/**"]),
     embed = [":sanitize"],

--- a/cli/internal/sanitize/signature.go
+++ b/cli/internal/sanitize/signature.go
@@ -1,0 +1,69 @@
+package sanitize
+
+import "strings"
+
+// signatureMarkers are HTML patterns that indicate the start of an email
+// signature. Kept intentionally conservative — unrecognized signatures are
+// shown rather than incorrectly stripped.
+var signatureMarkers = []string{
+	// RFC 3676 separator wrapped in block elements
+	"<div>-- <br></div>",
+	"<div>-- <br/></div>",
+	"<div>-- <br /></div>",
+
+	// Thunderbird
+	`<div class="moz-signature"`,
+
+	// Gmail
+	`<div class="gmail_signature"`,
+
+	// Apple Mail
+	`<div id="applemailsignature"`,
+}
+
+// DetectSignature returns the byte index where the signature begins in
+// the given HTML, or -1 if no known signature marker is found.
+func DetectSignature(html string) int {
+	if html == "" {
+		return -1
+	}
+	lower := strings.ToLower(html)
+	for _, marker := range signatureMarkers {
+		if idx := strings.Index(lower, marker); idx != -1 {
+			return idx
+		}
+	}
+	return -1
+}
+
+// StripSignature removes the signature from HTML content.
+// Returns the original HTML if no signature is detected.
+func StripSignature(html string) string {
+	idx := DetectSignature(html)
+	if idx == -1 {
+		return html
+	}
+	return strings.TrimRight(html[:idx], " \t\n\r")
+}
+
+// ExtractSignature returns the signature portion of HTML content,
+// or an empty string if no signature marker is found.
+func ExtractSignature(html string) string {
+	idx := DetectSignature(html)
+	if idx == -1 {
+		return ""
+	}
+	return html[idx:]
+}
+
+// CommonSuffix returns the longest common suffix of two strings.
+// Used to detect signatures by comparing multiple messages from the
+// same sender — the identical trailing content is the signature.
+func CommonSuffix(a, b string) string {
+	i, j := len(a)-1, len(b)-1
+	for i >= 0 && j >= 0 && a[i] == b[j] {
+		i--
+		j--
+	}
+	return a[i+1:]
+}

--- a/cli/internal/sanitize/signature_test.go
+++ b/cli/internal/sanitize/signature_test.go
@@ -1,0 +1,97 @@
+package sanitize
+
+import "testing"
+
+func TestDetectSignature(t *testing.T) {
+	tests := []struct {
+		name string
+		html string
+		want bool // true = signature found
+	}{
+		{"RFC 3676 div", `<div>Hello</div><div>-- <br></div><span>Sig</span>`, true},
+		{"RFC 3676 self-closing br", `<div>Hello</div><div>-- <br/></div><span>Sig</span>`, true},
+		{"Gmail", `<div>Hello</div><div class="gmail_signature" dir="ltr">Sig</div>`, true},
+		{"Thunderbird", `<div>Hello</div><div class="moz-signature">-- <br>Sig</div>`, true},
+		{"Apple Mail", `<div>Hello</div><div id="AppleMailSignature">Sig</div>`, true},
+		{"Apple Mail lowercase", `<div>Hello</div><div id="applemailsignature">Sig</div>`, true},
+		{"no marker", `<div>Hello World</div>`, false},
+		{"dashes in text", `<div>Use -- for comments</div>`, false},
+		{"empty", "", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := DetectSignature(tt.html)
+			if (got != -1) != tt.want {
+				t.Errorf("DetectSignature() = %d, wantFound = %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestStripSignature(t *testing.T) {
+	tests := []struct {
+		name string
+		html string
+		want string
+	}{
+		{"RFC 3676", `<div>Hello</div><div>-- <br></div><span>Julian</span>`, `<div>Hello</div>`},
+		{"Gmail", `<div>Hi</div><div class="gmail_signature"><span>Bob</span></div>`, `<div>Hi</div>`},
+		{"Thunderbird", `<p>Hey</p><div class="moz-signature">-- <br>Alice</div>`, `<p>Hey</p>`},
+		{"no marker", `<div>Hello World</div>`, `<div>Hello World</div>`},
+		{"empty", "", ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := StripSignature(tt.html)
+			if got != tt.want {
+				t.Errorf("StripSignature()\ngot:  %q\nwant: %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestCommonSuffix(t *testing.T) {
+	tests := []struct {
+		name string
+		a, b string
+		want string
+	}{
+		{"identical ending", "<div>Hello</div><sig>Julian</sig>", "<div>Bye</div><sig>Julian</sig>", "</div><sig>Julian</sig>"},
+		{"no common", "<div>Hello</div>", "<div>Bye</div>", "</div>"},
+		{"identical", "abc", "abc", "abc"},
+		{"empty a", "", "abc", ""},
+		{"empty both", "", "", ""},
+		{"one char common", "xz", "yz", "z"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := CommonSuffix(tt.a, tt.b)
+			if got != tt.want {
+				t.Errorf("CommonSuffix()\ngot:  %q\nwant: %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestExtractSignature(t *testing.T) {
+	tests := []struct {
+		name string
+		html string
+		want string
+	}{
+		{"RFC 3676", `<div>Hello</div><div>-- <br></div><span>Julian</span>`,
+			`<div>-- <br></div><span>Julian</span>`},
+		{"Gmail", `<div>Hi</div><div class="gmail_signature">Bob</div>`,
+			`<div class="gmail_signature">Bob</div>`},
+		{"no marker", `<div>Hello</div>`, ""},
+		{"empty", "", ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := ExtractSignature(tt.html)
+			if got != tt.want {
+				t.Errorf("ExtractSignature()\ngot:  %q\nwant: %q", got, tt.want)
+			}
+		})
+	}
+}

--- a/macos/durian/ContentView.swift
+++ b/macos/durian/ContentView.swift
@@ -393,6 +393,11 @@ struct ContentView: View {
                 exitSearchMode()
             }
         }
+        .onChange(of: accountManager.selectedFolder) { _, newFolder in
+            if selectedTagID != newFolder {
+                selectedTagID = newFolder
+            }
+        }
         .onChange(of: accountManager.emailListGeneration) { _, _ in
             // Auto-select first email when list data arrives and cursor is empty
             if cursorEmailId == nil, let firstId = accountManager.mailMessages.first?.id {

--- a/macos/durian/ContentView.swift
+++ b/macos/durian/ContentView.swift
@@ -389,7 +389,7 @@ struct ContentView: View {
             registerKeymapHandlers()
         }
         .onChange(of: selectedTagID) { _, tagId in
-            if tagId != nil {
+            if tagId != nil && tagId != accountManager.selectedFolder {
                 exitSearchMode()
             }
         }

--- a/macos/durian/Managers/AccountManager.swift
+++ b/macos/durian/Managers/AccountManager.swift
@@ -110,11 +110,21 @@ class AccountManager: ObservableObject {
         }
         await backend.connect()
         syncFromBackend()
-        await refreshFolderCounts()
+        await selectTag(resolvedFolder())
     }
     
     // MARK: - Folder/Tag Selection
-    
+
+    /// Returns `selectedFolder` if it exists in the current profile,
+    /// otherwise the first non-section folder, falling back to "inbox".
+    private func resolvedFolder() -> String {
+        let profile = ProfileManager.shared.currentProfile
+        let folders = profile?.folders ?? ProfileManager.defaultFolders
+        let exists = folders.contains { !$0.isSection && $0.name.lowercased() == selectedFolder }
+        if exists { return selectedFolder }
+        return folders.first { !$0.isSection }?.name.lowercased() ?? "inbox"
+    }
+
     func selectTag(_ tag: String) async {
         guard let backend = emailBackend else { return }
         selectedFolder = tag
@@ -134,8 +144,7 @@ class AccountManager: ObservableObject {
         ProfileManager.shared.currentProfile = profile
         Log.info("BACKEND", "Switched to profile '\(profile.name)'")
         
-        // Reload current folder with new profile filter
-        await selectTag(selectedFolder)
+        await selectTag(resolvedFolder())
     }
     
     // MARK: - Email Operations

--- a/macos/durian/Managers/EmailSendingManager.swift
+++ b/macos/durian/Managers/EmailSendingManager.swift
@@ -187,7 +187,7 @@ class EmailSendingManager: ObservableObject {
                     .replacingOccurrences(of: ">", with: "&gt;")
                     .replacingOccurrences(of: "\n", with: "<br>")
             }
-            finalBody = "<div>\(userHTML)</div><br>\(htmlSig)"
+            finalBody = "<div>\(userHTML)</div><br><div>-- <br></div>\(htmlSig)"
 
             if let quoted = draft.quotedContent, !quoted.isEmpty {
                 let cleanQuoted = draft.quotedIsHTML ? Self.stripStyleTags(quoted) : quoted

--- a/macos/durian/Models/Mail.swift
+++ b/macos/durian/Models/Mail.swift
@@ -35,6 +35,7 @@ struct ThreadMessage: Decodable, Identifiable, Equatable {
     let references: String?
     let body: String
     let html: String?
+    let hidden_signature: String?
     let attachments: [AttachmentInfo]?
     let tags: [String]?
 }

--- a/macos/durian/Utilities/WindowCloseGuard.swift
+++ b/macos/durian/Utilities/WindowCloseGuard.swift
@@ -11,6 +11,7 @@ import AppKit
 
 struct WindowCloseGuard: NSViewRepresentable {
     @Binding var allowClose: Bool
+    @Binding var window: NSWindow?
     let onCloseAttempt: () -> Void
 
     // MARK: - Coordinator
@@ -47,6 +48,7 @@ struct WindowCloseGuard: NSViewRepresentable {
         let view = NSView()
         DispatchQueue.main.async {
             guard let window = view.window else { return }
+            self.window = window
             context.coordinator.originalDelegate = window.delegate
             context.coordinator.allowClose = self.allowClose
             context.coordinator.onCloseAttempt = self.onCloseAttempt

--- a/macos/durian/Views/ComposeWindow.swift
+++ b/macos/durian/Views/ComposeWindow.swift
@@ -25,6 +25,7 @@ struct ComposeWindow: View {
     @State private var allowClose: Bool = false
     @State private var showInvalidEmailWarning: Bool = false
     @State private var invalidEmails: [String] = []
+    @State private var composeNSWindow: NSWindow?
 
     var body: some View {
         Group {
@@ -205,12 +206,24 @@ struct ComposeWindow: View {
             .animation(.easeInOut(duration: 0.3), value: sendingManager.isSending)
         }
         } // ZStack
-        .background(WindowCloseGuard(allowClose: $allowClose, onCloseAttempt: { handleDismiss() }))
+        .background(WindowCloseGuard(allowClose: $allowClose, window: $composeNSWindow, onCloseAttempt: { handleDismiss() }))
         .onAppear { KeymapHandler.shared.composeActive = true }
         .onDisappear { KeymapHandler.shared.composeActive = false }
     }
     
     // MARK: - Actions
+
+    /// Activate the next visible Durian window so the app doesn't appear
+    /// to hide when the compose window is removed via orderOut.
+    private func activateMainWindow() {
+        if let mainWindow = NSApp.windows.first(where: {
+            $0.isVisible && $0.canBecomeKey && !($0 is NSPanel)
+        }) {
+            mainWindow.makeKeyAndOrderFront(nil)
+        }
+        // Always activate the app to prevent it from going behind other apps
+        NSApp.activate()
+    }
 
     private func closeWindow() {
         allowClose = true
@@ -219,8 +232,8 @@ struct ComposeWindow: View {
 
     private func handleDismiss() {
         // Hide the compose window instantly, save draft in background
-        let composeWindow = NSApp.keyWindow
-        composeWindow?.orderOut(nil)
+        composeNSWindow?.orderOut(nil)
+        activateMainWindow()
         isSaving = true
 
         Task {
@@ -233,7 +246,7 @@ struct ComposeWindow: View {
                 await MainActor.run {
                     // Save failed — bring window back so user can act
                     isSaving = false
-                    composeWindow?.makeKeyAndOrderFront(nil)
+                    composeNSWindow?.makeKeyAndOrderFront(nil)
                     saveErrorMessage = error.localizedDescription
                     showSaveError = true
                 }
@@ -259,9 +272,9 @@ struct ComposeWindow: View {
         let reopenDraft = openWindow
         let capturedDraftId = draftId
 
-        // Hide the compose window instantly (it's key window right now)
-        let composeWindow = NSApp.keyWindow
-        composeWindow?.orderOut(nil)
+        // Hide the compose window instantly
+        composeNSWindow?.orderOut(nil)
+        activateMainWindow()
 
         // Close via SwiftUI for proper cleanup
         isSaving = true

--- a/macos/durian/Views/ThreadMessageCardView.swift
+++ b/macos/durian/Views/ThreadMessageCardView.swift
@@ -30,6 +30,8 @@ struct ThreadMessageCardView: View {
     @State private var selectedAttachmentId: Int? = nil
     @State private var spaceMonitor: AnyObject? = nil
     @State private var resolvedHTML: String? = nil
+    @State private var showSignature: Bool = false
+    @State private var signatureHeight: CGFloat = 0
 
     /// Non-inline attachments for this message
     private var displayAttachments: [AttachmentInfo] {
@@ -67,6 +69,30 @@ struct ThreadMessageCardView: View {
                     .font(.system(size: 14))
                     .foregroundColor(Color.Detail.textPrimary)
                     .textSelection(.enabled)
+            }
+
+            // Hidden signature (collapsed by default, expand via "..." button)
+            if let sig = message.hidden_signature, !sig.isEmpty {
+                if showSignature {
+                    NonScrollingWebView(
+                        html: sig,
+                        theme: SettingsManager.shared.settings.theme,
+                        loadRemoteImages: SettingsManager.shared.settings.loadRemoteImages,
+                        emailId: "\(message.id)-sig",
+                        contentHeight: $signatureHeight
+                    )
+                    .frame(height: max(signatureHeight, 20))
+                }
+                Button {
+                    withAnimation(.easeInOut(duration: 0.2)) {
+                        showSignature.toggle()
+                    }
+                } label: {
+                    Text(showSignature ? "Hide signature" : "•••")
+                        .font(.system(size: 12))
+                        .foregroundColor(Color.Detail.textTertiary)
+                }
+                .buttonStyle(.plain)
             }
 
             // Action footer only on last (newest) card

--- a/macos/tests/SequenceMatcherTests.swift
+++ b/macos/tests/SequenceMatcherTests.swift
@@ -12,22 +12,22 @@ final class SequenceMatcherTests: XCTestCase {
 
         let entries: [KeymapEntry] = [
             // List context
-            .init(action: "next_email", key: "j", modifiers: [], description: "",
+            .init(action: "next_email", key: "j", modifiers: [],
                   sequence: false, supportsCount: true, context: "list"),
-            .init(action: "prev_email", key: "k", modifiers: [], description: "",
+            .init(action: "prev_email", key: "k", modifiers: [],
                   sequence: false, supportsCount: true, context: "list"),
-            .init(action: "first_email", key: "gg", modifiers: [], description: "",
+            .init(action: "first_email", key: "gg", modifiers: [],
                   sequence: true, supportsCount: false, context: "list"),
-            .init(action: "go_inbox", key: "gi", modifiers: [], description: "",
+            .init(action: "go_inbox", key: "gi", modifiers: [],
                   sequence: true, supportsCount: false, context: "list"),
-            .init(action: "delete", key: "dd", modifiers: [], description: "",
+            .init(action: "delete", key: "dd", modifiers: [],
                   sequence: true, supportsCount: true, context: "list"),
-            .init(action: "page_down", key: "d", modifiers: ["ctrl"], description: "",
+            .init(action: "page_down", key: "d", modifiers: ["ctrl"],
                   sequence: false, supportsCount: true, context: "list"),
-            .init(action: "compose", key: "c", modifiers: [], description: "",
+            .init(action: "compose", key: "c", modifiers: [],
                   sequence: false, supportsCount: false, context: "list"),
             // Thread context (to verify context isolation)
-            .init(action: "reply", key: "r", modifiers: [], description: "",
+            .init(action: "reply", key: "r", modifiers: [],
                   sequence: false, supportsCount: false, context: "thread"),
         ]
 


### PR DESCRIPTION
## Changes

### Compose WYSIWYG fixes
- Add `normalizeListStyles()` to inline padding/margin on `<ul>`/`<ol>` tags matching compose editor CSS
- Strip paste-inherited `-apple-system` font-family from inline styles (`cleanEditorArtifacts`)
- Update `plainTextToHTML` font stack from Apple-only to cross-platform
- Add RFC 3676 signature separator (`-- `) before HTML signature

### Thread signature dedup
- Common-suffix signature detection: compare trailing HTML across messages from the same sender, strip identical suffixes (>100 chars) from all but the oldest message
- Send stripped signature as `hidden_signature` field for GUI expand/collapse
- Add collapsible '•••' button in ThreadMessageCardView

### Window management
- Replace fragile `NSApp.keyWindow` with stored NSWindow reference via WindowCloseGuard binding
- Add `NSApp.activate()` fallback to keep app in foreground after compose close

### Profile folder fallback
- Extract `resolvedFolder()` helper — falls back to first profile folder on start and switch
- Sync `selectedFolder` → `selectedTagID` via onChange for sidebar consistency

### Tests
- 9 Go tests (list normalization)
- 4 Swift tests (font stripping)
- 20 Go tests (signature detection, common suffix)