### PR TITLE
fix(go-serve): add request body size limits and server timeouts

### DIFF
--- a/cli/cmd/durian/serve.go
+++ b/cli/cmd/durian/serve.go
@@ -193,8 +193,11 @@ func runServe(cmd *cobra.Command, args []string) {
 	}
 
 	server := &http.Server{
-		Addr:    addr,
-		Handler: r,
+		Addr:           addr,
+		Handler:        r,
+		ReadTimeout:    30 * time.Second,
+		IdleTimeout:    120 * time.Second,
+		MaxHeaderBytes: 1 << 20, // 1 MB
 	}
 
 	// Graceful shutdown

--- a/cli/internal/handler/contacts.go
+++ b/cli/internal/handler/contacts.go
@@ -100,6 +100,7 @@ func (h *Handler) IncrementContactUsageHandler(w http.ResponseWriter, r *http.Re
 	var req struct {
 		Emails []string `json:"emails"`
 	}
+	r.Body = http.MaxBytesReader(w, r.Body, 1<<20) // 1 MB
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 		http.Error(w, "invalid request body", http.StatusBadRequest)
 		return

--- a/cli/internal/handler/drafts.go
+++ b/cli/internal/handler/drafts.go
@@ -18,6 +18,7 @@ func (h *Handler) SaveLocalDraftHandler(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 
+	r.Body = http.MaxBytesReader(w, r.Body, 1<<20) // 1 MB
 	var body struct {
 		DraftJSON json.RawMessage `json:"draft_json"`
 	}

--- a/cli/internal/handler/http.go
+++ b/cli/internal/handler/http.go
@@ -178,6 +178,7 @@ func (h *Handler) TagThreadHandler(w http.ResponseWriter, r *http.Request) {
 	vars := mux.Vars(r)
 	threadID := vars["thread_id"]
 
+	r.Body = http.MaxBytesReader(w, r.Body, 1<<20) // 1 MB
 	var tagRequest struct {
 		Tags string `json:"tags"`
 	}

--- a/cli/internal/handler/outbox.go
+++ b/cli/internal/handler/outbox.go
@@ -50,6 +50,7 @@ type OutboxAttachment struct {
 
 // EnqueueOutboxHandler handles POST /api/v1/outbox/send.
 func (h *Handler) EnqueueOutboxHandler(w http.ResponseWriter, r *http.Request) {
+	r.Body = http.MaxBytesReader(w, r.Body, 50<<20) // 50 MB (attachments)
 	var draft OutboxDraft
 	if err := json.NewDecoder(r.Body).Decode(&draft); err != nil {
 		http.Error(w, "Invalid request body", http.StatusBadRequest)


### PR DESCRIPTION
## Summary

- Add `ReadTimeout` (30s), `IdleTimeout` (120s), `MaxHeaderBytes` (1MB) to the HTTP server
- Add per-handler `MaxBytesReader` limits: 50MB for outbox/send (attachments), 1MB for tags/drafts/contacts
- No `WriteTimeout` — SSE endpoint and IMAP attachment streaming require long-lived responses

Closes #213

## Test plan

- [ ] GUI: compose + send email with attachment (< 50MB)
- [ ] GUI: tag threads, save drafts, search contacts
- [ ] GUI: SSE event stream stays connected
- [ ] GUI: download attachment from email