### PR TITLE
fix(sanitize): strip quoted reply blocks in plain-text and GMX HTML bodies

### DIFF
--- a/cli/internal/handler/show.go
+++ b/cli/internal/handler/show.go
@@ -60,8 +60,8 @@ func (h *Handler) ShowMessageBody(messageID string) protocol.Response {
 	}
 
 	return protocol.SuccessWithMessageBody(&internmail.MessageBody{
-		Body: msg.BodyText,
-		HTML: msg.BodyHTML,
+		Body: sanitize.StripQuotedTextContent(msg.BodyText),
+		HTML: sanitize.StripQuotedContent(msg.BodyHTML),
 	})
 }
 
@@ -85,7 +85,7 @@ func (h *Handler) convertThread(threadID string, msgs []*store.Message, light bo
 			Date:      time.Unix(msg.Date, 0).Format(time.RFC1123Z),
 			Timestamp: msg.Date,
 			MessageID: msg.MessageID,
-			Body:      msg.BodyText,
+			Body:      sanitize.StripQuotedTextContent(msg.BodyText),
 		}
 		if !light {
 			info.InReplyTo = msg.InReplyTo

--- a/cli/internal/sanitize/quote.go
+++ b/cli/internal/sanitize/quote.go
@@ -82,6 +82,13 @@ var quoteRegexPatterns = []*regexp.Regexp{
 	// matches "On 5 Apr 2026 ... wrote:<br/><blockquote>" (and similar variants).
 	// The opening <div> or <p> wrapping this attribution is the cut point.
 	regexp.MustCompile(`(?i)<(?:div|p)[^>]*>\s*On\s+\d[^<]*?wrote:\s*<br[^>]*>\s*<blockquote`),
+
+	// GMX / web.de Web: <div style="margin: ...; padding: ...; border-left: 2px solid rgb(...)">
+	// followed by a header block with <strong>Gesendet:</strong> / <strong>Von:</strong>.
+	// GMX does not use a stable class/id, but the border-left + Gesendet/Von combination
+	// is reliable. We anchor on the opening <div> with border-left so the quote box
+	// (including its surrounding margin/padding) is the cut point.
+	regexp.MustCompile(`(?is)<div[^>]*style="[^"]*border-left:[^"]*"[^>]*>\s*<div[^>]*>\s*<div[^>]*>\s*<strong>(?:Gesendet|Sent|Von|From):`),
 }
 
 // StripQuotedContent removes quoted reply content from HTML.
@@ -121,6 +128,70 @@ func StripQuotedContent(html string) string {
 		return html
 	}
 
+	return stripped
+}
+
+// textQuotePatterns are regex anchors for the start of a quoted/forwarded
+// block in plain-text mail bodies. The earliest match wins; everything
+// from the match position onward is treated as quoted content.
+//
+// We anchor on the BEGINNING OF A LINE so we don't trip over the same words
+// appearing inside legitimate prose (e.g. "Betreff dieses Treffens…").
+var textQuotePatterns = []*regexp.Regexp{
+	// GMX / web.de / many German webmailers: header block of a quoted reply.
+	// `Gesendet:` is the most distinctive marker; we accept it followed by
+	// optional `Von:`/`An:`/`Betreff:` lines but key on Gesendet alone.
+	regexp.MustCompile(`(?m)^[ \t]*Gesendet:\s`),
+	// Outlook English plain-text reply header.
+	regexp.MustCompile(`(?m)^[ \t]*Sent:\s.*\r?\n[ \t]*(?:From|To|Subject):`),
+	// German Outlook plain-text reply header.
+	regexp.MustCompile(`(?m)^[ \t]*Von:\s.*\r?\n[ \t]*(?:Gesendet|An|Betreff):`),
+	// Forwarded-message separators.
+	regexp.MustCompile(`(?im)^[ \t]*-{3,}\s*Urspr(?:ü|ue)ngliche Nachricht\s*-{3,}`),
+	regexp.MustCompile(`(?im)^[ \t]*-{3,}\s*Original Message\s*-{3,}`),
+	regexp.MustCompile(`(?im)^[ \t]*-{3,}\s*Forwarded message\s*-{3,}`),
+	// "On <date>, <name> wrote:" attribution line (Apple Mail, Spark, Gmail).
+	regexp.MustCompile(`(?m)^On\s+\w[^\n]{0,200}?\s+wrote:\s*$`),
+	// "Am <date> schrieb <name>:" attribution line (Thunderbird/Apple Mail DE).
+	regexp.MustCompile(`(?m)^Am\s+\w[^\n]{0,200}?\s+schrieb\s[^\n]{0,200}?:\s*$`),
+}
+
+// StripQuotedTextContent removes quoted reply / forwarded content from a
+// plain-text mail body. Mirrors StripQuotedContent for HTML.
+//
+// Like the HTML variant, if stripping leaves only whitespace or a mobile
+// signature the original is returned so the user still sees something.
+func StripQuotedTextContent(text string) string {
+	if text == "" {
+		return text
+	}
+
+	earliestIdx := -1
+	for _, re := range textQuotePatterns {
+		loc := re.FindStringIndex(text)
+		if loc != nil && (earliestIdx == -1 || loc[0] < earliestIdx) {
+			earliestIdx = loc[0]
+		}
+	}
+
+	if earliestIdx == -1 {
+		return text
+	}
+
+	stripped := strings.TrimRight(text[:earliestIdx], " \t\n\r")
+
+	textLower := strings.ToLower(strings.TrimSpace(stripped))
+	if textLower == "" {
+		return text
+	}
+	for _, sig := range mobileSignatures {
+		if strings.Contains(textLower, sig) {
+			remainder := strings.TrimSpace(strings.ReplaceAll(textLower, sig, ""))
+			if len(remainder) < 5 {
+				return text
+			}
+		}
+	}
 	return stripped
 }
 

