### PR TITLE
feat: attachment prefetch cache with LRU eviction

### DIFF
--- a/cli/internal/config/helpers.go
+++ b/cli/internal/config/helpers.go
@@ -61,7 +61,7 @@ func (c *Config) GetAccountByName(name string) (*AccountConfig, error) {
 	}
 
 	for i := range c.Accounts {
-		if c.Accounts[i].Name == name {
+		if strings.EqualFold(c.Accounts[i].Name, name) {
 			return &c.Accounts[i], nil
 		}
 	}

--- a/cli/internal/config/types.go
+++ b/cli/internal/config/types.go
@@ -19,10 +19,17 @@ type SettingsConfig struct {
 
 // SyncConfig contains sync settings from config.pkl [sync].
 type SyncConfig struct {
-	GuiAutoSync       bool          `pkl:"gui_auto_sync" json:"gui_auto_sync"`
-	AutoFetchInterval int           `pkl:"auto_fetch_interval" json:"auto_fetch_interval"`
-	FullSyncInterval  int           `pkl:"full_sync_interval" json:"full_sync_interval"`
-	TagSync           *TagSyncConfig `pkl:"tag_sync" json:"tag_sync"`
+	GuiAutoSync       bool                   `pkl:"gui_auto_sync" json:"gui_auto_sync"`
+	AutoFetchInterval int                    `pkl:"auto_fetch_interval" json:"auto_fetch_interval"`
+	FullSyncInterval  int                    `pkl:"full_sync_interval" json:"full_sync_interval"`
+	TagSync           *TagSyncConfig         `pkl:"tag_sync" json:"tag_sync"`
+	AttachmentCache   *AttachmentCacheConfig `pkl:"attachment_cache" json:"attachment_cache"`
+}
+
+// AttachmentCacheConfig configures the GUI attachment cache.
+type AttachmentCacheConfig struct {
+	MaxSizeMB int `pkl:"max_size_mb" json:"max_size_mb"` // Max cache size in MB (default: 100)
+	TTLDays   int `pkl:"ttl_days" json:"ttl_days"`       // Days to keep cached attachments (default: 7)
 }
 
 // TagSyncConfig configures the optional remote tag sync server.

--- a/docs/config-example.pkl
+++ b/docs/config-example.pkl
@@ -20,6 +20,9 @@ sync {
 
   // Optional: sync tags across machines via a self-hosted sync server.
   // tag_sync { url = "http://nas:8724"; api_key = "your-secret" }
+
+  // Optional: attachment cache settings (GUI prefetches on thread open).
+  // attachment_cache { max_size_mb = 100; ttl_days = 7 }
 }
 
 signatures {

--- a/macos/durian/Managers/AttachmentCacheManager.swift
+++ b/macos/durian/Managers/AttachmentCacheManager.swift
@@ -1,0 +1,215 @@
+//
+//  AttachmentCacheManager.swift
+//  Durian
+//
+//  Caches downloaded attachments locally to avoid repeated IMAP fetches.
+//  Prefetches attachments when a thread is opened.
+//
+
+import Foundation
+
+@MainActor
+class AttachmentCacheManager: ObservableObject {
+    static let shared = AttachmentCacheManager()
+
+    private let fileManager = FileManager.default
+    private let indexFile: URL
+    private let cacheDir: URL
+    private var index: [String: CachedAttachment] = [:]
+    private var prefetchTasks: [String: Task<Void, Never>] = [:]
+    private var failedKeys: Set<String> = []
+
+    private init() {
+        let caches = fileManager.urls(for: .cachesDirectory, in: .userDomainMask).first!
+        cacheDir = caches.appendingPathComponent("org.js-lab.durian/attachments", isDirectory: true)
+        indexFile = cacheDir.appendingPathComponent(".cache-index.json")
+        try? fileManager.createDirectory(at: cacheDir, withIntermediateDirectories: true)
+        loadIndex()
+        evict()
+    }
+
+    // MARK: - Public API
+
+    /// Returns cached data if available, nil otherwise.
+    func get(messageId: String, partId: Int) -> Data? {
+        let key = cacheKey(messageId: messageId, partId: partId)
+        guard var entry = index[key] else { return nil }
+
+        // Check TTL
+        let settings = SettingsManager.shared.attachmentCacheSettings
+        if Date().timeIntervalSince(entry.cachedAt) > settings.ttl {
+            remove(key: key)
+            return nil
+        }
+
+        guard fileManager.fileExists(atPath: entry.localPath.path) else {
+            index.removeValue(forKey: key)
+            saveIndex()
+            return nil
+        }
+
+        // Update access metadata
+        entry.lastAccessDate = Date()
+        entry.accessCount += 1
+        index[key] = entry
+        saveIndex()
+
+        return try? Data(contentsOf: entry.localPath)
+    }
+
+    /// Store attachment data in cache.
+    func put(messageId: String, partId: Int, filename: String, data: Data) {
+        let key = cacheKey(messageId: messageId, partId: partId)
+        let safeFilename = filename.replacingOccurrences(of: "/", with: "_")
+        let localPath = cacheDir.appendingPathComponent("\(key)_\(safeFilename)")
+
+        do {
+            try data.write(to: localPath)
+        } catch {
+            Log.error("CACHE", "Failed to write \(filename): \(error)")
+            return
+        }
+
+        index[key] = CachedAttachment(
+            id: UUID(),
+            filename: filename,
+            localPath: localPath,
+            sizeBytes: Int64(data.count),
+            cachedAt: Date(),
+            lastAccessDate: Date(),
+            accessCount: 1,
+            emailUID: 0,
+            pinned: false
+        )
+        saveIndex()
+        evict()
+    }
+
+    /// Check if an attachment is cached (or known to be unavailable).
+    func isCached(messageId: String, partId: Int) -> Bool {
+        let key = cacheKey(messageId: messageId, partId: partId)
+        if failedKeys.contains(key) { return false }
+        guard let entry = index[key] else { return false }
+        let settings = SettingsManager.shared.attachmentCacheSettings
+        if Date().timeIntervalSince(entry.cachedAt) > settings.ttl {
+            return false
+        }
+        return fileManager.fileExists(atPath: entry.localPath.path)
+    }
+
+    /// Whether a prefetch already failed for this attachment (stale UID, etc.)
+    func prefetchFailed(messageId: String, partId: Int) -> Bool {
+        failedKeys.contains(cacheKey(messageId: messageId, partId: partId))
+    }
+
+    /// Prefetch all attachments for a thread's messages in the background.
+    func prefetch(messages: [ThreadMessage], backend: EmailBackend) {
+        for message in messages {
+            guard let attachments = message.attachments, !attachments.isEmpty else { continue }
+            for attachment in attachments {
+                let key = cacheKey(messageId: message.id, partId: attachment.partId)
+                guard index[key] == nil else { continue }
+                guard prefetchTasks[key] == nil else { continue }
+
+                guard !failedKeys.contains(key) else { continue }
+
+                prefetchTasks[key] = Task {
+                    do {
+                        let (data, _) = try await backend.downloadAttachment(
+                            messageId: message.id,
+                            partId: attachment.partId
+                        )
+                        put(messageId: message.id, partId: attachment.partId,
+                            filename: attachment.filename, data: data)
+                        Log.debug("CACHE", "Prefetched \(attachment.filename) (\(data.count) bytes)")
+                    } catch {
+                        failedKeys.insert(key)
+                        Log.debug("CACHE", "Prefetch failed for \(attachment.filename): \(error)")
+                    }
+                    prefetchTasks.removeValue(forKey: key)
+                }
+            }
+        }
+    }
+
+    /// Cancel all active prefetch tasks.
+    func cancelPrefetch() {
+        for (_, task) in prefetchTasks {
+            task.cancel()
+        }
+        prefetchTasks.removeAll()
+    }
+
+    /// Total cache size in bytes.
+    var totalSize: Int64 {
+        index.values.reduce(0) { $0 + $1.sizeBytes }
+    }
+
+    /// Clear entire cache.
+    func clearAll() {
+        for (_, entry) in index {
+            try? fileManager.removeItem(at: entry.localPath)
+        }
+        index.removeAll()
+        saveIndex()
+        Log.info("CACHE", "Cache cleared")
+    }
+
+    // MARK: - Eviction
+
+    private func evict() {
+        let settings = SettingsManager.shared.attachmentCacheSettings
+        let now = Date()
+
+        // Phase 1: Remove expired entries
+        for (key, entry) in index where !entry.pinned {
+            if now.timeIntervalSince(entry.cachedAt) > settings.ttl {
+                remove(key: key)
+            }
+        }
+
+        // Phase 2: LRU eviction if still over size limit
+        while totalSize > settings.maxSizeBytes {
+            guard let oldest = index
+                .filter({ !$0.value.pinned })
+                .min(by: { $0.value.lastAccessDate < $1.value.lastAccessDate })
+            else { break }
+            remove(key: oldest.key)
+        }
+    }
+
+    // MARK: - Persistence
+
+    private func loadIndex() {
+        guard fileManager.fileExists(atPath: indexFile.path) else { return }
+        do {
+            let data = try Data(contentsOf: indexFile)
+            index = try JSONDecoder().decode([String: CachedAttachment].self, from: data)
+        } catch {
+            Log.warning("CACHE", "Failed to load index: \(error)")
+            index = [:]
+        }
+    }
+
+    private func saveIndex() {
+        do {
+            let data = try JSONEncoder().encode(index)
+            try data.write(to: indexFile)
+        } catch {
+            Log.error("CACHE", "Failed to save index: \(error)")
+        }
+    }
+
+    // MARK: - Helpers
+
+    private func cacheKey(messageId: String, partId: Int) -> String {
+        "\(messageId):\(partId)"
+    }
+
+    private func remove(key: String) {
+        guard let entry = index[key] else { return }
+        try? fileManager.removeItem(at: entry.localPath)
+        index.removeValue(forKey: key)
+        saveIndex()
+    }
+}

--- a/macos/durian/Managers/ConfigManager.swift
+++ b/macos/durian/Managers/ConfigManager.swift
@@ -48,23 +48,48 @@ struct SyncSettings: Codable {
     var guiAutoSync: Bool = true
     var autoFetchInterval: TimeInterval = 120.0
     var fullSyncInterval: TimeInterval = 7200
-    
+    var attachmentCache: AttachmentCacheSettings = AttachmentCacheSettings()
+
     enum CodingKeys: String, CodingKey {
         case mode
         case guiAutoSync = "gui_auto_sync"
         case autoFetchInterval = "auto_fetch_interval"
         case fullSyncInterval = "full_sync_interval"
+        case attachmentCache = "attachment_cache"
     }
-    
+
     init() {}
-    
+
     init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         mode = try container.decodeIfPresent(String.self, forKey: .mode) ?? "bidirectional"
         guiAutoSync = try container.decodeIfPresent(Bool.self, forKey: .guiAutoSync) ?? true
         autoFetchInterval = try container.decodeIfPresent(TimeInterval.self, forKey: .autoFetchInterval) ?? 120.0
         fullSyncInterval = try container.decodeIfPresent(TimeInterval.self, forKey: .fullSyncInterval) ?? 7200
+        attachmentCache = try container.decodeIfPresent(AttachmentCacheSettings.self, forKey: .attachmentCache) ?? AttachmentCacheSettings()
     }
+}
+
+/// Attachment cache settings from [sync.attachment_cache] section
+struct AttachmentCacheSettings: Codable {
+    var maxSizeMB: Int = 100
+    var ttlDays: Int = 7
+
+    enum CodingKeys: String, CodingKey {
+        case maxSizeMB = "max_size_mb"
+        case ttlDays = "ttl_days"
+    }
+
+    init() {}
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        maxSizeMB = try container.decodeIfPresent(Int.self, forKey: .maxSizeMB) ?? 100
+        ttlDays = try container.decodeIfPresent(Int.self, forKey: .ttlDays) ?? 7
+    }
+
+    var maxSizeBytes: Int64 { Int64(maxSizeMB) * 1_048_576 }
+    var ttl: TimeInterval { TimeInterval(ttlDays) * 86_400 }
 }
 
 struct AppConfig: Codable {

--- a/macos/durian/Managers/SettingsManager.swift
+++ b/macos/durian/Managers/SettingsManager.swift
@@ -52,6 +52,11 @@ class SettingsManager: ObservableObject {
     var fullSyncInterval: TimeInterval {
         syncSettings.fullSyncInterval
     }
+
+    /// Attachment cache settings
+    var attachmentCacheSettings: AttachmentCacheSettings {
+        syncSettings.attachmentCache
+    }
     
     // MARK: - Public API
     

--- a/macos/durian/Views/EmailDetailView.swift
+++ b/macos/durian/Views/EmailDetailView.swift
@@ -106,6 +106,12 @@ struct EmailDetailView: View {
         case .loaded:
             // Use thread messages from CLI if available
             if let messages = email.threadMessages, !messages.isEmpty {
+                Color.clear.frame(height: 0)
+                    .onAppear {
+                        if let backend = AccountManager.shared.emailBackend {
+                            AttachmentCacheManager.shared.prefetch(messages: messages, backend: backend)
+                        }
+                    }
                 ForEach(Array(messages.enumerated()), id: \.element.id) { index, message in
                     Color.clear.frame(height: 0)
                         .id("msg-\(index)")

--- a/macos/durian/Views/ThreadMessageCardView.swift
+++ b/macos/durian/Views/ThreadMessageCardView.swift
@@ -457,6 +457,12 @@ struct ThreadMessageCardView: View {
     }
 
     private func fetchAttachmentData(_ attachment: AttachmentInfo) async -> Data? {
+        // Check cache first
+        if let cached = AttachmentCacheManager.shared.get(messageId: message.id, partId: attachment.partId) {
+            Log.debug("ATTACHMENT", "Cache hit for \(attachment.filename)")
+            return cached
+        }
+
         guard let backend = AccountManager.shared.emailBackend else {
             downloadStates[attachment.partId] = .failed(error: "Not connected")
             scheduleErrorClear(attachment.partId)
@@ -466,6 +472,11 @@ struct ThreadMessageCardView: View {
             let (data, _) = try await backend.downloadAttachment(
                 messageId: message.id,
                 partId: attachment.partId
+            )
+            // Cache for future access
+            AttachmentCacheManager.shared.put(
+                messageId: message.id, partId: attachment.partId,
+                filename: attachment.filename, data: data
             )
             return data
         } catch {

--- a/schema/Config.pkl
+++ b/schema/Config.pkl
@@ -16,6 +16,12 @@ class SyncConfig {
   auto_fetch_interval: Int(this > 0) = 120
   full_sync_interval: Int(this > 0) = 7200
   tag_sync: TagSyncConfig?
+  attachment_cache: AttachmentCacheConfig?
+}
+
+class AttachmentCacheConfig {
+  max_size_mb: Int(this > 0) = 100
+  ttl_days: Int(this > 0) = 7
 }
 
 class TagSyncConfig {


### PR DESCRIPTION
## Summary

- Prefetch attachments when a thread is opened, cache locally with configurable TTL (7d) and max size (100MB)
- LRU eviction removes oldest entries when over limit, respecting pinned items
- Negative cache prevents repeated IMAP fetches for stale UIDs
- Fix case-insensitive account lookup in `GetAccountByName` (`durian attachment --save` failed for mixed-case names)
- New config option: `sync { attachment_cache { max_size_mb = 100; ttl_days = 7 } }`

## Test plan

- [x] Cache directory populates on thread open (`~/Library/Caches/org.js-lab.durian/attachments/`)
- [x] Cache hit logs on second access
- [x] Go tests pass (`bazel test //cli/...`)
- [x] GUI builds (`bazel build //macos:Durian`)
- [x] `durian validate` passes with new schema
- [ ] Verify eviction after TTL expires (#203)
- [ ] Fix stale UID attachment failures (#204)