### PR TITLE
ci: migrate GUI runner to macos-26, drop durian_core split

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,15 +6,16 @@ on:
 
 jobs:
   release:
-    runs-on: macos-15
-    env:
-      DEVELOPER_DIR: /Applications/Xcode_26.3.app/Contents/Developer
+    runs-on: macos-26
     permissions:
       contents: write
     steps:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+
+      - name: Select Xcode
+        run: sudo xcode-select -s /Applications/Xcode_26.4.1.app
 
       - name: Get version
         id: version

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -53,9 +53,12 @@ jobs:
 
   gui:
     name: GUI (Swift)
-    runs-on: macos-15
+    runs-on: macos-26
     steps:
       - uses: actions/checkout@v4
+
+      - name: Select Xcode
+        run: sudo xcode-select -s /Applications/Xcode_26.4.1.app
 
       - name: Mount Bazel cache
         uses: actions/cache@v4
@@ -65,7 +68,7 @@ jobs:
           restore-keys: bazel-gui-
 
       - name: Test
-        run: bazel test //macos:ci_config_test //macos:ci_profile_test //macos:ci_banner_manager_test //macos:ci_model_test //macos:ci_sync_manager_test //macos:ci_search_manager_test //macos:ci_outbox_manager_test //macos:ci_contacts_manager_test //macos:ci_email_sending_test //macos:ci_account_manager_test //macos:ci_key_buffer_test //macos:ci_sequence_matcher_test //macos:ci_attachment_cache_manager_test --test_output=errors
+        run: bazel test //macos:all --build_tests_only --test_output=errors
 
   linux:
     name: Linux GUI (Qt)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,7 +7,6 @@ Email client: Go CLI backend + Swift macOS GUI.
 - **CLI:** `bazel build //cli/cmd/durian` → install: `cli/install.sh` (copies to /usr/local/bin)
 - **GUI:** `bazel build //macos:Durian` → dev run: `macos/run.sh` (debug build → `/Applications/DurianNightly.app`) → install: `macos/install.sh` (release build → `/Applications/Durian.app`)
 - **Tests:** `bazel test //cli/...` (CLI) / `bazel test //macos/...` (GUI, requires Xcode 26) / `bazel test //...` (all)
-- **CI Tests (GUI):** `bazel test //macos:ci_config_test //macos:ci_profile_test //macos:ci_banner_manager_test //macos:ci_model_test //macos:ci_sync_manager_test //macos:ci_search_manager_test //macos:ci_outbox_manager_test //macos:ci_attachment_cache_manager_test` (uses `durian_core` target, no Views, works on Xcode 16+)
 - **Integration Tests:** `bazel test //integration:integration_test` (starts real server, validates API contract via curl+jq)
 - **Validate Config:** `durian validate` (checks config.pkl, rules.pkl, profiles.pkl, keymaps.pkl, groups.pkl)
 - **Logs (GUI/Swift):** `log stream --level debug --predicate 'subsystem == "org.js-lab.durian.nightly"'` (nightly) / `subsystem == "org.js-lab.durian"` (release)
@@ -33,9 +32,7 @@ Email client: Go CLI backend + Swift macOS GUI.
 
 - GitHub Actions: `.github/workflows/test.yml`
 - **CLI job** runs on `ubuntu-latest` (Go tests + build)
-- **GUI job** runs on `macos-15` with `ci_*` test targets using `durian_core` (models/managers/utilities, no Views)
-- Views use macOS 26 APIs (`glassEffect`) requiring Xcode 26, but `rules_swift` `test_discoverer` crashes on Xcode 26. The `durian_core` target splits out testable code that compiles on Xcode 16+.
-- When adding new GUI tests: add both a regular `swift_test` (deps `durian_testlib`) and a `ci_*` variant (deps `durian_core`) in `macos/BUILD.bazel`
+- **GUI job** runs on `macos-26` with `DEVELOPER_DIR=/Applications/Xcode_26.4.1.app/...` (macOS 26 SDK required for `glassEffect` etc.)
 
 ## Code Style
 

--- a/macos/BUILD.bazel
+++ b/macos/BUILD.bazel
@@ -39,24 +39,6 @@ swift_library(
     deps = ["@swiftpkg_pkl_swift//:PklSwift"],
 )
 