--- a/cli/internal/sanitize/quote_test.go
+++ b/cli/internal/sanitize/quote_test.go
@@ -129,6 +129,27 @@ func TestStripQuotedContent_OutlookHR_EnglishFrom(t *testing.T) {
 	assertStripped(t, "Outlook HR From", html, "Hi Bob", "Alice")
 }
 
+// --- GMX / web.de Web (border-left quote box) ---
+
+func TestStripQuotedContent_GMX_BorderLeftGesendet(t *testing.T) {
+	html := `<div>Hi Julian,</div>` +
+		`<div>der 20.7. passt.</div>` +
+		`<div>Viele Grüße, Georg</div>` +
+		`<div style="margin: 10px 5px 5px 10px; padding: 10px 0px 10px 10px; border-left: 2px solid rgb(195, 217, 229)">` +
+		`<div style="margin: 0px 0px 10px">` +
+		`<div><strong>Gesendet: </strong>Montag, 18. Mai 2026 um 21:08</div>` +
+		`<div><strong>Von: </strong>Julian Schenker</div>` +
+		`</div><div>Quoted reply text here.</div></div>`
+	assertStripped(t, "GMX border-left Gesendet", html, "der 20.7. passt", "Quoted reply text here")
+}
+
+func TestStripQuotedContent_GMX_BorderLeftVon(t *testing.T) {
+	html := `<div>Reply body.</div>` +
+		`<div style="border-left: 2px solid rgb(195, 217, 229); padding-left: 10px">` +
+		`<div><div><strong>Von: </strong>Alice</div></div>Original content.</div>`
+	assertStripped(t, "GMX border-left Von", html, "Reply body", "Original content")
+}
+
 // --- Forwarded message separators ---
 
 func TestStripQuotedContent_GermanForward(t *testing.T) {
@@ -381,6 +402,72 @@ func TestStripQuotedContent_Fixture_SparkForward(t *testing.T) {
 	mustContain(t, result, "Upgrade your account", "forwarded body heading")
 	mustContain(t, result, "Subscription ID", "forwarded body details")
 	mustContain(t, result, "noreply@example.com", "forwarded sender")
+}
+
+// --- StripQuotedTextContent (plain-text bodies) ---
+
+func assertTextStripped(t *testing.T, name, input, expectedKeep, expectedRemove string) {
+	t.Helper()
+	result := StripQuotedTextContent(input)
+	if expectedKeep != "" && !strings.Contains(result, expectedKeep) {
+		t.Errorf("[%s] result should contain %q, got: %q", name, expectedKeep, result)
+	}
+	if expectedRemove != "" && strings.Contains(result, expectedRemove) {
+		t.Errorf("[%s] result should NOT contain %q, got: %q", name, expectedRemove, result)
+	}
+}
+
+func TestStripQuotedTextContent_GMX_Gesendet(t *testing.T) {
+	text := "Hi Julian,\n\nder 20.7. nachmittags würde gut passen.\n\nViele Grüße\nGeorg\n\n" +
+		"Gesendet: Montag, 18. Mai 2026 um 21:08\n" +
+		"Von: \"Julian Schenker\" <julian@habric.com>\n" +
+		"An: dram-hn@gmx.de\n" +
+		"Betreff: Re: Treffen heute\n\n" +
+		"Hey Georg, danke dir für den Call.\n"
+	assertTextStripped(t, "GMX Gesendet", text, "der 20.7. nachmittags", "danke dir für den Call")
+}
+
+func TestStripQuotedTextContent_OutlookEnglish(t *testing.T) {
+	text := "My reply.\n\nSent: Monday, May 18, 2026 9:08 PM\nFrom: Julian\nTo: Georg\nSubject: Re: Hi\n\nOriginal body."
+	assertTextStripped(t, "Outlook English Sent/From", text, "My reply", "Original body")
+}
+
+func TestStripQuotedTextContent_OutlookGerman(t *testing.T) {
+	text := "Antwort.\n\nVon: Alice\nGesendet: Montag\nAn: Bob\nBetreff: Test\n\nOriginal."
+	assertTextStripped(t, "Outlook German Von/Gesendet", text, "Antwort", "Original.")
+}
+
+func TestStripQuotedTextContent_OnWrote(t *testing.T) {
+	text := "Thanks!\n\nOn 19 May 2026, Alice wrote:\n> Original message body here\n> more\n"
+	assertTextStripped(t, "On wrote attribution", text, "Thanks", "Original message body")
+}
+
+func TestStripQuotedTextContent_GermanForward(t *testing.T) {
+	text := "Schau mal:\n\n--- Ursprüngliche Nachricht ---\nVon: Alice\n\nOriginal text."
+	assertTextStripped(t, "German forward separator", text, "Schau mal", "Original text")
+}
+
+func TestStripQuotedTextContent_NoQuote(t *testing.T) {
+	text := "A short standalone email with no replies or forwards."
+	if got := StripQuotedTextContent(text); got != text {
+		t.Errorf("unmodified text changed: %q vs %q", got, text)
+	}
+}
+
+func TestStripQuotedTextContent_OnlyMobileSig(t *testing.T) {
+	// If stripping leaves only "Sent from my iPhone" we keep the original
+	// so the forwarded body is still visible.
+	text := "Sent from my iPhone\n\nOn 19 May 2026, Alice wrote:\nOriginal content."
+	got := StripQuotedTextContent(text)
+	if !strings.Contains(got, "Original content") {
+		t.Errorf("expected fallback to original, got: %q", got)
+	}
+}
+
+func TestStripQuotedTextContent_Empty(t *testing.T) {
+	if got := StripQuotedTextContent(""); got != "" {
+		t.Errorf("empty input should return empty, got %q", got)
+	}
 }
 
 // --- isEmptyHTML ---


### PR DESCRIPTION
fix(sanitize): strip quoted reply blocks in plain-text and GMX HTML bodies

Two gaps were causing the latest message in a GMX-sourced thread to render
with the full reply chain inlined:

1. Plain-text bodies were never run through any quote-stripping logic;
   StripQuotedContent operated on HTML only. `durian show` defaults to
   the plain-text body, so every plain-text reply showed the embedded
   Gesendet/Von/An/Betreff header block and everything below it.
2. The HTML stripper had no GMX/web.de pattern. GMX wraps quoted replies
   in a div with `border-left: 2px solid rgb(...)` plus a header block
   of `<strong>Gesendet|Sent|Von|From:</strong>` tags — different shape
   from Outlook, which uses border-top.

Adds:
- StripQuotedTextContent for plain-text bodies. Anchors on line-start
  for Gesendet:, Sent:+From:, Von:+Gesendet:, German and English forward
  separators, and "On <date>, ... wrote:" / "Am <date> schrieb ...:"
  attributions. Falls back to original if stripping would leave only
  whitespace or a mobile-client signature.
- GMX border-left + Gesendet/Von regex in quoteRegexPatterns.
- handler.ShowThread and ShowMessage now apply both strippers.
- Six new sanitize unit tests covering GMX HTML and plain-text variants.

All //cli/... + //integration + //sync tests green locally.
