### PR TITLE
feat(go-serve,swift-net): add per-session auth token for HTTP API

### DIFF
--- a/cli/cmd/durian/serve.go
+++ b/cli/cmd/durian/serve.go
@@ -2,9 +2,13 @@ package main
 
 import (
 	"context"
+	"crypto/rand"
+	"crypto/subtle"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"log/slog"
+	"net"
 	"net/http"
 	"os"
 	"os/signal"
@@ -93,6 +97,15 @@ func runServe(cmd *cobra.Command, args []string) {
 	h := handler.New(emailDB, contactsDB)
 	eventHub := handler.NewEventHub()
 
+	// Generate auth token for this session
+	tokenBytes := make([]byte, 32)
+	if _, err := rand.Read(tokenBytes); err != nil {
+		slog.Error("Failed to generate auth token", "module", "SERVE", "err", err)
+		os.Exit(1)
+	}
+	authToken := hex.EncodeToString(tokenBytes)
+	expectedHeader := []byte("Bearer " + authToken)
+
 	r := mux.NewRouter()
 	addr := fmt.Sprintf("127.0.0.1:%d", servePort)
 	allowedHost := fmt.Sprintf("localhost:%d", servePort)
@@ -103,6 +116,12 @@ func runServe(cmd *cobra.Command, args []string) {
 			if host != allowedHost && host != allowedHostIP &&
 				host != "localhost" && host != "127.0.0.1" {
 				http.Error(w, "forbidden", http.StatusForbidden)
+				return
+			}
+			// Verify auth token
+			auth := []byte(req.Header.Get("Authorization"))
+			if subtle.ConstantTimeCompare(auth, expectedHeader) != 1 {
+				http.Error(w, "unauthorized", http.StatusUnauthorized)
 				return
 			}
 			next.ServeHTTP(w, req)
@@ -193,22 +212,29 @@ func runServe(cmd *cobra.Command, args []string) {
 	}
 
 	server := &http.Server{
-		Addr:           addr,
 		Handler:        r,
 		ReadTimeout:    30 * time.Second,
 		IdleTimeout:    120 * time.Second,
 		MaxHeaderBytes: 1 << 20, // 1 MB
 	}
 
-	// Graceful shutdown
+	// Bind first, then signal readiness with auth token on stdout
+	listener, err := net.Listen("tcp", addr)
+	if err != nil {
+		slog.Error("Could not listen", "module", "SERVE", "addr", addr, "err", err)
+		fmt.Fprintln(os.Stderr, "Error: could not listen on", addr, err)
+		os.Exit(1)
+	}
+
 	go func() {
-		if err := server.ListenAndServe(); err != nil && err != http.ErrServerClosed {
-			slog.Error("Could not listen", "module", "SERVE", "addr", server.Addr, "err", err)
+		if err := server.Serve(listener); err != nil && err != http.ErrServerClosed {
+			slog.Error("Server error", "module", "SERVE", "err", err)
 			os.Exit(1)
 		}
 	}()
 
-	fmt.Println("Server is ready to handle requests at", server.Addr)
+	// Machine-readable ready line — GUI parses this from stdout pipe
+	fmt.Printf("READY token=%s addr=%s\n", authToken, addr)
 	quit := make(chan os.Signal, 1)
 	signal.Notify(quit, syscall.SIGINT, syscall.SIGTERM)
 	<-quit

--- a/integration/integration_test.sh
+++ b/integration/integration_test.sh
@@ -50,9 +50,9 @@ assert_http_code() {
     local desc="$1" url="$2" method="${3:-GET}" expected="$4" body="${5:-}"
     local code
     if [ "$method" = "GET" ]; then
-        code=$(curl -s -o /dev/null -w "%{http_code}" "$url")
+        code=$(curl -s -o /dev/null -w "%{http_code}" "${AUTH[@]}" "$url")
     else
-        code=$(curl -s -o /dev/null -w "%{http_code}" -X "$method" -H "Content-Type: application/json" -d "$body" "$url")
+        code=$(curl -s -o /dev/null -w "%{http_code}" "${AUTH[@]}" -X "$method" -H "Content-Type: application/json" -d "$body" "$url")
     fi
     if [ "$code" = "$expected" ]; then
         pass "$desc"
@@ -75,25 +75,27 @@ else
 fi
 
 echo "==> Starting durian serve on port $PORT"
-"$DURIAN" serve --port "$PORT" --db "$EMAIL_DB" --contacts-db "$CONTACTS_DB" -c "$TEST_CONFIG" &
+# Capture stdout to read the READY line with auth token
+READY_PIPE=$(mktemp -u)
+mkfifo "$READY_PIPE"
+"$DURIAN" serve --port "$PORT" --db "$EMAIL_DB" --contacts-db "$CONTACTS_DB" -c "$TEST_CONFIG" > "$READY_PIPE" &
 SERVER_PID=$!
 
 echo "==> Waiting for server..."
-for i in $(seq 1 50); do
-    if curl -sf "http://localhost:$PORT/api/v1/version" > /dev/null 2>&1; then
-        echo "==> Server ready"
-        break
-    fi
-    if ! kill -0 "$SERVER_PID" 2>/dev/null; then
-        echo "ERROR: Server process died"; exit 1
-    fi
-    sleep 0.1
-done
-if ! curl -sf "http://localhost:$PORT/api/v1/version" > /dev/null 2>&1; then
-    echo "ERROR: Server not responding after 5s"; exit 1
+TOKEN=""
+if read -r -t 10 READY_LINE < "$READY_PIPE"; then
+    echo "$READY_LINE"
+    TOKEN=$(echo "$READY_LINE" | grep -o 'token=[^ ]*' | cut -d= -f2)
 fi
+rm -f "$READY_PIPE"
+
+if [ -z "$TOKEN" ]; then
+    echo "ERROR: Server not responding after 10s"; exit 1
+fi
+echo "==> Server ready (token received)"
 
 BASE="http://localhost:$PORT/api/v1"
+AUTH=(-H "Authorization: Bearer $TOKEN")
 
 echo ""
 echo "=== API Contract Tests ==="
@@ -102,14 +104,14 @@ echo ""
 # ─────────────────────────────────────────────
 # 1. Version
 # ─────────────────────────────────────────────
-RESP=$(curl -sf "$BASE/version")
+RESP=$(curl -sf "${AUTH[@]}" "$BASE/version")
 assert_jq "GET /version .version is string" "$RESP" '.version | type == "string"'
 assert_jq "GET /version .commit is string" "$RESP" '.commit | type == "string"'
 
 # ─────────────────────────────────────────────
 # 2. Search (DurianResponse + MailSearchResult)
 # ─────────────────────────────────────────────
-RESP=$(curl -sf "$BASE/search?query=tag:inbox&limit=10")
+RESP=$(curl -sf "${AUTH[@]}" "$BASE/search?query=tag:inbox&limit=10")
 assert_jq "GET /search .ok is true" "$RESP" '.ok == true'
 assert_jq "GET /search .results is array" "$RESP" '.results | type == "array"'
 assert_jq "GET /search .results[0].thread_id is string" "$RESP" '.results[0].thread_id | type == "string"'
@@ -120,7 +122,7 @@ assert_jq "GET /search .results[0].timestamp is number" "$RESP" '.results[0].tim
 assert_jq "GET /search .results[0].tags is string" "$RESP" '.results[0].tags | type == "string"'
 
 # 3. Search count
-RESP=$(curl -sf "$BASE/search/count?query=tag:inbox")
+RESP=$(curl -sf "${AUTH[@]}" "$BASE/search/count?query=tag:inbox")
 assert_jq "GET /search/count .count is number" "$RESP" '.count | type == "number"'
 assert_jq "GET /search/count .count > 0" "$RESP" '.count > 0'
 
@@ -130,7 +132,7 @@ assert_http_code "GET /search without query → 400" "$BASE/search" "GET" "400"
 # ─────────────────────────────────────────────
 # 4. Tags (DurianResponse + tags array)
 # ─────────────────────────────────────────────
-RESP=$(curl -sf "$BASE/tags")
+RESP=$(curl -sf "${AUTH[@]}" "$BASE/tags")
 assert_jq "GET /tags .ok is true" "$RESP" '.ok == true'
 assert_jq "GET /tags .tags is array" "$RESP" '.tags | type == "array"'
 assert_jq "GET /tags .tags contains inbox" "$RESP" '.tags | index("inbox") != null'
@@ -138,8 +140,8 @@ assert_jq "GET /tags .tags contains inbox" "$RESP" '.tags | index("inbox") != nu
 # ─────────────────────────────────────────────
 # 5. Show thread (DurianResponse + ThreadContent + ThreadMessage)
 # ─────────────────────────────────────────────
-THREAD_ID=$(curl -sf "$BASE/search?query=tag:inbox&limit=1" | jq -r '.results[0].thread_id')
-RESP=$(curl -sf "$BASE/threads/$THREAD_ID")
+THREAD_ID=$(curl -sf "${AUTH[@]}" "$BASE/search?query=tag:inbox&limit=1" | jq -r '.results[0].thread_id')
+RESP=$(curl -sf "${AUTH[@]}" "$BASE/threads/$THREAD_ID")
 assert_jq "GET /threads/{id} .ok is true" "$RESP" '.ok == true'
 assert_jq "GET /threads/{id} .thread.thread_id is string" "$RESP" '.thread.thread_id | type == "string"'
 assert_jq "GET /threads/{id} .thread.subject is string" "$RESP" '.thread.subject | type == "string"'
@@ -154,12 +156,12 @@ assert_jq "GET /threads/{id} message.tags is array" "$RESP" '.thread.messages[0]
 # ─────────────────────────────────────────────
 # 6. Tag thread (POST, write + verify)
 # ─────────────────────────────────────────────
-RESP=$(curl -sf -X POST -H "Content-Type: application/json" \
+RESP=$(curl -sf "${AUTH[@]}" -X POST -H "Content-Type: application/json" \
     -d '{"tags":"+starred"}' "$BASE/threads/$THREAD_ID/tags")
 assert_jq "POST /threads/{id}/tags .ok is true" "$RESP" '.ok == true'
 
 # Verify tag was applied
-RESP=$(curl -sf "$BASE/tags")
+RESP=$(curl -sf "${AUTH[@]}" "$BASE/tags")
 assert_jq "POST /tags verified: starred exists" "$RESP" '.tags | index("starred") != null'
 
 # Error: invalid body
@@ -169,7 +171,7 @@ assert_http_code "POST /threads/{id}/tags invalid body → 400" \
 # ─────────────────────────────────────────────
 # 7. Message body (DurianResponse + MessageBody)
 # ─────────────────────────────────────────────
-RESP=$(curl -sf "$BASE/message/body?id=msg1@test")
+RESP=$(curl -sf "${AUTH[@]}" "$BASE/message/body?id=msg1@test")
 assert_jq "GET /message/body .ok is true" "$RESP" '.ok == true'
 assert_jq "GET /message/body .message_body.body is string" "$RESP" '.message_body.body | type == "string"'
 assert_jq "GET /message/body .message_body.html is string" "$RESP" '.message_body.html | type == "string"'
@@ -181,7 +183,7 @@ assert_http_code "GET /message/body without id → 400" "$BASE/message/body" "GE
 # ─────────────────────────────────────────────
 # 8. Contacts
 # ─────────────────────────────────────────────
-RESP=$(curl -sf "$BASE/contacts?limit=10")
+RESP=$(curl -sf "${AUTH[@]}" "$BASE/contacts?limit=10")
 assert_jq "GET /contacts is array" "$RESP" 'type == "array"'
 assert_jq "GET /contacts[0].email is string" "$RESP" '.[0].email | type == "string"'
 assert_jq "GET /contacts[0].name is string" "$RESP" '.[0].name | type == "string"'
@@ -189,12 +191,12 @@ assert_jq "GET /contacts[0].usage_count is number" "$RESP" '.[0].usage_count | t
 assert_jq "GET /contacts[0].source is string" "$RESP" '.[0].source | type == "string"'
 
 # Search contacts
-RESP=$(curl -sf "$BASE/contacts/search?query=alice&limit=5")
+RESP=$(curl -sf "${AUTH[@]}" "$BASE/contacts/search?query=alice&limit=5")
 assert_jq "GET /contacts/search returns array" "$RESP" 'type == "array"'
 assert_jq "GET /contacts/search finds alice" "$RESP" '.[0].email | contains("alice")'
 
 # Increment usage
-RESP=$(curl -sf -X POST -H "Content-Type: application/json" \
+RESP=$(curl -sf "${AUTH[@]}" -X POST -H "Content-Type: application/json" \
     -d '{"emails":["alice@example.com"]}' "$BASE/contacts/usage")
 assert_jq "POST /contacts/usage returns ok" "$RESP" '. == {}'
 
@@ -202,35 +204,35 @@ assert_jq "POST /contacts/usage returns ok" "$RESP" '. == {}'
 # 9. Local drafts (CRUD roundtrip)
 # ─────────────────────────────────────────────
 # Save a draft
-RESP=$(curl -sf -X PUT -H "Content-Type: application/json" \
+RESP=$(curl -sf "${AUTH[@]}" -X PUT -H "Content-Type: application/json" \
     -d '{"draft_json":{"to":"test@example.com","subject":"Draft"}}' \
     "$BASE/local-drafts/test-draft-1")
 assert_jq "PUT /local-drafts/{id} .ok is true" "$RESP" '.ok == true'
 
 # Get the draft back
-RESP=$(curl -sf "$BASE/local-drafts/test-draft-1")
+RESP=$(curl -sf "${AUTH[@]}" "$BASE/local-drafts/test-draft-1")
 assert_jq "GET /local-drafts/{id} .id is string" "$RESP" '.id | type == "string"'
 assert_jq "GET /local-drafts/{id} .draft_json exists" "$RESP" '.draft_json != null'
 
 # List drafts
-RESP=$(curl -sf "$BASE/local-drafts")
+RESP=$(curl -sf "${AUTH[@]}" "$BASE/local-drafts")
 assert_jq "GET /local-drafts is array" "$RESP" 'type == "array"'
 assert_jq "GET /local-drafts has 1 entry" "$RESP" 'length == 1'
 assert_jq "GET /local-drafts[0].id is string" "$RESP" '.[0].id | type == "string"'
 assert_jq "GET /local-drafts[0].draft_json exists" "$RESP" '.[0].draft_json != null'
 
 # Delete the draft
-RESP=$(curl -sf -X DELETE "$BASE/local-drafts/test-draft-1")
+RESP=$(curl -sf "${AUTH[@]}" -X DELETE "$BASE/local-drafts/test-draft-1")
 assert_jq "DELETE /local-drafts/{id} .ok is true" "$RESP" '.ok == true'
 
 # Verify deleted
-RESP=$(curl -sf "$BASE/local-drafts")
+RESP=$(curl -sf "${AUTH[@]}" "$BASE/local-drafts")
 assert_jq "GET /local-drafts empty after delete" "$RESP" 'length == 0'
 
 # ─────────────────────────────────────────────
 # 10. Outbox
 # ─────────────────────────────────────────────
-RESP=$(curl -sf "$BASE/outbox")
+RESP=$(curl -sf "${AUTH[@]}" "$BASE/outbox")
 assert_jq "GET /outbox is array" "$RESP" 'type == "array"'
 
 # ─────────────────────────────────────────────

--- a/macos/durian/Managers/DraftManager.swift
+++ b/macos/durian/Managers/DraftManager.swift
@@ -25,6 +25,12 @@ class DraftManager {
 
     private init() {}
 
+    private func authHeader(for request: inout URLRequest) {
+        if let token = EmailBackend.authToken {
+            request.addValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+        }
+    }
+
     func saveDraft(_ draft: EmailDraft) {
         var cleaned = draft
         cleaned.to = Self.filterValidAddresses(draft.to)
@@ -42,6 +48,7 @@ class DraftManager {
             request.addValue("application/json", forHTTPHeaderField: "Content-Type")
             request.httpBody = body
             request.timeoutInterval = 5
+            authHeader(for: &request)
 
             URLSession.shared.dataTask(with: request) { _, response, error in
                 if let error {
@@ -61,6 +68,7 @@ class DraftManager {
         var request = URLRequest(url: baseURL.appendingPathComponent(id.uuidString))
         request.httpMethod = "DELETE"
         request.timeoutInterval = 5
+        authHeader(for: &request)
 
         URLSession.shared.dataTask(with: request) { _, _, error in
             if let error {

--- a/macos/durian/Network/EmailBackend.swift
+++ b/macos/durian/Network/EmailBackend.swift
@@ -118,6 +118,8 @@ class EmailBackend: ObservableObject, SearchBackend, OutboxBackend {
     private var durianProcess: Process?
     private let decoder = JSONDecoder()
     private let baseURL = URL(string: "http://localhost:9723/api/v1")!
+    // Auth token for the current server session — static for cross-component access
+    nonisolated(unsafe) static var authToken: String?
 
     // MARK: - Published State (Protocol conformance)
     @Published var isConnected = false
@@ -198,31 +200,45 @@ class EmailBackend: ObservableObject, SearchBackend, OutboxBackend {
         env["PATH"] = (extraPaths + [currentPath]).joined(separator: ":")
         durianProcess?.environment = env
 
-        // Go manages serve.log directly (truncate-on-start, leveled via slog)
-        durianProcess?.standardOutput = FileHandle.nullDevice
+        // Capture stdout to read the READY line with auth token
+        let stdoutPipe = Pipe()
+        durianProcess?.standardOutput = stdoutPipe
         durianProcess?.standardError = FileHandle.nullDevice
 
         do {
             try durianProcess?.run()
             Log.info("BACKEND", "Started durian server process")
 
-            // Give the server a moment to start
-            try? await Task.sleep(for: .seconds(1))
-
-            // Check if the server is reachable
-            var request = URLRequest(url: baseURL)
-            request.httpMethod = "HEAD" // Lightweight request to check server status
-            request.timeoutInterval = 10
-
-            let (_, response) = try await URLSession.shared.data(for: request)
-            if let httpResponse = response as? HTTPURLResponse, httpResponse.statusCode == 404 { // 404 is ok, means our base endpoint is handled
-                isConnected = true
-                connectionStatus = "Connected"
-                Log.info("BACKEND", "Server is responsive")
-                await selectFolder("inbox")
-            } else {
-                throw NSError(domain: "EmailBackend", code: -1, userInfo: [NSLocalizedDescriptionKey: "Server not responsive"])
+            // Read the READY line from stdout (blocks until the server prints it)
+            let token = try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<String, Error>) in
+                stdoutPipe.fileHandleForReading.readabilityHandler = { handle in
+                    let data = handle.availableData
+                    guard !data.isEmpty, let line = String(data: data, encoding: .utf8) else {
+                        handle.readabilityHandler = nil
+                        continuation.resume(throwing: NSError(domain: "EmailBackend", code: -1, userInfo: [NSLocalizedDescriptionKey: "Server closed stdout without READY"]))
+                        return
+                    }
+                    // Parse "READY token=<hex> addr=<addr>\n"
+                    if line.hasPrefix("READY token=") {
+                        handle.readabilityHandler = nil
+                        let parts = line.trimmingCharacters(in: .whitespacesAndNewlines).split(separator: " ")
+                        for part in parts {
+                            if part.hasPrefix("token=") {
+                                let tokenValue = String(part.dropFirst(6))
+                                continuation.resume(returning: tokenValue)
+                                return
+                            }
+                        }
+                        continuation.resume(throwing: NSError(domain: "EmailBackend", code: -1, userInfo: [NSLocalizedDescriptionKey: "Malformed READY line"]))
+                    }
+                }
             }
+
+            Self.authToken = token
+            isConnected = true
+            connectionStatus = "Connected"
+            Log.info("BACKEND", "Server is ready, auth token received")
+            await selectFolder("inbox")
         } catch {
             connectionStatus = "Failed to start or connect to server: \(error.localizedDescription)"
             Log.error("BACKEND", connectionStatus)
@@ -319,6 +335,9 @@ class EmailBackend: ObservableObject, SearchBackend, OutboxBackend {
         var request = URLRequest(url: url)
         request.httpMethod = method
         request.timeoutInterval = 10
+        if let token = Self.authToken {
+            request.addValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+        }
 
         if let bodyData {
             request.addValue("application/json", forHTTPHeaderField: "Content-Type")
@@ -543,6 +562,9 @@ class EmailBackend: ObservableObject, SearchBackend, OutboxBackend {
         var request = URLRequest(url: url)
         request.httpMethod = "GET"
         request.timeoutInterval = 60
+        if let token = Self.authToken {
+            request.addValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+        }
 
         let signposter = Log.signposter(for: "HTTP")
         let endpoint = "/messages/\(encodedId)/attachments/\(partId)"

--- a/macos/durian/Network/EventStreamClient.swift
+++ b/macos/durian/Network/EventStreamClient.swift
@@ -88,7 +88,11 @@ class EventStreamClient: ObservableObject {
     // MARK: - SSE Parser
 
     private func readStream() async throws {
-        let (bytes, response) = try await URLSession.shared.bytes(from: eventsURL)
+        var request = URLRequest(url: eventsURL)
+        if let token = EmailBackend.authToken {
+            request.addValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+        }
+        let (bytes, response) = try await URLSession.shared.bytes(for: request)
 
         guard let http = response as? HTTPURLResponse, http.statusCode == 200 else {
             Log.warning("EVENTS", "Server returned non-200, will retry")


### PR DESCRIPTION
## Summary

- Go server generates a cryptographic random token (32 bytes) on each `durian serve` startup
- Token is printed via stdout pipe as `READY token=<hex> addr=<addr>` — GUI reads it directly from the subprocess pipe
- Auth middleware validates `Authorization: Bearer <token>` on all matched routes using constant-time comparison
- No file-based token storage — token only exists in process memory (stdout pipe is ephemeral, not visible via `ps` or on disk)
- Replaces the 1-second sleep + HEAD health check with synchronous pipe reading (server signals readiness only after TCP bind succeeds)
- Also includes server timeouts (ReadTimeout 30s, IdleTimeout 120s, MaxHeaderBytes 1MB)

### Files changed

**Go:** `cli/cmd/durian/serve.go` — token generation, auth middleware, listener-based startup
**Swift:** `EmailBackend.swift` — stdout pipe parsing, Bearer header on `performRequest` + `downloadAttachment`
**Swift:** `EventStreamClient.swift` — Bearer header on SSE connection
**Swift:** `DraftManager.swift` — Bearer header on draft save/delete

Closes #210

## Test plan

- [x] GUI connects and loads all accounts (12 IMAP accounts tested)
- [x] SSE event stream connects with auth
- [x] Outbox send works
- [x] Draft auto-save works
- [x] Attachment download works
- [x] `curl localhost:9723/api/v1/version` without token returns 401