### PR TITLE
feat(swift-keymaps): merge user keymaps with built-in defaults (#202)

### DIFF
--- a/cli/internal/config/validate.go
+++ b/cli/internal/config/validate.go
@@ -275,6 +275,8 @@ var (
 		"next_message": "Next message", "prev_message": "Previous message",
 		"next_profile": "Next profile", "prev_profile": "Previous profile",
 		"open_in_browser": "Open in browser", "copy_link": "Copy link",
+		"go_folder": "Go to folder by position", "next_folder": "Next folder",
+		"prev_folder": "Previous folder", "folder_picker": "Open folder picker",
 	}
 	validKeymapModifiers = map[string]bool{"cmd": true, "ctrl": true, "shift": true}
 	validKeymapContexts  = map[string]bool{

--- a/docs/keymaps-example.pkl
+++ b/docs/keymaps-example.pkl
@@ -1,12 +1,20 @@
 // Durian Keymaps Configuration
 // Copy to ~/.config/durian/keymaps.pkl
-// These are the defaults. Only include keymaps you want to change.
 //
-// All vim-style keybindings are fully configurable.
+// Your keymaps are MERGED with the built-in defaults below.
+// Only include keymaps you want to override, add, or disable.
+// Bindings match by (key + modifiers + context) — same combo = override.
+//
 // sequence = true  : multi-key sequence (e.g. "gg", "dd", "gi")
 // supports_count   : accepts count prefix (e.g. "5j" = move down 5)
+// enabled = false  : disable a default binding
 // modifiers        : { "cmd" }, { "ctrl" }, { "shift" }, or omit for none
 // context          : "list" (default), "search", "tag_picker", "thread", "compose_normal"
+//
+// Examples:
+//   Override:  new { action = "archive"; key = "e" }          // rebind archive from "a" to "e"
+//   Disable:   new { action = "delete"; key = "dd"; sequence = true; enabled = false }
+//   Add new:   new { action = "tag_op"; key = "T"; tags = "+todo -inbox" }
 
 global_settings {
   keymaps_enabled = true
@@ -14,10 +22,16 @@ global_settings {
   sequence_timeout = 1.0              // seconds to wait for next key in sequence
 }
 
+// ── Built-in defaults (reference) ────────────────────────────
+// These are active even without a keymaps.pkl file.
+// Copy only the lines you want to change into your keymaps.pkl.
+
 keymaps {
   // ── Navigation ─────────────────────────────────────────────
   new { action = "next_email";  key = "j";  supports_count = true }
   new { action = "prev_email";  key = "k";  supports_count = true }
+  new { action = "next_email";  key = "Down" }
+  new { action = "prev_email";  key = "Up" }
   new { action = "first_email"; key = "gg"; sequence = true }
   new { action = "last_email";  key = "G" }
   new { action = "page_down";   key = "d";  modifiers { "ctrl" }; supports_count = true }
@@ -25,15 +39,16 @@ keymaps {
 
   // ── Actions ────────────────────────────────────────────────
   new { action = "archive";      key = "a" }
-  new { action = "delete";       key = "dd"; sequence = true }
+  new { action = "delete";       key = "dd"; sequence = true; supports_count = true }
   new { action = "toggle_read";  key = "u" }
   new { action = "toggle_star";  key = "s" }
   new { action = "tag_picker";   key = "t" }
 
   // ── Tag Operations (configurable tag shortcuts) ────────────
   // tag_op applies +/- tag operations defined in the "tags" field.
-  new { action = "tag_op"; key = "T"; tags = "+todo -inbox" }
-  new { action = "tag_op"; key = "W"; tags = "+waiting -inbox" }
+  // These have no defaults — add your own:
+  // new { action = "tag_op"; key = "T"; tags = "+todo -inbox" }
+  // new { action = "tag_op"; key = "W"; tags = "+waiting -inbox" }
 
   // ── Compose ────────────────────────────────────────────────
   new { action = "compose";   key = "c" }
@@ -46,10 +61,24 @@ keymaps {
   new { action = "go_sent";    key = "gs"; sequence = true }
   new { action = "go_drafts";  key = "gd"; sequence = true }
   new { action = "go_archive"; key = "ga"; sequence = true }
+  new { action = "go_folder";  key = "g1"; sequence = true }
+  new { action = "go_folder";  key = "g2"; sequence = true }
+  new { action = "go_folder";  key = "g3"; sequence = true }
+  new { action = "go_folder";  key = "g4"; sequence = true }
+  new { action = "go_folder";  key = "g5"; sequence = true }
+  new { action = "go_folder";  key = "g6"; sequence = true }
+  new { action = "go_folder";  key = "g7"; sequence = true }
+  new { action = "go_folder";  key = "g8"; sequence = true }
+  new { action = "go_folder";  key = "g9"; sequence = true }
+  new { action = "next_folder"; key = "J" }
+  new { action = "prev_folder"; key = "K" }
+  new { action = "folder_picker"; key = "gf"; sequence = true }
 
   // ── Search & UI ────────────────────────────────────────────
   new { action = "search";       key = "/" }
+  new { action = "search";       key = "/"; modifiers { "cmd" } }
   new { action = "close_detail"; key = "q" }
+  new { action = "close_detail"; key = "Escape" }
   new { action = "reload_inbox"; key = "r"; modifiers { "cmd" } }
 
   // ── Selection (Visual Mode) ────────────────────────────────
@@ -61,10 +90,14 @@ keymaps {
   // ── Search Popup (context = "search") ──────────────────────
   new { action = "select_next"; key = "j"; modifiers { "ctrl" }; context = "search" }
   new { action = "select_prev"; key = "k"; modifiers { "ctrl" }; context = "search" }
+  new { action = "select_next"; key = "n"; modifiers { "ctrl" }; context = "search" }
+  new { action = "select_prev"; key = "p"; modifiers { "ctrl" }; context = "search" }
 
   // ── Tag Picker (context = "tag_picker") ────────────────────
   new { action = "select_next"; key = "j"; modifiers { "ctrl" }; context = "tag_picker" }
   new { action = "select_prev"; key = "k"; modifiers { "ctrl" }; context = "tag_picker" }
+  new { action = "select_next"; key = "n"; modifiers { "ctrl" }; context = "tag_picker" }
+  new { action = "select_prev"; key = "p"; modifiers { "ctrl" }; context = "tag_picker" }
 
   // ── Compose Vim Mode (context = "compose_normal") ──────────
   new { action = "exit_insert"; key = "jk"; sequence = true; context = "compose_normal" }
@@ -73,8 +106,13 @@ keymaps {
   new { action = "enter_thread"; key = "l" }
   new { action = "scroll_down";  key = "j"; context = "thread"; supports_count = true }
   new { action = "scroll_up";    key = "k"; context = "thread"; supports_count = true }
+  new { action = "page_down";    key = "d"; modifiers { "ctrl" }; context = "thread"; supports_count = true }
+  new { action = "page_up";      key = "u"; modifiers { "ctrl" }; context = "thread"; supports_count = true }
   new { action = "next_message"; key = "n"; context = "thread"; supports_count = true }
   new { action = "prev_message"; key = "N"; context = "thread"; supports_count = true }
+  new { action = "first_email";  key = "gg"; sequence = true; context = "thread" }
+  new { action = "last_email";   key = "G"; context = "thread" }
   new { action = "close_detail"; key = "h"; context = "thread" }
+  new { action = "close_detail"; key = "Escape"; context = "thread" }
   new { action = "reply";        key = "r"; context = "thread" }
 }

--- a/macos/BUILD.bazel
+++ b/macos/BUILD.bazel
@@ -247,6 +247,21 @@ swift_test(
 )
 
 swift_test(
+    name = "keymaps_merge_test",
+    size = "small",
+    srcs = ["tests/KeymapsMergeTests.swift"],
+    deps = [":durian_testlib"],
+)
+
+swift_test(
+    name = "ci_keymaps_merge_test",
+    size = "small",
+    srcs = ["tests/KeymapsMergeTests.swift"],
+    tags = ["ci"],
+    deps = [":durian_core"],
+)
+
+swift_test(
     name = "sequence_matcher_test",
     size = "small",
     srcs = ["tests/SequenceMatcherTests.swift"],

--- a/macos/durian/Keymaps/KeymapsManager.swift
+++ b/macos/durian/Keymaps/KeymapsManager.swift
@@ -31,7 +31,8 @@ class KeymapsManager: ObservableObject {
 
         do {
             keymaps = try PklEvaluator.evalSync(KeymapConfig.self, from: pklURL)
-            Log.info("KEYMAPS", "Loaded from: \(pklURL.path)")
+            keymaps.keymaps = mergeWithDefaults(userKeymaps: keymaps.keymaps)
+            Log.info("KEYMAPS", "Loaded \(keymaps.keymaps.count) keymaps (merged with defaults)")
         } catch {
             Log.error("KEYMAPS", "Failed to load: \(error)")
             keymaps = KeymapConfig()
@@ -121,6 +122,27 @@ class KeymapsManager: ObservableObject {
         ]
     }
 
+    /// Merges user-defined keymaps with the built-in defaults.
+    /// User entries override defaults that share the same (key + modifiers + context).
+    /// Entries with enabled=false are removed from the final result.
+    func mergeWithDefaults(userKeymaps: [KeymapEntry]) -> [KeymapEntry] {
+        let userByKey = Dictionary(userKeymaps.map { ($0.bindingKey, $0) }, uniquingKeysWith: { _, last in last })
+        var seen = Set<String>()
+
+        // Defaults first — replaced by user entry if same bindingKey exists
+        var merged = getDefaultKeymaps().map { entry -> KeymapEntry in
+            seen.insert(entry.bindingKey)
+            return userByKey[entry.bindingKey] ?? entry
+        }
+
+        // Append user entries that don't overlap with any default
+        for entry in userKeymaps where !seen.contains(entry.bindingKey) {
+            merged.append(entry)
+        }
+
+        return merged.filter { $0.enabled }
+    }
+
     private func getKeymapsURL() -> URL {
         let homeURL = FileManager.default.homeDirectoryForCurrentUser
         return homeURL.appendingPathComponent(".config/durian/keymaps.pkl")
@@ -191,13 +213,14 @@ struct KeymapEntry: Codable {
     var action: String
     var key: String
     var modifiers: [String]
+    var enabled: Bool
     var sequence: Bool
     var supportsCount: Bool
     var context: String
     var tags: String?  // For tag_op action: "+todo -inbox"
 
     enum CodingKeys: String, CodingKey {
-        case action, key, modifiers, sequence
+        case action, key, modifiers, enabled, sequence
         case supportsCount = "supports_count"
         case context, tags
     }
@@ -207,20 +230,28 @@ struct KeymapEntry: Codable {
         action = try container.decode(String.self, forKey: .action)
         key = try container.decode(String.self, forKey: .key)
         modifiers = try container.decodeIfPresent([String].self, forKey: .modifiers) ?? []
+        enabled = try container.decodeIfPresent(Bool.self, forKey: .enabled) ?? true
         sequence = try container.decodeIfPresent(Bool.self, forKey: .sequence) ?? false
         supportsCount = try container.decodeIfPresent(Bool.self, forKey: .supportsCount) ?? false
         context = try container.decodeIfPresent(String.self, forKey: .context) ?? "list"
         tags = try container.decodeIfPresent(String.self, forKey: .tags)
     }
 
-    init(action: String, key: String, modifiers: [String] = [], sequence: Bool = false, supportsCount: Bool = false, context: String = "list", tags: String? = nil) {
+    init(action: String, key: String, modifiers: [String] = [], enabled: Bool = true, sequence: Bool = false, supportsCount: Bool = false, context: String = "list", tags: String? = nil) {
         self.action = action
         self.key = key
         self.modifiers = modifiers
+        self.enabled = enabled
         self.sequence = sequence
         self.supportsCount = supportsCount
         self.context = context
         self.tags = tags
+    }
+
+    /// The identity used for merging: same key + modifiers + context = same binding slot.
+    var bindingKey: String {
+        let mods = modifiers.sorted().joined(separator: "+")
+        return "\(key)|\(mods)|\(context)"
     }
 }
 

--- a/macos/tests/KeymapsMergeTests.swift
+++ b/macos/tests/KeymapsMergeTests.swift
@@ -1,0 +1,197 @@
+import XCTest
+@testable import durian_lib
+
+@MainActor
+final class KeymapsMergeTests: XCTestCase {
+
+    private var manager: KeymapsManager { KeymapsManager.shared }
+
+    // MARK: - No user overrides
+
+    func testEmptyUserKeymapsReturnsAllDefaults() {
+        let merged = manager.mergeWithDefaults(userKeymaps: [])
+
+        // Should contain known defaults
+        XCTAssertTrue(merged.contains(where: { $0.action == "next_email" && $0.key == "j" }))
+        XCTAssertTrue(merged.contains(where: { $0.action == "delete" && $0.key == "dd" }))
+        XCTAssertTrue(merged.contains(where: { $0.action == "reply" && $0.key == "r" && $0.context == "thread" }))
+    }
+
+    // MARK: - Override existing binding
+
+    func testUserOverridesDefaultByBindingKey() {
+        // Default: "a" in list context = archive
+        // User remaps "a" in list context to toggle_star
+        let user: [KeymapEntry] = [
+            .init(action: "toggle_star", key: "a"),
+        ]
+        let merged = manager.mergeWithDefaults(userKeymaps: user)
+
+        let aBindings = merged.filter { $0.key == "a" && $0.context == "list" && $0.modifiers.isEmpty }
+        XCTAssertEqual(aBindings.count, 1)
+        XCTAssertEqual(aBindings.first?.action, "toggle_star")
+    }
+
+    func testOverridePreservesPositionInArray() {
+        // The overridden entry should stay at the same position as the default
+        let user: [KeymapEntry] = [
+            .init(action: "toggle_star", key: "j", supportsCount: true),
+        ]
+        let merged = manager.mergeWithDefaults(userKeymaps: user)
+
+        // "j" in list context is the first default — should still be near the top
+        guard let idx = merged.firstIndex(where: { $0.key == "j" && $0.context == "list" && $0.modifiers.isEmpty }) else {
+            XCTFail("Expected j binding in merged result")
+            return
+        }
+        XCTAssertEqual(merged[idx].action, "toggle_star")
+        XCTAssertLessThan(idx, 5, "Overridden binding should keep its position near the start")
+    }
+
+    // MARK: - Add new binding
+
+    func testUserAddsNewBinding() {
+        let user: [KeymapEntry] = [
+            .init(action: "tag_op", key: "T", tags: "+todo -inbox"),
+        ]
+        let merged = manager.mergeWithDefaults(userKeymaps: user)
+
+        XCTAssertTrue(merged.contains(where: { $0.action == "tag_op" && $0.key == "T" }))
+    }
+
+    func testNewBindingsAppendedAfterDefaults() {
+        let user: [KeymapEntry] = [
+            .init(action: "tag_op", key: "W", tags: "+waiting"),
+        ]
+        let merged = manager.mergeWithDefaults(userKeymaps: user)
+
+        guard let wIdx = merged.firstIndex(where: { $0.key == "W" && $0.action == "tag_op" }) else {
+            XCTFail("Expected W binding")
+            return
+        }
+        // New entries should be at the end, after all defaults
+        guard let lastDefaultIdx = merged.lastIndex(where: { $0.action == "reply" && $0.key == "r" && $0.context == "thread" }) else {
+            XCTFail("Expected thread reply default")
+            return
+        }
+        XCTAssertGreaterThan(wIdx, lastDefaultIdx)
+    }
+
+    // MARK: - Disable default
+
+    func testEnabledFalseRemovesDefault() {
+        // Disable the default "dd" delete binding
+        let user: [KeymapEntry] = [
+            .init(action: "delete", key: "dd", enabled: false, sequence: true),
+        ]
+        let merged = manager.mergeWithDefaults(userKeymaps: user)
+
+        XCTAssertFalse(merged.contains(where: { $0.key == "dd" && $0.context == "list" }))
+    }
+
+    func testEnabledFalseDoesNotAffectOtherDefaults() {
+        let user: [KeymapEntry] = [
+            .init(action: "delete", key: "dd", enabled: false, sequence: true),
+        ]
+        let merged = manager.mergeWithDefaults(userKeymaps: user)
+
+        // Other defaults still present
+        XCTAssertTrue(merged.contains(where: { $0.action == "next_email" && $0.key == "j" }))
+        XCTAssertTrue(merged.contains(where: { $0.action == "archive" && $0.key == "a" }))
+    }
+
+    // MARK: - Context isolation
+
+    func testOverrideRespectContext() {
+        // Override "r" only in thread context, list "r" (reply) stays untouched
+        let user: [KeymapEntry] = [
+            .init(action: "forward", key: "r", context: "thread"),
+        ]
+        let merged = manager.mergeWithDefaults(userKeymaps: user)
+
+        // Thread: should be overridden to forward
+        let threadR = merged.filter { $0.key == "r" && $0.context == "thread" && $0.modifiers.isEmpty }
+        XCTAssertEqual(threadR.count, 1)
+        XCTAssertEqual(threadR.first?.action, "forward")
+
+        // List: default reply should still be there
+        let listR = merged.filter { $0.key == "r" && $0.context == "list" && $0.modifiers.isEmpty }
+        XCTAssertTrue(listR.contains(where: { $0.action == "reply" }))
+    }
+
+    // MARK: - Modifier isolation
+
+    func testOverrideRespectsModifiers() {
+        // Override Cmd+R (reload_inbox) but leave plain "r" (reply) alone
+        let user: [KeymapEntry] = [
+            .init(action: "compose", key: "r", modifiers: ["cmd"]),
+        ]
+        let merged = manager.mergeWithDefaults(userKeymaps: user)
+
+        let cmdR = merged.filter { $0.key == "r" && $0.modifiers == ["cmd"] && $0.context == "list" }
+        XCTAssertEqual(cmdR.count, 1)
+        XCTAssertEqual(cmdR.first?.action, "compose")
+
+        // Plain "r" in list context should still be reply
+        let plainR = merged.filter { $0.key == "r" && $0.modifiers.isEmpty && $0.context == "list" }
+        XCTAssertTrue(plainR.contains(where: { $0.action == "reply" }))
+    }
+
+    // MARK: - Combined: override + add + disable
+
+    func testMixedUserConfig() {
+        let user: [KeymapEntry] = [
+            // Override: remap archive to "e"
+            .init(action: "archive", key: "a", enabled: false),
+            .init(action: "archive", key: "e"),
+            // Add: new tag shortcut
+            .init(action: "tag_op", key: "T", tags: "+todo -inbox"),
+            // Disable: remove visual mode
+            .init(action: "enter_visual_mode", key: "v", enabled: false),
+        ]
+        let merged = manager.mergeWithDefaults(userKeymaps: user)
+
+        // "a" disabled
+        XCTAssertFalse(merged.contains(where: { $0.key == "a" && $0.context == "list" }))
+        // "e" added as archive
+        XCTAssertTrue(merged.contains(where: { $0.key == "e" && $0.action == "archive" }))
+        // "T" tag_op added
+        XCTAssertTrue(merged.contains(where: { $0.key == "T" && $0.action == "tag_op" }))
+        // "v" disabled
+        XCTAssertFalse(merged.contains(where: { $0.key == "v" && $0.action == "enter_visual_mode" }))
+        // Other defaults still intact
+        XCTAssertTrue(merged.contains(where: { $0.action == "next_email" && $0.key == "j" }))
+        XCTAssertTrue(merged.contains(where: { $0.action == "compose" && $0.key == "c" }))
+    }
+
+    // MARK: - Duplicate user entries
+
+    func testDuplicateUserEntriesLastWins() {
+        let user: [KeymapEntry] = [
+            .init(action: "archive", key: "j"),
+            .init(action: "compose", key: "j"),
+        ]
+        let merged = manager.mergeWithDefaults(userKeymaps: user)
+
+        let jBindings = merged.filter { $0.key == "j" && $0.context == "list" && $0.modifiers.isEmpty }
+        XCTAssertEqual(jBindings.count, 1)
+        XCTAssertEqual(jBindings.first?.action, "compose", "Last user entry should win for same bindingKey")
+    }
+
+    // MARK: - bindingKey
+
+    func testBindingKeyFormat() {
+        let entry = KeymapEntry(action: "page_down", key: "d", modifiers: ["ctrl"], context: "thread")
+        XCTAssertEqual(entry.bindingKey, "d|ctrl|thread")
+    }
+
+    func testBindingKeyModifiersSorted() {
+        let entry = KeymapEntry(action: "test", key: "x", modifiers: ["shift", "cmd"])
+        XCTAssertEqual(entry.bindingKey, "x|cmd+shift|list")
+    }
+
+    func testBindingKeyNoModifiers() {
+        let entry = KeymapEntry(action: "next_email", key: "j")
+        XCTAssertEqual(entry.bindingKey, "j||list")
+    }
+}


### PR DESCRIPTION
## Summary
- User keymaps from `keymaps.pkl` are now **merged** with built-in defaults instead of replacing them. Users only need to include bindings they want to override, add, or disable (`enabled = false`).
- Added `enabled` field and `bindingKey` identity to `KeymapEntry` for merge matching by `(key + modifiers + context)`.
- Added folder navigation actions (`go_folder`, `next_folder`, `prev_folder`, `folder_picker`) to the Go validator whitelist.
- Updated `keymaps-example.pkl` to document merge behavior and list all defaults as reference.

Closes #202

## Test plan
- [x] Unit tests for merge function (13 test cases covering override, add, disable, context/modifier isolation, duplicates)
- [x] Manual test: launch app with minimal `keymaps.pkl` (only tag_ops), verify all default bindings still work
- [x] Manual test: override a default binding, verify only that one changes
- [x] `durian validate` passes cleanly with reduced config