### PR TITLE
feat(swift-email): infinite scroll via larger limit + cursor prefetch

### DIFF
--- a/macos/durian/ContentView.swift
+++ b/macos/durian/ContentView.swift
@@ -447,6 +447,11 @@ struct ContentView: View {
                 handleEmailSelection(emailId)
             }
         }
+        .onChange(of: cursorEmailId) { _, newId in
+            if let id = newId {
+                accountManager.prefetchAroundCursor(cursorId: id)
+            }
+        }
         .onChange(of: showSearchPopup) { _, isShowing in
             keymapHandler.engine.setContext(isShowing ? .search : .list)
         }

--- a/macos/durian/Managers/AccountManager.swift
+++ b/macos/durian/Managers/AccountManager.swift
@@ -155,6 +155,10 @@ class AccountManager: ObservableObject {
         syncFromBackend()
         return standalone
     }
+
+    func prefetchAroundCursor(cursorId: String) {
+        emailBackend?.prefetchAroundCursor(cursorId: cursorId)
+    }
     
     func markAsRead(id: String) async {
         guard let backend = emailBackend else { return }

--- a/macos/durian/Network/EmailBackend.swift
+++ b/macos/durian/Network/EmailBackend.swift
@@ -136,6 +136,7 @@ class EmailBackend: ObservableObject, SearchBackend, OutboxBackend {
     // Cancellation support for prefetch and active search
     private var prefetchTask: Task<Void, Never>?
     private var searchTask: Task<Void, Never>?
+    private var cursorPrefetchTask: Task<Void, Never>?
     private var shouldCancelPrefetch = false
 
     // Generation counter to discard stale search results on rapid folder/profile switches
@@ -882,6 +883,88 @@ class EmailBackend: ObservableObject, SearchBackend, OutboxBackend {
         prefetchTask = Task {
             await prefetchInitialBodiesInternal(count: count)
         }
+    }
+
+    /// Triggered when the cursor moves to a new email. Debounces 200ms (so j/k
+    /// spam doesn't fire 100 requests), then prefetches bodies in a window
+    /// around the cursor with a concurrency cap of 3.
+    func prefetchAroundCursor(cursorId: String, before: Int = 5, after: Int = 15) {
+        cursorPrefetchTask?.cancel()
+        cursorPrefetchTask = Task { [weak self] in
+            try? await Task.sleep(for: .milliseconds(200))
+            guard !Task.isCancelled, let self else { return }
+
+            guard let cursorIndex = self.emails.firstIndex(where: { $0.id == cursorId }) else {
+                return
+            }
+
+            let toFetch = self.selectEmailsAroundCursor(
+                cursorIndex: cursorIndex,
+                before: before,
+                after: after
+            )
+            guard !toFetch.isEmpty else { return }
+
+            Log.debug("BACKEND", "Cursor prefetch: \(toFetch.count) bodies around index \(cursorIndex)")
+
+            // Concurrency cap of 3 — both for server load and for limiting
+            // @Published mutation storms that cause SwiftUI re-renders.
+            await withTaskGroup(of: Void.self) { group in
+                var inFlight = 0
+                let cap = 3
+                for id in toFetch {
+                    if Task.isCancelled { break }
+                    if inFlight >= cap {
+                        await group.next()
+                        inFlight -= 1
+                    }
+                    group.addTask { [weak self] in
+                        _ = await self?.fetchEmailBodyInternal(id: id, isPrefetch: true)
+                    }
+                    inFlight += 1
+                }
+            }
+        }
+    }
+
+    /// Returns the email IDs to prefetch around the cursor, in fetch-priority
+    /// order (first one fetched first). Skip emails whose body is already
+    /// loaded/loading. Window is `before` rows above and `after` rows below
+    /// the cursor.
+    private func selectEmailsAroundCursor(cursorIndex: Int, before: Int, after: Int) -> [String] {
+        guard !emails.isEmpty, cursorIndex >= 0, cursorIndex < emails.count else { return [] }
+
+        let needsFetch: (Int) -> Bool = { idx in
+            switch self.emails[idx].bodyState {
+            case .notLoaded, .failed: return true
+            case .loading, .loaded:   return false
+            }
+        }
+
+        var result: [String] = []
+
+        // Cursor itself first — most likely what the user wants to see right now.
+        if needsFetch(cursorIndex) {
+            result.append(emails[cursorIndex].id)
+        }
+
+        // Forward window (j-direction, most common scroll path).
+        let forwardEnd = min(cursorIndex + after, emails.count - 1)
+        if forwardEnd > cursorIndex {
+            for i in (cursorIndex + 1)...forwardEnd where needsFetch(i) {
+                result.append(emails[i].id)
+            }
+        }
+
+        // Backward window (k-direction).
+        let backwardStart = max(cursorIndex - before, 0)
+        if backwardStart < cursorIndex {
+            for i in stride(from: cursorIndex - 1, through: backwardStart, by: -1) where needsFetch(i) {
+                result.append(emails[i].id)
+            }
+        }
+
+        return result
     }
 }
 

--- a/macos/durian/Network/EmailBackend.swift
+++ b/macos/durian/Network/EmailBackend.swift
@@ -418,7 +418,7 @@ class EmailBackend: ObservableObject, SearchBackend, OutboxBackend {
     
     /// Shared search pipeline: build URL, request, parse results, apply enrichment.
     /// Returns nil on request failure, empty array on no results.
-    private func performSearch(query: String, limit: Int, enrich: Int = 30) async -> [MailMessage]? {
+    private func performSearch(query: String, limit: Int, enrich: Int = 50) async -> [MailMessage]? {
         var components = URLComponents()
         components.path = "/search"
         components.queryItems = [
@@ -455,7 +455,7 @@ class EmailBackend: ObservableObject, SearchBackend, OutboxBackend {
         return emails
     }
 
-    private func search(_ query: String, limit: Int = 200) async {
+    private func search(_ query: String, limit: Int = 2000) async {
         searchGeneration += 1
         let myGeneration = searchGeneration
 

--- a/macos/durian/Views/EmailRowView.swift
+++ b/macos/durian/Views/EmailRowView.swift
@@ -20,6 +20,8 @@ struct EmailRowView: View, Equatable {
         lhs.email.tags == rhs.email.tags &&
         lhs.email.isRead == rhs.email.isRead &&
         lhs.email.isPinned == rhs.email.isPinned &&
+        lhs.email.previewText == rhs.email.previewText &&
+        lhs.email.bodyState == rhs.email.bodyState &&
         lhs.isSelected == rhs.isSelected &&
         lhs.isFirstInGroup == rhs.isFirstInGroup &&
         lhs.isLastInGroup == rhs.isLastInGroup &&


### PR DESCRIPTION
## Summary
Closes #146.

Two-step fix for the 200-result hard cap:

1. **Raise limits** (commit 1): `limit` 200 → 2000, `enrich` 30 → 50.
   Real-world benchmarks (curl + SQLite, archive 3.8k / newsletter 4.5k / trash 6.2k threads) show <30ms overhead vs the previous defaults; cached on second access.
2. **Cursor-relative body prefetch** (commit 2): when the cursor moves (j/k or click), prefetch bodies in a -5..+15 window around it with 200ms debounce and a concurrency cap of 3. Forward-biased to match typical scroll direction. Removes the "no preview after #50" pain.

Also fixes a latent EquatableView bug: `EmailRowView`'s `==` didn't include `previewText` or `bodyState`, so prefetch-only updates were silently skipped until `isSelected` flipped.

## Why no offset-based pagination?
Issue #146 proposed offset pagination + loadMore + lazy prefetch. Benchmarks showed metadata fetching is essentially free (limit=2000 ≈ limit=200 in SQL cost — the GROUP BY scans the same set), and the offset approach has real downsides for Durian: race conditions with background sync (duplicate rows), no real performance win on local SQLite. The simpler "raise the cap + smarter prefetch" path solves the actual user pain (invisible/preview-less mails) with ~50 lines of code instead of a new pagination contract.

## Test plan
- [x] Folder switching (gi/gs/ga) stays snappy on inbox/archive/newsletter/trash
- [x] Mails beyond #50 show preview text after cursor lands nearby
- [x] No regression on first folder load (no extra loading state)
- [ ] CI green