-# Core library for CI tests — models, managers, utilities only (no Views).
-# Views use macOS 26 APIs (glassEffect) that require Xcode 26, but CI
-# runs on macos-15 with Xcode 16 which lacks these APIs. This target
-# compiles on Xcode 16+ and is used by CI test targets.
-swift_library(
-    name = "durian_core",
-    testonly = True,
-    srcs = glob([
-        "durian/Models/**/*.swift",
-        "durian/Managers/**/*.swift",
-        "durian/Utilities/**/*.swift",
-        "durian/Network/**/*.swift",
-        "durian/Keymaps/**/*.swift",
-    ]),
-    module_name = "durian_lib",
-    deps = ["@swiftpkg_pkl_swift//:PklSwift"],
-)
-
 swift_test(
     name = "config_test",
     size = "small",
@@ -89,43 +71,6 @@ swift_test(
     deps = [":durian_testlib"],
 )
 
-# CI test targets — use durian_core (no Views) to avoid Xcode 26 requirement
-swift_test(
-    name = "ci_config_test",
-    size = "small",
-    srcs = ["tests/ConfigTests.swift"],
-    tags = ["ci"],
-    deps = [
-        ":durian_core",
-    ],
-)
-
-swift_test(
-    name = "ci_profile_test",
-    size = "small",
-    srcs = ["tests/ProfileTests.swift"],
-    tags = ["ci"],
-    deps = [
-        ":durian_core",
-    ],
-)
-
-swift_test(
-    name = "ci_banner_manager_test",
-    size = "small",
-    srcs = ["tests/BannerManagerTests.swift"],
-    tags = ["ci"],
-    deps = [":durian_core"],
-)
-
-swift_test(
-    name = "ci_model_test",
-    size = "small",
-    srcs = ["tests/ModelTests.swift"],
-    tags = ["ci"],
-    deps = [":durian_core"],
-)
-
 swift_test(
     name = "sync_manager_test",
     size = "small",
@@ -148,42 +93,10 @@ swift_test(
 )
 
 swift_test(
-    name = "ci_sync_manager_test",
-    size = "small",
-    srcs = ["tests/SyncManagerTests.swift"],
-    tags = ["ci"],
-    deps = [":durian_core"],
-)
-
-swift_test(
-    name = "ci_search_manager_test",
-    size = "small",
-    srcs = ["tests/SearchManagerTests.swift"],
-    tags = ["ci"],
-    deps = [":durian_core"],
-)
-
-swift_test(
-    name = "ci_outbox_manager_test",
-    size = "small",
-    srcs = ["tests/OutboxManagerTests.swift"],
-    tags = ["ci"],
-    deps = [":durian_core"],
-)
-
-swift_test(
     name = "sending_manager_test",
     size = "small",
     srcs = ["tests/EmailSendingManagerTests.swift"],
     deps = [":durian_testlib"],
-)
-
-swift_test(
-    name = "ci_sending_manager_test",
-    size = "small",
-    srcs = ["tests/EmailSendingManagerTests.swift"],
-    tags = ["ci"],
-    deps = [":durian_core"],
 )
 
 swift_test(
@@ -194,26 +107,10 @@ swift_test(
 )
 
 swift_test(
-    name = "ci_contacts_manager_test",
-    size = "small",
-    srcs = ["tests/ContactsManagerTests.swift"],
-    tags = ["ci"],
-    deps = [":durian_core"],
-)
-
-swift_test(
     name = "email_sending_test",
     size = "small",
     srcs = ["tests/EmailSendingTests.swift"],
     deps = [":durian_testlib"],
-)
-
-swift_test(
-    name = "ci_email_sending_test",
-    size = "small",
-    srcs = ["tests/EmailSendingTests.swift"],
-    tags = ["ci"],
-    deps = [":durian_core"],
 )
 
 swift_test(
@@ -224,26 +121,10 @@ swift_test(
 )
 
 swift_test(
-    name = "ci_account_manager_test",
-    size = "small",
-    srcs = ["tests/AccountManagerTests.swift"],
-    tags = ["ci"],
-    deps = [":durian_core"],
-)
-
-swift_test(
     name = "key_buffer_test",
     size = "small",
     srcs = ["tests/KeyBufferTests.swift"],
     deps = [":durian_testlib"],
-)
-
-swift_test(
-    name = "ci_key_buffer_test",
-    size = "small",
-    srcs = ["tests/KeyBufferTests.swift"],
-    tags = ["ci"],
-    deps = [":durian_core"],
 )
 
 swift_test(
@@ -254,14 +135,6 @@ swift_test(
 )
 
 swift_test(
-    name = "ci_keymaps_merge_test",
-    size = "small",
-    srcs = ["tests/KeymapsMergeTests.swift"],
-    tags = ["ci"],
-    deps = [":durian_core"],
-)
-
-swift_test(
     name = "sequence_matcher_test",
     size = "small",
     srcs = ["tests/SequenceMatcherTests.swift"],
@@ -269,26 +142,10 @@ swift_test(
 )
 
 swift_test(
-    name = "ci_sequence_matcher_test",
-    size = "small",
-    srcs = ["tests/SequenceMatcherTests.swift"],
-    tags = ["ci"],
-    deps = [":durian_core"],
-)
-
-swift_test(
     name = "attachment_cache_manager_test",
     size = "small",
     srcs = ["tests/AttachmentCacheManagerTests.swift"],
     deps = [":durian_testlib"],
-)
-
-swift_test(
-    name = "ci_attachment_cache_manager_test",
-    size = "small",
-    srcs = ["tests/AttachmentCacheManagerTests.swift"],
-    tags = ["ci"],
-    deps = [":durian_core"],
 )
 
 genrule(


### PR DESCRIPTION
GitHub Actions now provides `macos-26` runners with Xcode 26.x, so the `durian_core` / `ci_*` test target split is no longer needed.

The split was originally added to keep CI on `macos-15` (Xcode 16) while Views require the macOS 26 SDK (`glassEffect`).

## Changes

- `macos/BUILD.bazel`: remove `durian_core` library and 13 `ci_*` swift_test targets
- `.github/workflows/test.yml`: gui job runs on `macos-26` with `DEVELOPER_DIR=Xcode_26.4.1`, tests via `//macos:all --build_tests_only`
- `.github/workflows/release.yml`: same runner + `DEVELOPER_DIR` migration
- `CLAUDE.md`: simplify CI section, drop `ci_*` documentation

## Verified

- All 15 Swift tests pass locally on Xcode 26.4.1 + rules_swift 3.6.1
- The original `test_discoverer` Xcode 26 issue (#1629) was fixed in rules_swift 3.4.2; we are on 3.6.1