### PR TITLE
fix(swift-email): show Edit Draft per message, not per thread

### DIFF
--- a/cli/cmd/durian/draft.go
+++ b/cli/cmd/durian/draft.go
@@ -213,15 +213,42 @@ func runDraftDelete(cmd *cobra.Command, args []string) error {
 		return outputDraftError(fmt.Sprintf("no IMAP host configured for %s", account.Email))
 	}
 
-	// Delete draft
+	// Delete draft from IMAP
 	service := draft.NewService(account)
 	if err := service.Delete(messageID); err != nil {
 		return outputDraftError(fmt.Sprintf("failed to delete draft: %v", err))
 	}
 
+	// Also drop the local DB row so the draft tag disappears immediately.
+	// `durian draft save` inserts the draft into the local store with tag:draft
+	// so the GUI can show it without waiting for IMAP sync. Without this delete,
+	// the row (and its tag) lives on after the IMAP draft is gone, and every
+	// sent reply ends up with thread tags = sent,draft,... forever.
+	deleteDraftFromLocalStore(account, messageID)
+
 	// Output success
 	resp := draftResponse{OK: true}
 	return outputJSON(resp)
+}
+
+// deleteDraftFromLocalStore removes the local draft row mirroring the IMAP
+// delete. Best-effort: errors are logged but do not affect the API result.
+func deleteDraftFromLocalStore(account *config.AccountConfig, messageID string) {
+	messageID = strings.Trim(messageID, "<>")
+	if messageID == "" {
+		return
+	}
+
+	db, err := store.Open(store.DefaultDBPath())
+	if err != nil {
+		slog.Debug("Could not open store for draft delete", "module", "DRAFT", "err", err)
+		return
+	}
+	defer db.Close()
+
+	if err := db.DeleteByMessageIDAndAccount(messageID, account.AccountIdentifier()); err != nil {
+		slog.Debug("Local draft row not deleted", "module", "DRAFT", "message_id", messageID, "err", err)
+	}
 }
 
 // saveDraftToLocalStore inserts the draft into SQLite so the Drafts folder

--- a/macos/durian/Models/Mail.swift
+++ b/macos/durian/Models/Mail.swift
@@ -38,6 +38,10 @@ struct ThreadMessage: Decodable, Identifiable, Equatable {
     let hidden_signature: String?
     let attachments: [AttachmentInfo]?
     let tags: [String]?
+
+    var isDraft: Bool {
+        tags?.contains("draft") ?? false
+    }
 }
 
 // MARK: - Email Body State

--- a/macos/durian/Views/ThreadMessageCardView.swift
+++ b/macos/durian/Views/ThreadMessageCardView.swift
@@ -601,7 +601,7 @@ struct ThreadMessageCardView: View {
         HStack {
             Spacer()
 
-            if email.isDraft, let onEditDraft = onEditDraft {
+            if message.isDraft, let onEditDraft = onEditDraft {
                 Button(action: onEditDraft) {
                     HStack(spacing: 6) {
                         Image(systemName: "pencil")


### PR DESCRIPTION
## Problem

`MailMessage.isDraft` reflects the *thread* aggregate tag set: it returns
true as soon as any message in the thread has `tag:draft`. The per-message
card in `ThreadMessageCardView` keyed the "Edit Draft" button on this
flag, so any thread that ever held a draft showed an Edit Draft button on
**every** card in that thread \u2014 including incoming replies and already-sent
mails.

## Fix

Add an `isDraft` computed property on `ThreadMessage` (`tags?.contains(\"draft\")`)
and use that in the card footer instead of the parent `MailMessage.isDraft`.
The single-message fallback in `EmailDetailView` still keys on the parent
`MailMessage.isDraft` since it renders the whole message without a
per-message context.

## Verified

- `bazel build //macos:Durian -c opt --define ci=true` passes
- All 15 macOS Swift tests pass
- Reproduced the spurious Edit Draft buttons before the fix; after the
  fix the button only appears on the actual draft message card within a
  thread.