### PR TITLE
fix(swift-attachment-cache): respect pinned in TTL, snapshot evict, drop get() saveIndex

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -65,7 +65,7 @@ jobs:
           restore-keys: bazel-gui-
 
       - name: Test
-        run: bazel test //macos:ci_config_test //macos:ci_profile_test //macos:ci_banner_manager_test //macos:ci_model_test //macos:ci_sync_manager_test //macos:ci_search_manager_test //macos:ci_outbox_manager_test //macos:ci_contacts_manager_test //macos:ci_email_sending_test //macos:ci_account_manager_test //macos:ci_key_buffer_test //macos:ci_sequence_matcher_test --test_output=errors
+        run: bazel test //macos:ci_config_test //macos:ci_profile_test //macos:ci_banner_manager_test //macos:ci_model_test //macos:ci_sync_manager_test //macos:ci_search_manager_test //macos:ci_outbox_manager_test //macos:ci_contacts_manager_test //macos:ci_email_sending_test //macos:ci_account_manager_test //macos:ci_key_buffer_test //macos:ci_sequence_matcher_test //macos:ci_attachment_cache_manager_test --test_output=errors
 
   linux:
     name: Linux GUI (Qt)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,7 +7,7 @@ Email client: Go CLI backend + Swift macOS GUI.
 - **CLI:** `bazel build //cli/cmd/durian` → install: `cli/install.sh` (copies to /usr/local/bin)
 - **GUI:** `bazel build //macos:Durian` → dev run: `macos/run.sh` (debug build → `/Applications/DurianNightly.app`) → install: `macos/install.sh` (release build → `/Applications/Durian.app`)
 - **Tests:** `bazel test //cli/...` (CLI) / `bazel test //macos/...` (GUI, requires Xcode 26) / `bazel test //...` (all)
-- **CI Tests (GUI):** `bazel test //macos:ci_config_test //macos:ci_profile_test //macos:ci_banner_manager_test //macos:ci_model_test //macos:ci_sync_manager_test //macos:ci_search_manager_test //macos:ci_outbox_manager_test` (uses `durian_core` target, no Views, works on Xcode 16+)
+- **CI Tests (GUI):** `bazel test //macos:ci_config_test //macos:ci_profile_test //macos:ci_banner_manager_test //macos:ci_model_test //macos:ci_sync_manager_test //macos:ci_search_manager_test //macos:ci_outbox_manager_test //macos:ci_attachment_cache_manager_test` (uses `durian_core` target, no Views, works on Xcode 16+)
 - **Integration Tests:** `bazel test //integration:integration_test` (starts real server, validates API contract via curl+jq)
 - **Validate Config:** `durian validate` (checks config.pkl, rules.pkl, profiles.pkl, keymaps.pkl, groups.pkl)
 - **Logs (GUI/Swift):** `log stream --level debug --predicate 'subsystem == "org.js-lab.durian.nightly"'` (nightly) / `subsystem == "org.js-lab.durian"` (release)

--- a/macos/BUILD.bazel
+++ b/macos/BUILD.bazel
@@ -276,6 +276,21 @@ swift_test(
     deps = [":durian_core"],
 )
 
