### PR TITLE
fix(go-mail): parse single-part non-text messages as attachments

### DIFF
--- a/cli/internal/mail/parser.go
+++ b/cli/internal/mail/parser.go
@@ -110,6 +110,49 @@ func (p *Parser) extractBody(msg *mail.Message) (string, string, []AttachmentInf
 		return p.extractMultipart(msg.Body, params["boundary"])
 	}
 
+	// Single-part non-text message (e.g. application/zip from Google DMARC reports,
+	// application/pdf, image/*, application/octet-stream with a filename). RFC 7489
+	// §A.1 explicitly allows DMARC aggregate reports as a single application/zip
+	// part with no multipart wrapper. Treat the whole body as one attachment
+	// instead of stuffing decoded binary bytes into BodyText.
+	contentDisp := msg.Header.Get("Content-Disposition")
+	dispMediaType, dispParams, _ := mime.ParseMediaType(contentDisp)
+	isAttachment := mediaType != "" && !strings.HasPrefix(mediaType, "text/") &&
+		(strings.HasPrefix(dispMediaType, "attachment") || strings.HasPrefix(dispMediaType, "inline") ||
+			params["name"] != "" || dispParams["filename"] != "")
+	if isAttachment {
+		body, _ := io.ReadAll(msg.Body)
+		name := encoding.DecodeHeader(dispParams["filename"])
+		if name == "" {
+			name = encoding.DecodeHeader(params["name"])
+		}
+		disposition := "attachment"
+		if strings.HasPrefix(dispMediaType, "inline") {
+			disposition = "inline"
+		}
+		if mediaType == "application/octet-stream" || name == "" {
+			if detected, ext := detectMagic(body, transferEncoding); detected != "" {
+				if mediaType == "application/octet-stream" {
+					mediaType = detected
+				}
+				if name == "" {
+					name = "attachment" + ext
+				}
+			}
+		}
+		if name == "" {
+			name = "unnamed"
+		}
+		attachments = append(attachments, AttachmentInfo{
+			Filename:    name,
+			ContentType: mediaType,
+			Size:        len(body),
+			Disposition: disposition,
+			ContentID:   msg.Header.Get("Content-Id"),
+		})
+		return "", "", attachments
+	}
+
 	body, _ := io.ReadAll(msg.Body)
 	return encoding.DecodeBody(body, transferEncoding, charset), "", attachments
 }

--- a/cli/internal/mail/parser_test.go
+++ b/cli/internal/mail/parser_test.go
@@ -366,6 +366,41 @@ func TestParserUnnamedAttachmentMagicDetection(t *testing.T) {
 	}
 }
 
+func TestParserSinglePartZipAttachment(t *testing.T) {
+	// Google sends DMARC aggregate reports as a single-part application/zip
+	// message (no multipart wrapper) per RFC 7489 §A.1. The parser must
+	// emit one AttachmentInfo and not stuff the decoded zip into BodyText.
+	msg := loadTestMail(t, "singlepart_zip_dmarc.eml")
+	parser := NewParser()
+
+	content := parser.Parse(msg)
+
+	if content.Body != "" {
+		t.Errorf("Body should be empty for binary single-part attachment, got %d bytes", len(content.Body))
+	}
+	if content.HTML != "" {
+		t.Errorf("HTML should be empty, got %d bytes", len(content.HTML))
+	}
+	if len(content.Attachments) != 1 {
+		t.Fatalf("Should have 1 attachment, got %d", len(content.Attachments))
+	}
+
+	att := content.Attachments[0]
+	wantName := "google.com!habric.com!1766001600!1766088000.zip"
+	if att.Filename != wantName {
+		t.Errorf("Filename = %q, want %q", att.Filename, wantName)
+	}
+	if att.ContentType != "application/zip" {
+		t.Errorf("ContentType = %q, want %q", att.ContentType, "application/zip")
+	}
+	if att.Disposition != "attachment" {
+		t.Errorf("Disposition = %q, want %q", att.Disposition, "attachment")
+	}
+	if att.Size == 0 {
+		t.Errorf("Size = 0, want non-zero")
+	}
+}
+
 func TestParserEmptyContentType(t *testing.T) {
 	msg := loadTestMail(t, "empty_content_type.eml")
 	parser := NewParser()

--- a/cli/internal/mail/testdata/singlepart_zip_dmarc.eml
+++ b/cli/internal/mail/testdata/singlepart_zip_dmarc.eml
@@ -1,0 +1,12 @@
+From: noreply-dmarc-support@google.com
+To: dmarc@habric.com
+Subject: Report Domain: habric.com Submitter: google.com Report-ID: 99
+Date: Sat, 03 May 2026 14:00:00 +0000
+MIME-Version: 1.0
+Content-Type: application/zip; name="google.com!habric.com!1766001600!1766088000.zip"
+Content-Transfer-Encoding: base64
+Content-Disposition: attachment; filename="google.com!habric.com!1766001600!1766088000.zip"
+
+UEsDBBQAAAAIAAAAIQA0aGVsbG8td29ybGQudHh0AAAAAAAAAAAAAAAAAAAA
+UEsBAhQAFAAAAAgAAAAhADRoZWxsby13b3JsZC50eHQAAAAAAAAAAAAAAAAA
+UEsFBgAAAAABAAEALwAAACQAAAAAAA==


### PR DESCRIPTION
Google sends DMARC aggregate reports as a single-part message with `Content-Type: application/zip` directly on the top level, no multipart wrapper. RFC 7489 §A.1 explicitly allows this. The previous parser fell through to the generic body path and stuffed the decoded binary into `BodyText` without registering any attachment, making the zip unreachable through any CLI/API code path (`No attachments found`).

`extractBody` now detects single-part non-text, non-multipart messages that look like attachments (filename in `Content-Type name=` or `Content-Disposition filename=`, or an explicit attachment/inline disposition) and emits one `AttachmentInfo` with the body, leaving `BodyText` empty. `application/octet-stream` still falls through to magic-byte detection for type + extension.

Verified end-to-end against a real Google DMARC report: the .zip extracts to valid DMARC XML.

Fixes part of #227.