### PR TITLE
feat(go-cli): add account completion via Cobra ValidArgsFunction

### DIFF
--- a/cli/cmd/durian/BUILD.bazel
+++ b/cli/cmd/durian/BUILD.bazel
@@ -5,6 +5,7 @@ go_library(
     srcs = [
         "attachment.go",
         "auth.go",
+        "completion.go",
         "contacts.go",
         "draft.go",
         "group.go",

--- a/cli/cmd/durian/auth.go
+++ b/cli/cmd/durian/auth.go
@@ -35,6 +35,7 @@ var authLoginCmd = &cobra.Command{
   durian auth login work         # Use alias
   durian auth login you@company.com  # Use full email`,
 	Args: cobra.ExactArgs(1),
+	ValidArgsFunction: completeAccounts,
 	RunE: runAuthLogin,
 }
 
@@ -50,6 +51,7 @@ var authLogoutCmd = &cobra.Command{
 	Short: "Remove credentials for an account",
 	Long: "Remove stored OAuth tokens or passwords from the keychain.",
 	Args: cobra.ExactArgs(1),
+	ValidArgsFunction: completeAccounts,
 	RunE: runAuthLogout,
 }
 
@@ -58,6 +60,7 @@ var authRefreshCmd = &cobra.Command{
 	Short: "Manually refresh OAuth token for an account",
 	Long: "Force a token refresh (normally done automatically).",
 	Args: cobra.ExactArgs(1),
+	ValidArgsFunction: completeAccounts,
 	RunE: runAuthRefresh,
 }
 

--- a/cli/cmd/durian/completion.go
+++ b/cli/cmd/durian/completion.go
@@ -1,0 +1,20 @@
+package main
+
+import (
+	"github.com/spf13/cobra"
+)
+
+// completeAccounts returns Cobra-style completions of every configured account
+// identifier (alias, name, or email — same set used by GetAccountByIdentifier).
+//
+// Usage:
+//
+//	cmd.ValidArgsFunction = completeAccounts
+//	cmd.RegisterFlagCompletionFunc("account", completeAccounts)
+func completeAccounts(_ *cobra.Command, _ []string, _ string) ([]string, cobra.ShellCompDirective) {
+	cfg := GetConfig()
+	if cfg == nil {
+		return nil, cobra.ShellCompDirectiveNoFileComp
+	}
+	return cfg.ListAccountIdentifiers(), cobra.ShellCompDirectiveNoFileComp
+}

--- a/cli/cmd/durian/draft.go
+++ b/cli/cmd/durian/draft.go
@@ -70,10 +70,13 @@ func init() {
 	draftSaveCmd.Flags().StringVar(&draftInReplyTo, "in-reply-to", "", "Message-ID of the message being replied to")
 	draftSaveCmd.Flags().StringVar(&draftReferences, "references", "", "space-separated Message-IDs of the thread")
 	draftSaveCmd.MarkFlagRequired("account")
+	_ = draftSaveCmd.RegisterFlagCompletionFunc("account", completeAccounts)
+	_ = draftSaveCmd.RegisterFlagCompletionFunc("from", completeAccounts)
 
 	// Delete command flags
 	draftDeleteCmd.Flags().StringVar(&draftAccount, "account", "", "account email (required)")
 	draftDeleteCmd.MarkFlagRequired("account")
+	_ = draftDeleteCmd.RegisterFlagCompletionFunc("account", completeAccounts)
 
 	draftCmd.AddCommand(draftSaveCmd)
 	draftCmd.AddCommand(draftDeleteCmd)

--- a/cli/cmd/durian/send.go
+++ b/cli/cmd/durian/send.go
@@ -60,6 +60,7 @@ func init() {
 	sendCmd.Flags().BoolVar(&sendForce, "force", false, "send even if attachments exceed size limit")
 	sendCmd.Flags().StringVar(&sendInReplyTo, "in-reply-to", "", "Message-ID of the message being replied to")
 	sendCmd.Flags().StringVar(&sendReferences, "references", "", "space-separated Message-IDs of the thread")
+	_ = sendCmd.RegisterFlagCompletionFunc("from", completeAccounts)
 
 	rootCmd.AddCommand(sendCmd)
 }

--- a/cli/cmd/durian/sync.go
+++ b/cli/cmd/durian/sync.go
@@ -33,6 +33,12 @@ var syncCmd = &cobra.Command{
   durian sync --upload-only
   durian sync --no-flags
   durian sync --dry-run`,
+	ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+		if len(args) == 0 {
+			return completeAccounts(cmd, args, toComplete)
+		}
+		return nil, cobra.ShellCompDirectiveNoFileComp
+	},
 	RunE: runSync,
 }
 

--- a/cli/cmd/durian/tag.go
+++ b/cli/cmd/durian/tag.go
@@ -37,6 +37,7 @@ var tagCmd = &cobra.Command{
 func init() {
 	tagCmd.Flags().SetInterspersed(false)
 	tagListCmd.Flags().StringVar(&tagAccountFilter, "account", "", "filter by account (comma-separated)")
+	_ = tagListCmd.RegisterFlagCompletionFunc("account", completeAccounts)
 	tagCmd.AddCommand(tagListCmd)
 	rootCmd.AddCommand(tagCmd)
 }


### PR DESCRIPTION
Hook a shared `completeAccounts` function into the commands that take an account identifier so shells (carapace, bash/zsh/fish completion) can auto-complete configured aliases, names, and emails from `config.pkl`.

## Wired up

- `durian auth login|logout|refresh <account>` (positional)
- `durian sync <account>` (first positional)
- `durian send --from`
- `durian tag list --account`
- `durian draft save --account|--from`
- `durian draft delete --account`

Cobra exposes this through its hidden `__complete` subcommand, which carapace-bridge picks up automatically; no separate completion script generation is required for users who already have carapace installed.

## Verified

- All 16 `cli/` + integration tests pass
- `durian __complete auth login ""` returns the expected list of account aliases