+swift_test(
+    name = "attachment_cache_manager_test",
+    size = "small",
+    srcs = ["tests/AttachmentCacheManagerTests.swift"],
+    deps = [":durian_testlib"],
+)
+
+swift_test(
+    name = "ci_attachment_cache_manager_test",
+    size = "small",
+    srcs = ["tests/AttachmentCacheManagerTests.swift"],
+    tags = ["ci"],
+    deps = [":durian_core"],
+)
+
 genrule(
     name = "StampedInfoPlist",
     srcs = ["Info.plist"],

--- a/macos/durian/Managers/AttachmentCacheManager.swift
+++ b/macos/durian/Managers/AttachmentCacheManager.swift
@@ -15,15 +15,24 @@ class AttachmentCacheManager: ObservableObject {
     private let fileManager = FileManager.default
     private let indexFile: URL
     private let cacheDir: URL
+    private let settingsProvider: () -> AttachmentCacheSettings
     private var index: [String: CachedAttachment] = [:]
     private var prefetchTasks: [String: Task<Void, Never>] = [:]
     private var failedKeys: Set<String> = []
 
-    private init() {
-        let caches = fileManager.urls(for: .cachesDirectory, in: .userDomainMask).first!
-        cacheDir = caches.appendingPathComponent("org.js-lab.durian/attachments", isDirectory: true)
-        indexFile = cacheDir.appendingPathComponent(".cache-index.json")
-        try? fileManager.createDirectory(at: cacheDir, withIntermediateDirectories: true)
+    init(cacheDir: URL? = nil,
+         settingsProvider: @escaping () -> AttachmentCacheSettings = { SettingsManager.shared.attachmentCacheSettings }) {
+        let resolvedDir: URL
+        if let cacheDir {
+            resolvedDir = cacheDir
+        } else {
+            let caches = FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask).first!
+            resolvedDir = caches.appendingPathComponent("org.js-lab.durian/attachments", isDirectory: true)
+        }
+        self.cacheDir = resolvedDir
+        self.indexFile = resolvedDir.appendingPathComponent(".cache-index.json")
+        self.settingsProvider = settingsProvider
+        try? fileManager.createDirectory(at: resolvedDir, withIntermediateDirectories: true)
         loadIndex()
         evict()
     }
@@ -35,9 +44,9 @@ class AttachmentCacheManager: ObservableObject {
         let key = cacheKey(messageId: messageId, partId: partId)
         guard var entry = index[key] else { return nil }
 
-        // Check TTL
-        let settings = SettingsManager.shared.attachmentCacheSettings
-        if Date().timeIntervalSince(entry.cachedAt) > settings.ttl {
+        // TTL check — pinned entries are exempt (consistent with evict()).
+        let settings = settingsProvider()
+        if !entry.pinned && Date().timeIntervalSince(entry.cachedAt) > settings.ttl {
             remove(key: key)
             return nil
         }
@@ -48,13 +57,15 @@ class AttachmentCacheManager: ObservableObject {
             return nil
         }
 
-        // Update access metadata
+        guard let data = try? Data(contentsOf: entry.localPath) else { return nil }
+
+        // Update access metadata in-memory only; the next put/evict/clear
+        // will persist it. Avoids a JSON-encode + disk-write per cache hit.
         entry.lastAccessDate = Date()
         entry.accessCount += 1
         index[key] = entry
-        saveIndex()
 
-        return try? Data(contentsOf: entry.localPath)
+        return data
     }
 
     /// Store attachment data in cache.
@@ -90,8 +101,8 @@ class AttachmentCacheManager: ObservableObject {
         let key = cacheKey(messageId: messageId, partId: partId)
         if failedKeys.contains(key) { return false }
         guard let entry = index[key] else { return false }
-        let settings = SettingsManager.shared.attachmentCacheSettings
-        if Date().timeIntervalSince(entry.cachedAt) > settings.ttl {
+        let settings = settingsProvider()
+        if !entry.pinned && Date().timeIntervalSince(entry.cachedAt) > settings.ttl {
             return false
         }
         return fileManager.fileExists(atPath: entry.localPath.path)
@@ -158,17 +169,22 @@ class AttachmentCacheManager: ObservableObject {
     // MARK: - Eviction
 
     private func evict() {
-        let settings = SettingsManager.shared.attachmentCacheSettings
+        let settings = settingsProvider()
         let now = Date()
 
-        // Phase 1: Remove expired entries
-        for (key, entry) in index where !entry.pinned {
-            if now.timeIntervalSince(entry.cachedAt) > settings.ttl {
-                remove(key: key)
-            }
+        // Phase 1: Remove expired entries. Snapshot the keys first — mutating
+        // `index` during iteration is undefined behavior in Swift.
+        let expiredKeys: [String] = index.compactMap { key, entry in
+            guard !entry.pinned else { return nil }
+            return now.timeIntervalSince(entry.cachedAt) > settings.ttl ? key : nil
+        }
+        for key in expiredKeys {
+            remove(key: key)
         }
 
-        // Phase 2: LRU eviction if still over size limit
+        // Phase 2: LRU eviction if still over size limit. Pinned entries are
+        // immune — the loop bails when no unpinned candidates remain, even if
+        // pinned alone exceeds the cap.
         while totalSize > settings.maxSizeBytes {
             guard let oldest = index
                 .filter({ !$0.value.pinned })

--- a/macos/tests/AttachmentCacheManagerTests.swift
+++ b/macos/tests/AttachmentCacheManagerTests.swift
@@ -1,0 +1,191 @@
+import XCTest
+@testable import durian_lib
+
+@MainActor
+final class AttachmentCacheManagerTests: XCTestCase {
+
+    // MARK: - Helpers
+
+    private var tempDir: URL!
+
+    override func setUp() async throws {
+        tempDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("durian-cache-tests-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+    }
+
+    override func tearDown() async throws {
+        try? FileManager.default.removeItem(at: tempDir)
+        tempDir = nil
+    }
+
+    private func makeManager(maxSizeMB: Int = 100, ttlDays: Int = 7) -> AttachmentCacheManager {
+        var settings = AttachmentCacheSettings()
+        settings.maxSizeMB = maxSizeMB
+        settings.ttlDays = ttlDays
+        return AttachmentCacheManager(cacheDir: tempDir, settingsProvider: { settings })
+    }
+
+    private func bytes(_ count: Int) -> Data {
+        Data(repeating: 0xAB, count: count)
+    }
+
+    // MARK: - Basic put/get
+
+    func testPutThenGetReturnsData() {
+        let mgr = makeManager()
+        let payload = bytes(1024)
+
+        mgr.put(messageId: "msg-1", partId: 2, filename: "a.pdf", data: payload)
+        let fetched = mgr.get(messageId: "msg-1", partId: 2)
+
+        XCTAssertEqual(fetched, payload)
+    }
+
+    func testGetReturnsNilForUnknownKey() {
+        let mgr = makeManager()
+        XCTAssertNil(mgr.get(messageId: "nope", partId: 0))
+    }
+
+    // MARK: - TTL Eviction
+
+    func testTTLEvictionRemovesExpiredEntries() throws {
+        let mgr = makeManager(ttlDays: 7)
+        mgr.put(messageId: "msg-old", partId: 1, filename: "old.pdf", data: bytes(1024))
+
+        // Backdate the index entry so it's older than TTL.
+        let indexFile = tempDir.appendingPathComponent(".cache-index.json")
+        var raw = try JSONDecoder().decode([String: CachedAttachment].self, from: Data(contentsOf: indexFile))
+        for (key, var entry) in raw {
+            entry = CachedAttachment(
+                id: entry.id, filename: entry.filename, localPath: entry.localPath,
+                sizeBytes: entry.sizeBytes,
+                cachedAt: Date().addingTimeInterval(-8 * 86_400),
+                lastAccessDate: entry.lastAccessDate, accessCount: entry.accessCount,
+                emailUID: entry.emailUID, pinned: entry.pinned)
+            raw[key] = entry
+        }
+        try JSONEncoder().encode(raw).write(to: indexFile)
+
+        // Re-instantiate to trigger evict() in init.
+        let fresh = makeManager(ttlDays: 7)
+        XCTAssertNil(fresh.get(messageId: "msg-old", partId: 1))
+        XCTAssertEqual(fresh.totalSize, 0)
+    }
+
+    func testTTLEvictionHandlesManyExpiredEntries() throws {
+        // Phase 1 of evict() iterates the index while removing entries from
+        // it. With 50 expired keys, any mutation-during-iteration regression
+        // would surface as a crash or partial cleanup.
+        let mgr = makeManager(ttlDays: 7)
+        for i in 0..<50 {
+            mgr.put(messageId: "m\(i)", partId: 0, filename: "f\(i).bin", data: bytes(64))
+        }
+
+        // Backdate every entry past TTL.
+        let indexFile = tempDir.appendingPathComponent(".cache-index.json")
+        var raw = try JSONDecoder().decode([String: CachedAttachment].self, from: Data(contentsOf: indexFile))
+        for (key, entry) in raw {
+            raw[key] = CachedAttachment(
+                id: entry.id, filename: entry.filename, localPath: entry.localPath,
+                sizeBytes: entry.sizeBytes,
+                cachedAt: Date().addingTimeInterval(-30 * 86_400),
+                lastAccessDate: entry.lastAccessDate, accessCount: entry.accessCount,
+                emailUID: entry.emailUID, pinned: false)
+        }
+        try JSONEncoder().encode(raw).write(to: indexFile)
+
+        // Fresh manager → evict() in init wipes everything.
+        let fresh = makeManager(ttlDays: 7)
+        XCTAssertEqual(fresh.totalSize, 0, "all 50 expired entries must be evicted in one Phase 1 sweep")
+        for i in 0..<50 {
+            XCTAssertNil(fresh.get(messageId: "m\(i)", partId: 0))
+        }
+    }
+
+    // MARK: - Size-based LRU Eviction
+
+    func testSizeEvictionRemovesLRUEntries() {
+        // 1 MB cap; three 400 KB entries → third put forces eviction of LRU.
+        let mgr = makeManager(maxSizeMB: 1)
+        let kb400 = bytes(400 * 1024)
+
+        mgr.put(messageId: "a", partId: 0, filename: "a.bin", data: kb400)
+        mgr.put(messageId: "b", partId: 0, filename: "b.bin", data: kb400)
+
+        // Touch "a" so "b" becomes the LRU.
+        _ = mgr.get(messageId: "a", partId: 0)
+
+        mgr.put(messageId: "c", partId: 0, filename: "c.bin", data: kb400)
+
+        XCTAssertNotNil(mgr.get(messageId: "a", partId: 0), "recently accessed must survive")
+        XCTAssertNil(mgr.get(messageId: "b", partId: 0), "LRU must be evicted")
+        XCTAssertNotNil(mgr.get(messageId: "c", partId: 0), "newest must survive")
+    }
+
+    // MARK: - Pinned-Entry Survival
+
+    func testPinnedEntriesSurviveTTLAndSizePressure() throws {
+        // Cap = 1 MB. Insert one 400 KB pinned entry that is OLDER than TTL.
+        // Pinned must survive TTL (Phase 1) AND LRU pressure (Phase 2).
+        let mgr = makeManager(maxSizeMB: 1, ttlDays: 7)
+        let kb400 = bytes(400 * 1024)
+        mgr.put(messageId: "pinned", partId: 0, filename: "p.bin", data: kb400)
+
+        // Pin + backdate the entry on disk.
+        let indexFile = tempDir.appendingPathComponent(".cache-index.json")
+        var raw = try JSONDecoder().decode([String: CachedAttachment].self, from: Data(contentsOf: indexFile))
+        let key = "pinned:0"
+        guard let original = raw[key] else { return XCTFail("missing entry") }
+        raw[key] = CachedAttachment(
+            id: original.id, filename: original.filename, localPath: original.localPath,
+            sizeBytes: original.sizeBytes,
+            cachedAt: Date().addingTimeInterval(-30 * 86_400),
+            lastAccessDate: Date().addingTimeInterval(-30 * 86_400),
+            accessCount: original.accessCount, emailUID: original.emailUID,
+            pinned: true)
+        try JSONEncoder().encode(raw).write(to: indexFile)
+
+        // Fresh manager: triggers evict() in init with the manipulated index,
+        // exercising Phase 1 (TTL) on the pinned-and-expired entry.
+        let fresh = makeManager(maxSizeMB: 1, ttlDays: 7)
+        XCTAssertNotNil(fresh.get(messageId: "pinned", partId: 0),
+                        "pinned must survive TTL eviction (Phase 1) even when older than TTL")
+
+        // Pile on three 400 KB unpinned entries → 1.2 MB unpinned + 0.4 MB
+        // pinned = 1.6 MB total, well over the 1 MB cap. Each put() triggers
+        // evict()'s Phase 2 (LRU) which must skip the pinned entry.
+        fresh.put(messageId: "a", partId: 0, filename: "a.bin", data: kb400)
+        fresh.put(messageId: "b", partId: 0, filename: "b.bin", data: kb400)
+        fresh.put(messageId: "c", partId: 0, filename: "c.bin", data: kb400)
+
+        XCTAssertNotNil(fresh.get(messageId: "pinned", partId: 0),
+                        "pinned must survive LRU eviction (Phase 2) under sustained size pressure")
+        // After eviction, totalSize must be ≤ cap + 1 unpinned (LRU stops once
+        // under cap). Pinned alone is 400 KB, so totalSize will sit between
+        // 400 KB and ~1.4 MB depending on which unpinned survived last.
+        XCTAssertLessThanOrEqual(fresh.totalSize, Int64(1_048_576 + 400 * 1024),
+                                 "Phase 2 should evict unpinned until under cap, leaving at most one extra")
+        XCTAssertGreaterThanOrEqual(fresh.totalSize, Int64(400 * 1024),
+                                    "pinned 400 KB always remains")
+    }
+
+    // MARK: - Orphan Files
+
+    func testOrphanFileOnDiskWithoutIndexEntry() throws {
+        // A stray file in the cache dir without index entry is currently NOT
+        // cleaned up. This test pins the current behaviour so we notice when
+        // we add reconciliation later.
+        let mgr = makeManager()
+        let stray = tempDir.appendingPathComponent("orphan.bin")
+        try bytes(2048).write(to: stray)
+
+        // Adding/removing a normal entry triggers evict(), but the orphan
+        // is invisible to the index.
+        mgr.put(messageId: "x", partId: 0, filename: "x.bin", data: bytes(128))
+        mgr.clearAll()
+
+        XCTAssertTrue(FileManager.default.fileExists(atPath: stray.path),
+                      "orphan currently survives — update test when reconcile is added")
+    }
+}


### PR DESCRIPTION
## Summary

Verifies attachment-cache eviction (#203) with a test suite that pins TTL, LRU and pinned-survival semantics. Writing the tests surfaced three real bugs in `AttachmentCacheManager`:

- **Pinned TTL inconsistency:** `get()` and `isCached()` enforced TTL without the pinned exception that `evict()` honors. A pinned-and-expired entry would survive eviction sweeps and then die on the very next read. Now consistent across all three paths.
- **Mutation during iteration:** `evict()` Phase 1 mutated the index dictionary mid-iteration. Snapshot the keys first.
- **`saveIndex()` per cache hit:** `get()` triggered a JSON-encode + disk-write on every read just to update access metadata. Now in-memory only; flushed on the next put / evict / clear.

Also makes the manager testable via optional `cacheDir` and `settingsProvider` parameters, and registers `ci_attachment_cache_manager_test` in CI.

## Test plan
- [x] All 7 new test cases pass (`bazel test //macos:attachment_cache_manager_test`)
- [x] Existing manager tests still green (config, profile, banner, model, sync, search, outbox)
- [x] CI variant builds against `durian_core` (Xcode 16+ compatible)
- [x] GitHub Actions GUI job passes

Closes #203