### PR TITLE
chore: respect XDG Base Directory spec (config, data, state, docs)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,7 +15,7 @@ Email client: Go CLI backend + Swift macOS GUI.
 
 ## Project Structure
 
-- Config dir: `~/.config/durian/` (`config.pkl`, `keymaps.pkl`, `profiles.pkl`, `rules.pkl`, `groups.pkl`; see `docs/*-example.pkl`). Config uses [Apple Pkl](https://pkl-lang.org) — evaluated via `pkl eval --format json` at runtime. Schemas are embedded in the binary (`schema/*.pkl`) and provided via `--module-path`. Requires `pkl` CLI (`brew install pkl`).
+- Config dir: `~/.config/durian/` (or `$XDG_CONFIG_HOME/durian/`) — files: `config.pkl`, `keymaps.pkl`, `profiles.pkl`, `rules.pkl`, `groups.pkl` (see `docs/*-example.pkl`). Config uses [Apple Pkl](https://pkl-lang.org) — evaluated via `pkl eval --format json` at runtime. Schemas are embedded in the binary (`schema/*.pkl`) and provided via `--module-path`. Requires `pkl` CLI (`brew install pkl`).
 - `cli/` — Go 1.24 (Cobra), IMAP sync, SMTP send, SQLite store, HTTP API server
   - `cli/cmd/durian/` — CLI commands (sync, send, serve, search, tag, contacts, draft, auth)
   - `cli/internal/` — Internal packages (config, imap, smtp, handler, store, oauth, mail, encoding, contacts, draft, keychain, protocol)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,7 +11,8 @@ Email client: Go CLI backend + Swift macOS GUI.
 - **Integration Tests:** `bazel test //integration:integration_test` (starts real server, validates API contract via curl+jq)
 - **Validate Config:** `durian validate` (checks config.pkl, rules.pkl, profiles.pkl, keymaps.pkl, groups.pkl)
 - **Logs (GUI/Swift):** `log stream --level debug --predicate 'subsystem == "org.js-lab.durian.nightly"'` (nightly) / `subsystem == "org.js-lab.durian"` (release)
-- **Logs (CLI/Go):** `~/.config/durian/serve.log` (truncated on each `durian serve` start). Default: Info+, with `--debug`: Debug+. Other commands: Error → stderr, with `--debug`: Debug+ → stderr.
+- **Logs (CLI/Go):** `~/.local/state/durian/serve.log` (or `$XDG_STATE_HOME/durian/serve.log`; truncated on each `durian serve` start). Default: Info+, with `--debug`: Debug+. Other commands: Error → stderr, with `--debug`: Debug+ → stderr.
+- **Data:** `~/.local/share/durian/` (or `$XDG_DATA_HOME/durian/`) — `email.db`, `contacts.db`
 
 ## Project Structure
 

--- a/cli/cmd/durian/serve.go
+++ b/cli/cmd/durian/serve.go
@@ -47,7 +47,9 @@ func runServe(cmd *cobra.Command, args []string) {
 	if debugMode {
 		level = slog.LevelDebug
 	}
-	logPath := filepath.Join(filepath.Dir(config.DefaultPath()), "serve.log")
+	stateDir := config.DefaultStateDir()
+	os.MkdirAll(stateDir, 0o755)
+	logPath := filepath.Join(stateDir, "serve.log")
 	if f, err := os.Create(logPath); err == nil {
 		defer f.Close()
 		slog.SetDefault(slog.New(slog.NewTextHandler(f, &slog.HandlerOptions{Level: level})))

--- a/cli/internal/config/config.go
+++ b/cli/internal/config/config.go
@@ -44,6 +44,32 @@ func DefaultPath() string {
 	return filepath.Join(home, ".config", "durian", "config.pkl")
 }
 
+// DefaultDataDir returns the durian data directory.
+// Respects XDG_DATA_HOME, falls back to ~/.local/share/durian
+func DefaultDataDir() string {
+	if xdg := os.Getenv("XDG_DATA_HOME"); xdg != "" {
+		return filepath.Join(xdg, "durian")
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return ""
+	}
+	return filepath.Join(home, ".local", "share", "durian")
+}
+
+// DefaultStateDir returns the durian state directory.
+// Respects XDG_STATE_HOME, falls back to ~/.local/state/durian
+func DefaultStateDir() string {
+	if xdg := os.Getenv("XDG_STATE_HOME"); xdg != "" {
+		return filepath.Join(xdg, "durian")
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return ""
+	}
+	return filepath.Join(home, ".local", "state", "durian")
+}
+
 // ExpandPath expands ~ and environment variables in path
 func ExpandPath(path string) string {
 	if path == "" {

--- a/cli/internal/contacts/db.go
+++ b/cli/internal/contacts/db.go
@@ -12,10 +12,14 @@ import (
 	_ "modernc.org/sqlite"
 )
 
-// DefaultDBPath returns the default contacts database path
+// DefaultDBPath returns the default contacts database path.
+// Respects XDG_DATA_HOME, falls back to ~/.local/share/durian/contacts.db
 func DefaultDBPath() string {
+	if xdg := os.Getenv("XDG_DATA_HOME"); xdg != "" {
+		return filepath.Join(xdg, "durian", "contacts.db")
+	}
 	home, _ := os.UserHomeDir()
-	return filepath.Join(home, ".config", "durian", "contacts.db")
+	return filepath.Join(home, ".local", "share", "durian", "contacts.db")
 }
 
 // DB represents a contacts database connection

--- a/cli/internal/store/store.go
+++ b/cli/internal/store/store.go
@@ -209,9 +209,13 @@ func (d *DB) Init() error {
 }
 
 // DefaultDBPath returns the default database path for the email store.
+// Respects XDG_DATA_HOME, falls back to ~/.local/share/durian/email.db
 func DefaultDBPath() string {
+	if xdg := os.Getenv("XDG_DATA_HOME"); xdg != "" {
+		return filepath.Join(xdg, "durian", "email.db")
+	}
 	home, _ := os.UserHomeDir()
-	return filepath.Join(home, ".config", "durian", "email.db")
+	return filepath.Join(home, ".local", "share", "durian", "email.db")
 }
 
 // migrate checks the current schema version and applies pending migrations.

--- a/cli/internal/store/store_test.go
+++ b/cli/internal/store/store_test.go
@@ -46,8 +46,8 @@ func TestDefaultDBPath(t *testing.T) {
 	if !contains(path, "email.db") {
 		t.Errorf("path %q does not contain email.db", path)
 	}
-	if !contains(path, ".config/durian/") {
-		t.Errorf("path %q does not contain .config/durian/", path)
+	if !contains(path, "durian/") {
+		t.Errorf("path %q does not contain durian/", path)
 	}
 }
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -64,13 +64,13 @@ The GUI never talks IMAP directly. Every action the user takes in the UI — ope
 
 ### Config file ownership
 
-`~/.config/durian/config.toml` is **read by both the Go CLI and the Swift GUI**, each with its own TOML parser. Fields land in one of three categories:
+`~/.config/durian/config.pkl` (or `$XDG_CONFIG_HOME/durian/config.pkl`) is **read by both the Go CLI and the Swift GUI**, each with its own Pkl evaluator. Fields land in one of three categories:
 
 - **Go-only** (e.g. `accounts.imap.host`, `sync.tag_sync.url`) — consumed by `durian sync`, `durian serve`, etc.
 - **Swift-only** (e.g. `settings.theme`, `sync.gui_auto_sync`) — read directly by `macos/durian/Managers/ConfigManager.swift`.
 - **Shared for validation** (e.g. `settings.accent_color`) — Go's `durian validate` checks format before Swift loads.
 
-Go's TOML parser is **non-strict**, so unknown keys are silently ignored on each side. This is intentional: adding a GUI-only field to config.toml doesn't need a matching Go struct.
+Pkl schemas enforce structure at eval time, but each side only decodes the fields it needs. This is intentional: adding a GUI-only field to config.pkl doesn't need a matching Go struct.
 
 ### The HTTP API
 

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -32,12 +32,12 @@ The GUI launches `durian serve` automatically as a child process — no manual d
 
 ## 2. Create your config
 
-Durian reads `~/.config/durian/config.toml`. Start from the example:
+Durian reads `~/.config/durian/config.pkl` (or `$XDG_CONFIG_HOME/durian/config.pkl`). Start from the example:
 
 ```bash
 mkdir -p ~/.config/durian
-curl -o ~/.config/durian/config.toml \
-  https://raw.githubusercontent.com/julion2/Durian/main/docs/config-example.toml
+curl -o ~/.config/durian/config.pkl \
+  https://raw.githubusercontent.com/julion2/Durian/main/docs/config-example.pkl
 ```
 
 Open it and delete the example accounts you don't need. For each account you keep:
@@ -48,24 +48,27 @@ Open it and delete the example accounts you don't need. For each account you kee
 
 A minimal password-auth config:
 
-```toml
-[[accounts]]
-name = "Personal"
-email = "you@example.com"
-alias = "personal"
-
-[accounts.smtp]
-host = "smtp.example.com"
-port = 587
-auth = "password"
-
-[accounts.imap]
-host = "imap.example.com"
-port = 993
-auth = "password"
-
-[accounts.auth]
-username = "you@example.com"
+```pkl
+accounts {
+  new {
+    name = "Personal"
+    email = "you@example.com"
+    alias = "personal"
+    smtp {
+      host = "smtp.example.com"
+      port = 587
+      auth = "password"
+    }
+    imap {
+      host = "imap.example.com"
+      port = 993
+      auth = "password"
+    }
+    auth {
+      username = "you@example.com"
+    }
+  }
+}
 ```
 
 Validate the config before touching auth:
@@ -128,9 +131,9 @@ See `durian --help` for the full command list.
 
 ## 6. Common next steps
 
-- **Sidebar folders and profiles** — copy `docs/profiles-example.toml` to `~/.config/durian/profiles.toml`
-- **Custom keymaps** — copy `docs/keymaps-example.toml` to `~/.config/durian/keymaps.toml`
-- **Filter rules** (auto-tag on sync) — copy `docs/rules-example.toml` to `~/.config/durian/rules.toml`
+- **Sidebar folders and profiles** — copy `docs/profiles-example.pkl` to `~/.config/durian/profiles.pkl`
+- **Custom keymaps** — copy `docs/keymaps-example.pkl` to `~/.config/durian/keymaps.pkl`
+- **Filter rules** (auto-tag on sync) — copy `docs/rules-example.pkl` to `~/.config/durian/rules.pkl`
 - **Multi-machine tag sync** — [sync/README.md](../sync/README.md)
 - **How it actually works** — [ARCHITECTURE.md](ARCHITECTURE.md)
 

--- a/docs/OAUTH_SETUP.md
+++ b/docs/OAUTH_SETUP.md
@@ -20,12 +20,13 @@ omit `client_id` (the default will be used).
 6. Grant admin consent (required for work/school accounts)
 7. Copy **Application (client) ID**
 
-Add to config.toml (custom app):
-```toml
-[accounts.oauth]
-provider = "microsoft"
-client_id = "your-client-id"
-# tenant = "common"   # Optional: "common", "organizations", or your tenant ID/domain
+Add to config.pkl (custom app):
+```pkl
+oauth {
+  provider = "microsoft"
+  client_id = "your-client-id"
+  // tenant = "common"   // Optional: "common", "organizations", or your tenant ID/domain
+}
 ```
 
 Shared mailboxes: configure the shared mailbox as its own `[[accounts]]` entry
@@ -42,12 +43,13 @@ and set `auth_email` to the delegating user who has Full Access + Send As.
 5. Authorized redirect URI: `http://localhost:8080/callback`
 6. Copy **Client ID** and **Client Secret**
 
-Add to config.toml:
-```toml
-[accounts.oauth]
-provider = "google"
-client_id = "your-client-id"
-client_secret = "your-client-secret"
+Add to config.pkl:
+```pkl
+oauth {
+  provider = "google"
+  client_id = "your-client-id"
+  client_secret = "your-client-secret"
+}
 ```
 
 ## Usage

--- a/docs/PASSWORD_SETUP.md
+++ b/docs/PASSWORD_SETUP.md
@@ -6,26 +6,29 @@ On Linux, install `secret-tool` (libsecret). Then use `durian auth login <accoun
 
 ## Config + Login
 
-Add to your config.toml:
+Add to your config.pkl:
 
-```toml
-[[accounts]]
-name = "GMX"
-email = "you@gmx.de"
-
-[accounts.smtp]
-host = "mail.gmx.net"
-port = 587
-auth = "password"
-max_attachment_size = "20MB"
-
-[accounts.imap]
-host = "imap.gmx.net"
-port = 993
-auth = "password"
-
-[accounts.auth]
-username = "you@gmx.de"
+```pkl
+accounts {
+  new {
+    name = "GMX"
+    email = "you@gmx.de"
+    smtp {
+      host = "mail.gmx.net"
+      port = 587
+      auth = "password"
+      max_attachment_size = "20MB"
+    }
+    imap {
+      host = "imap.gmx.net"
+      port = 993
+      auth = "password"
+    }
+    auth {
+      username = "you@gmx.de"
+    }
+  }
+}
 ```
 
 Then run:

--- a/docs/vim-compose.md
+++ b/docs/vim-compose.md
@@ -116,13 +116,11 @@ Yank and delete operations copy to the system clipboard.
 
 ## Configuration
 
-Exit sequences for insert → normal mode are configured in `keymaps.toml`:
+Exit sequences for insert → normal mode are configured in `keymaps.pkl`:
 
-```toml
-[[keymaps]]
-action = "exit_insert"
-key = "jk"
-context = "compose_normal"
-enabled = true
-sequence = true
+```pkl
+// In keymaps.pkl
+keymaps {
+  new { action = "exit_insert"; key = "jk"; context = "compose_normal"; sequence = true }
+}
 ```

--- a/macos/durian/DurianApp.swift
+++ b/macos/durian/DurianApp.swift
@@ -163,9 +163,7 @@ struct DurianApp: App {
     }
 
     private func openConfig() {
-        let homeURL = FileManager.default.homeDirectoryForCurrentUser
-        let configURL = homeURL.appendingPathComponent(".config/durian/config.pkl")
-        
+        let configURL = FileManager.default.durianConfigURL().appendingPathComponent("config.pkl")
         NSWorkspace.shared.open(configURL)
     }
 }

--- a/macos/durian/Keymaps/KeymapsManager.swift
+++ b/macos/durian/Keymaps/KeymapsManager.swift
@@ -144,8 +144,7 @@ class KeymapsManager: ObservableObject {
     }
 
     private func getKeymapsURL() -> URL {
-        let homeURL = FileManager.default.homeDirectoryForCurrentUser
-        return homeURL.appendingPathComponent(".config/durian/keymaps.pkl")
+        FileManager.default.durianConfigURL().appendingPathComponent("keymaps.pkl")
     }
 
     

--- a/macos/durian/Managers/ConfigManager.swift
+++ b/macos/durian/Managers/ConfigManager.swift
@@ -172,8 +172,7 @@ class ConfigManager {
     }
 
     private func getConfigURL() -> URL {
-        let homeURL = FileManager.default.homeDirectoryForCurrentUser
-        return homeURL.appendingPathComponent(".config/durian/config.pkl")
+        FileManager.default.durianConfigURL().appendingPathComponent("config.pkl")
     }
     
     // MARK: - Public API

--- a/macos/durian/Managers/ProfileManager.swift
+++ b/macos/durian/Managers/ProfileManager.swift
@@ -90,8 +90,8 @@ class ProfileManager: ObservableObject {
     }
 
     func loadProfiles() {
-        let configURL = FileManager.default.homeDirectoryForCurrentUser
-            .appendingPathComponent(".config/durian/profiles.pkl")
+        let configURL = FileManager.default.durianConfigURL()
+            .appendingPathComponent("profiles.pkl")
 
         let config: ProfilesConfig
         do {

--- a/macos/durian/Utilities/FileManager+Extensions.swift
+++ b/macos/durian/Utilities/FileManager+Extensions.swift
@@ -1,6 +1,15 @@
 import Foundation
 
 extension FileManager {
+    /// Returns the durian config directory, respecting XDG_CONFIG_HOME.
+    /// Falls back to ~/.config/durian/ if XDG_CONFIG_HOME is unset.
+    func durianConfigURL() -> URL {
+        if let xdg = ProcessInfo.processInfo.environment["XDG_CONFIG_HOME"], !xdg.isEmpty {
+            return URL(fileURLWithPath: xdg).appendingPathComponent("durian")
+        }
+        return homeDirectoryForCurrentUser.appendingPathComponent(".config/durian")
+    }
+
     func resolveDurianPath() -> String? {
         // 1. Check ~/.local/bin/durian
         let homeURL = self.homeDirectoryForCurrentUser


### PR DESCRIPTION
## Summary
- **Swift GUI**: shared `durianConfigURL()` utility respects `XDG_CONFIG_HOME` (was hardcoded `~/.config/durian/` in 4 locations)
- **Go CLI**: move `email.db`/`contacts.db` to `XDG_DATA_HOME` (`~/.local/share/durian/`), `serve.log` to `XDG_STATE_HOME` (`~/.local/state/durian/`)
- **Docs**: fix all stale `.toml` references → `.pkl`, update code examples to Pkl syntax, add XDG mentions to CLAUDE.md

| Path | Before | After |
|------|--------|-------|
| Config | `~/.config/durian/` | `$XDG_CONFIG_HOME/durian/` |
| Data | `~/.config/durian/` | `~/.local/share/durian/` (`$XDG_DATA_HOME`) |
| Logs | `~/.config/durian/serve.log` | `~/.local/state/durian/serve.log` (`$XDG_STATE_HOME`) |

## Test plan
- [x] `durian validate` passes
- [x] GUI launches and loads config/keymaps from XDG_CONFIG_HOME
- [x] `durian serve` writes logs to `~/.local/state/durian/serve.log`
- [x] DB files read from `~/.local/share/durian/`