### PR TITLE
ADR-0001 step 6 — encrypt remaining messages.db columns (body, addrs, headers, drafts, meta)

### DIFF
--- a/cli/internal/dbcrypto/dbcrypto_test.go
+++ b/cli/internal/dbcrypto/dbcrypto_test.go
@@ -217,6 +217,7 @@ func TestNewKeyring_DerivesAllSubKeys(t *testing.T) {
 		{"Subject", kr.Subject, LabelSubject},
 		{"Body", kr.Body, LabelBody},
 		{"Addrs", kr.Addrs, LabelAddrs},
+		{"Headers", kr.Headers, LabelHeaders},
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
@@ -236,7 +237,10 @@ func TestNewKeyring_DerivesAllSubKeys(t *testing.T) {
 	pairs := [][2][]byte{
 		{kr.Subject, kr.Body},
 		{kr.Subject, kr.Addrs},
+		{kr.Subject, kr.Headers},
 		{kr.Body, kr.Addrs},
+		{kr.Body, kr.Headers},
+		{kr.Addrs, kr.Headers},
 	}
 	for i, p := range pairs {
 		if bytes.Equal(p[0], p[1]) {

--- a/cli/internal/dbcrypto/dbcrypto_test.go
+++ b/cli/internal/dbcrypto/dbcrypto_test.go
@@ -200,23 +200,48 @@ func TestDecrypt_RejectsBadKey(t *testing.T) {
 
 // --- Keyring ---
 
-func TestNewKeyring_DerivesSubjectSubKey(t *testing.T) {
+func TestNewKeyring_DerivesAllSubKeys(t *testing.T) {
 	master := bytes.Repeat([]byte{0x77}, MasterKeyLen)
 	kr, err := NewKeyring(master)
 	if err != nil {
 		t.Fatalf("NewKeyring: %v", err)
 	}
-	if len(kr.Subject) != KeyLen {
-		t.Errorf("Subject sub-key length = %d, want %d", len(kr.Subject), KeyLen)
+	// Every sub-key must (a) be the right length and (b) match a direct
+	// DeriveSubKey call bit-for-bit — both paths produce the same on-disk
+	// ciphertexts, any drift here corrupts the entire DB.
+	cases := []struct {
+		name  string
+		got   []byte
+		label Label
+	}{
+		{"Subject", kr.Subject, LabelSubject},
+		{"Body", kr.Body, LabelBody},
+		{"Addrs", kr.Addrs, LabelAddrs},
 	}
-	// Must match a direct DeriveSubKey call — they have to be bit-identical
-	// because both paths produce the same on-disk ciphertexts.
-	want, err := DeriveSubKey(master, LabelSubject)
-	if err != nil {
-		t.Fatalf("DeriveSubKey: %v", err)
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if len(c.got) != KeyLen {
+				t.Errorf("length = %d, want %d", len(c.got), KeyLen)
+			}
+			want, err := DeriveSubKey(master, c.label)
+			if err != nil {
+				t.Fatalf("DeriveSubKey: %v", err)
+			}
+			if !bytes.Equal(c.got, want) {
+				t.Errorf("diverged from DeriveSubKey(%s)", c.label)
+			}
+		})
 	}
-	if !bytes.Equal(kr.Subject, want) {
-		t.Errorf("Keyring.Subject diverged from DeriveSubKey(LabelSubject)")
+	// Pairwise distinctness — guards against future "oops, copy-paste".
+	pairs := [][2][]byte{
+		{kr.Subject, kr.Body},
+		{kr.Subject, kr.Addrs},
+		{kr.Body, kr.Addrs},
+	}
+	for i, p := range pairs {
+		if bytes.Equal(p[0], p[1]) {
+			t.Errorf("pair %d: sub-keys collided", i)
+		}
 	}
 }
 

--- a/cli/internal/dbcrypto/dbcrypto_test.go
+++ b/cli/internal/dbcrypto/dbcrypto_test.go
@@ -218,6 +218,8 @@ func TestNewKeyring_DerivesAllSubKeys(t *testing.T) {
 		{"Body", kr.Body, LabelBody},
 		{"Addrs", kr.Addrs, LabelAddrs},
 		{"Headers", kr.Headers, LabelHeaders},
+		{"Draft", kr.Draft, LabelDraft},
+		{"Meta", kr.Meta, LabelMeta},
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
@@ -234,13 +236,12 @@ func TestNewKeyring_DerivesAllSubKeys(t *testing.T) {
 		})
 	}
 	// Pairwise distinctness — guards against future "oops, copy-paste".
-	pairs := [][2][]byte{
-		{kr.Subject, kr.Body},
-		{kr.Subject, kr.Addrs},
-		{kr.Subject, kr.Headers},
-		{kr.Body, kr.Addrs},
-		{kr.Body, kr.Headers},
-		{kr.Addrs, kr.Headers},
+	all := [][]byte{kr.Subject, kr.Body, kr.Addrs, kr.Headers, kr.Draft, kr.Meta}
+	var pairs [][2][]byte
+	for i := range all {
+		for j := i + 1; j < len(all); j++ {
+			pairs = append(pairs, [2][]byte{all[i], all[j]})
+		}
 	}
 	for i, p := range pairs {
 		if bytes.Equal(p[0], p[1]) {

--- a/cli/internal/dbcrypto/keyring.go
+++ b/cli/internal/dbcrypto/keyring.go
@@ -10,14 +10,16 @@ import (
 // start, retained in memory for the lifetime of the daemon, and consumed
 // by the store layer for transparent encrypt-on-write / decrypt-on-read.
 //
-// Step 5 only derives Subject. Subsequent steps fill in Body, Headers,
-// Addrs, Draft, Contact, FTSToken, Meta — each as its own field so callers
-// never have to remember which label to pass.
+// Subsequent steps fill in Headers, Addrs, Draft, Contact, FTSToken, Meta
+// — each as its own field so callers never have to remember which label
+// to pass.
 type Keyring struct {
 	Subject []byte // encrypts messages.subject (LabelSubject)
+	Body    []byte // encrypts messages.body_text + body_html (LabelBody)
+	Addrs   []byte // encrypts messages.from_addr + to_addrs + cc_addrs (LabelAddrs)
 }
 
-// NewKeyring derives every step-5 sub-key from a 32-byte master key.
+// NewKeyring derives every currently-shipped sub-key from a 32-byte master.
 // The master is read once and never retained by the returned Keyring; the
 // caller is free to (and should) wipe its own copy once this returns.
 func NewKeyring(master []byte) (*Keyring, error) {
@@ -25,7 +27,15 @@ func NewKeyring(master []byte) (*Keyring, error) {
 	if err != nil {
 		return nil, fmt.Errorf("dbcrypto: derive subject sub-key: %w", err)
 	}
-	return &Keyring{Subject: subject}, nil
+	body, err := DeriveSubKey(master, LabelBody)
+	if err != nil {
+		return nil, fmt.Errorf("dbcrypto: derive body sub-key: %w", err)
+	}
+	addrs, err := DeriveSubKey(master, LabelAddrs)
+	if err != nil {
+		return nil, fmt.Errorf("dbcrypto: derive addrs sub-key: %w", err)
+	}
+	return &Keyring{Subject: subject, Body: body, Addrs: addrs}, nil
 }
 
 // Wipe overwrites every sub-key in place with zeroes and nils the slice
@@ -37,7 +47,11 @@ func (k *Keyring) Wipe() {
 		return
 	}
 	zero(k.Subject)
+	zero(k.Body)
+	zero(k.Addrs)
 	k.Subject = nil
+	k.Body = nil
+	k.Addrs = nil
 }
 
 // zero overwrites b with zero bytes in constant time. Used by Wipe.

--- a/cli/internal/dbcrypto/keyring.go
+++ b/cli/internal/dbcrypto/keyring.go
@@ -17,6 +17,7 @@ type Keyring struct {
 	Subject []byte // encrypts messages.subject (LabelSubject)
 	Body    []byte // encrypts messages.body_text + body_html (LabelBody)
 	Addrs   []byte // encrypts messages.from_addr + to_addrs + cc_addrs (LabelAddrs)
+	Headers []byte // encrypts message_headers.value (LabelHeaders)
 }
 
 // NewKeyring derives every currently-shipped sub-key from a 32-byte master.
@@ -35,7 +36,11 @@ func NewKeyring(master []byte) (*Keyring, error) {
 	if err != nil {
 		return nil, fmt.Errorf("dbcrypto: derive addrs sub-key: %w", err)
 	}
-	return &Keyring{Subject: subject, Body: body, Addrs: addrs}, nil
+	headers, err := DeriveSubKey(master, LabelHeaders)
+	if err != nil {
+		return nil, fmt.Errorf("dbcrypto: derive headers sub-key: %w", err)
+	}
+	return &Keyring{Subject: subject, Body: body, Addrs: addrs, Headers: headers}, nil
 }
 
 // Wipe overwrites every sub-key in place with zeroes and nils the slice
@@ -49,9 +54,11 @@ func (k *Keyring) Wipe() {
 	zero(k.Subject)
 	zero(k.Body)
 	zero(k.Addrs)
+	zero(k.Headers)
 	k.Subject = nil
 	k.Body = nil
 	k.Addrs = nil
+	k.Headers = nil
 }
 
 // zero overwrites b with zero bytes in constant time. Used by Wipe.

--- a/cli/internal/dbcrypto/keyring.go
+++ b/cli/internal/dbcrypto/keyring.go
@@ -18,6 +18,8 @@ type Keyring struct {
 	Body    []byte // encrypts messages.body_text + body_html (LabelBody)
 	Addrs   []byte // encrypts messages.from_addr + to_addrs + cc_addrs (LabelAddrs)
 	Headers []byte // encrypts message_headers.value (LabelHeaders)
+	Draft   []byte // encrypts local_drafts.draft_json + outbox.draft_json (LabelDraft)
+	Meta    []byte // encrypts mailboxes.name + accounts.name + messages.flags_other (LabelMeta)
 }
 
 // NewKeyring derives every currently-shipped sub-key from a 32-byte master.
@@ -40,7 +42,15 @@ func NewKeyring(master []byte) (*Keyring, error) {
 	if err != nil {
 		return nil, fmt.Errorf("dbcrypto: derive headers sub-key: %w", err)
 	}
-	return &Keyring{Subject: subject, Body: body, Addrs: addrs, Headers: headers}, nil
+	draft, err := DeriveSubKey(master, LabelDraft)
+	if err != nil {
+		return nil, fmt.Errorf("dbcrypto: derive draft sub-key: %w", err)
+	}
+	meta, err := DeriveSubKey(master, LabelMeta)
+	if err != nil {
+		return nil, fmt.Errorf("dbcrypto: derive meta sub-key: %w", err)
+	}
+	return &Keyring{Subject: subject, Body: body, Addrs: addrs, Headers: headers, Draft: draft, Meta: meta}, nil
 }
 
 // Wipe overwrites every sub-key in place with zeroes and nils the slice
@@ -55,10 +65,14 @@ func (k *Keyring) Wipe() {
 	zero(k.Body)
 	zero(k.Addrs)
 	zero(k.Headers)
+	zero(k.Draft)
+	zero(k.Meta)
 	k.Subject = nil
 	k.Body = nil
 	k.Addrs = nil
 	k.Headers = nil
+	k.Draft = nil
+	k.Meta = nil
 }
 
 // zero overwrites b with zero bytes in constant time. Used by Wipe.

--- a/cli/internal/store/headers.go
+++ b/cli/internal/store/headers.go
@@ -6,10 +6,16 @@ import (
 )
 
 // InsertHeader stores a message header. Overwrites if the header already exists.
+// Writes both plaintext value (so existing reads still work) and value_ct
+// (ADR-0001 step 6). The plaintext column dies in step 7.
 func (d *DB) InsertHeader(messageDBID int64, name, value string) error {
-	_, err := d.db.Exec(
-		"INSERT OR REPLACE INTO message_headers (message_id, name, value) VALUES (?, ?, ?)",
-		messageDBID, name, value)
+	valueCT, err := d.encryptHeaderValue(value)
+	if err != nil {
+		return fmt.Errorf("encrypt header value: %w", err)
+	}
+	_, err = d.db.Exec(
+		"INSERT OR REPLACE INTO message_headers (message_id, name, value, value_ct) VALUES (?, ?, ?, ?)",
+		messageDBID, name, value, valueCT)
 	if err != nil {
 		return fmt.Errorf("insert header: %w", err)
 	}
@@ -19,13 +25,18 @@ func (d *DB) InsertHeader(messageDBID int64, name, value string) error {
 // GetHeader returns a single header value for a message. Returns "" if not found.
 func (d *DB) GetHeader(messageDBID int64, name string) (string, error) {
 	var value string
+	var valueCT []byte
 	err := d.db.QueryRow(
-		"SELECT value FROM message_headers WHERE message_id = ? AND name = ?",
-		messageDBID, name).Scan(&value)
+		"SELECT value, value_ct FROM message_headers WHERE message_id = ? AND name = ?",
+		messageDBID, name).Scan(&value, &valueCT)
 	if err != nil {
 		return "", nil // not found
 	}
-	return value, nil
+	out, err := d.decryptHeaderValue(value, valueCT)
+	if err != nil {
+		return "", err
+	}
+	return out, nil
 }
 
 // HasHeaders returns true if the message has any stored headers.
@@ -95,7 +106,7 @@ func (d *DB) AllMessages() ([]*Message, error) {
 // AllHeadersByMessage loads all stored headers, keyed by message DB ID.
 // Header names are returned in canonical MIME form (e.g. "List-Unsubscribe").
 func (d *DB) AllHeadersByMessage() (map[int64]map[string][]string, error) {
-	rows, err := d.db.Query("SELECT message_id, name, value FROM message_headers")
+	rows, err := d.db.Query("SELECT message_id, name, value, value_ct FROM message_headers")
 	if err != nil {
 		return nil, fmt.Errorf("query headers: %w", err)
 	}
@@ -105,14 +116,19 @@ func (d *DB) AllHeadersByMessage() (map[int64]map[string][]string, error) {
 	for rows.Next() {
 		var msgID int64
 		var name, value string
-		if err := rows.Scan(&msgID, &name, &value); err != nil {
+		var valueCT []byte
+		if err := rows.Scan(&msgID, &name, &value, &valueCT); err != nil {
 			return nil, fmt.Errorf("scan header: %w", err)
+		}
+		plain, err := d.decryptHeaderValue(value, valueCT)
+		if err != nil {
+			return nil, err
 		}
 		if result[msgID] == nil {
 			result[msgID] = make(map[string][]string)
 		}
 		canonical := textproto.CanonicalMIMEHeaderKey(name)
-		result[msgID][canonical] = append(result[msgID][canonical], value)
+		result[msgID][canonical] = append(result[msgID][canonical], plain)
 	}
 	return result, rows.Err()
 }

--- a/cli/internal/store/headers.go
+++ b/cli/internal/store/headers.go
@@ -55,8 +55,9 @@ func (d *DB) GetMessageDBID(messageID, account string) (int64, error) {
 
 // AllMessages returns all messages with fields needed for rule matching.
 func (d *DB) AllMessages() ([]*Message, error) {
-	rows, err := d.db.Query(
-		"SELECT id, message_id, subject, subject_ct, from_addr, to_addrs, cc_addrs, body_text, account FROM messages")
+	rows, err := d.db.Query(`SELECT id, message_id, subject, subject_ct,
+		from_addr, from_addr_ct, to_addrs, to_addrs_ct, cc_addrs, cc_addrs_ct,
+		body_text, body_text_ct, account FROM messages`)
 	if err != nil {
 		return nil, fmt.Errorf("query messages: %w", err)
 	}
@@ -65,11 +66,25 @@ func (d *DB) AllMessages() ([]*Message, error) {
 	var msgs []*Message
 	for rows.Next() {
 		m := &Message{}
-		var subjectCT []byte
-		if err := rows.Scan(&m.ID, &m.MessageID, &m.Subject, &subjectCT, &m.FromAddr, &m.ToAddrs, &m.CCAddrs, &m.BodyText, &m.Account); err != nil {
+		var subjectCT, fromAddrCT, toAddrsCT, ccAddrsCT, bodyTextCT []byte
+		if err := rows.Scan(&m.ID, &m.MessageID, &m.Subject, &subjectCT,
+			&m.FromAddr, &fromAddrCT, &m.ToAddrs, &toAddrsCT, &m.CCAddrs, &ccAddrsCT,
+			&m.BodyText, &bodyTextCT, &m.Account); err != nil {
 			return nil, fmt.Errorf("scan message: %w", err)
 		}
 		if m.Subject, err = d.decryptSubject(m.Subject, subjectCT); err != nil {
+			return nil, err
+		}
+		if m.FromAddr, err = d.decryptAddr(m.FromAddr, fromAddrCT); err != nil {
+			return nil, err
+		}
+		if m.ToAddrs, err = d.decryptAddr(m.ToAddrs, toAddrsCT); err != nil {
+			return nil, err
+		}
+		if m.CCAddrs, err = d.decryptAddr(m.CCAddrs, ccAddrsCT); err != nil {
+			return nil, err
+		}
+		if m.BodyText, err = d.decryptBody(m.BodyText, bodyTextCT); err != nil {
 			return nil, err
 		}
 		msgs = append(msgs, m)

--- a/cli/internal/store/local_drafts.go
+++ b/cli/internal/store/local_drafts.go
@@ -21,13 +21,18 @@ func (d *DB) SaveLocalDraft(draft *LocalDraft) error {
 	}
 	draft.ModifiedAt = now
 
-	_, err := d.db.Exec(`
-		INSERT INTO local_drafts (id, draft_json, created_at, modified_at)
-		VALUES (?, ?, ?, ?)
+	ct, err := d.encryptDraftJSON(draft.DraftJSON)
+	if err != nil {
+		return fmt.Errorf("encrypt draft_json: %w", err)
+	}
+	_, err = d.db.Exec(`
+		INSERT INTO local_drafts (id, draft_json, draft_json_ct, created_at, modified_at)
+		VALUES (?, ?, ?, ?, ?)
 		ON CONFLICT(id) DO UPDATE SET
 			draft_json = excluded.draft_json,
+			draft_json_ct = excluded.draft_json_ct,
 			modified_at = excluded.modified_at`,
-		draft.ID, draft.DraftJSON, draft.CreatedAt, draft.ModifiedAt)
+		draft.ID, draft.DraftJSON, ct, draft.CreatedAt, draft.ModifiedAt)
 	if err != nil {
 		return fmt.Errorf("save local draft: %w", err)
 	}
@@ -37,11 +42,15 @@ func (d *DB) SaveLocalDraft(draft *LocalDraft) error {
 // GetLocalDraft retrieves a local draft by ID.
 func (d *DB) GetLocalDraft(id string) (*LocalDraft, error) {
 	draft := &LocalDraft{}
+	var ct []byte
 	err := d.db.QueryRow(
-		"SELECT id, draft_json, created_at, modified_at FROM local_drafts WHERE id = ?", id,
-	).Scan(&draft.ID, &draft.DraftJSON, &draft.CreatedAt, &draft.ModifiedAt)
+		"SELECT id, draft_json, draft_json_ct, created_at, modified_at FROM local_drafts WHERE id = ?", id,
+	).Scan(&draft.ID, &draft.DraftJSON, &ct, &draft.CreatedAt, &draft.ModifiedAt)
 	if err != nil {
 		return nil, fmt.Errorf("get local draft: %w", err)
+	}
+	if draft.DraftJSON, err = d.decryptDraftJSON(draft.DraftJSON, ct); err != nil {
+		return nil, err
 	}
 	return draft, nil
 }
@@ -62,7 +71,7 @@ func (d *DB) DeleteLocalDraft(id string) error {
 // ListLocalDrafts returns all local drafts, newest first.
 func (d *DB) ListLocalDrafts() ([]*LocalDraft, error) {
 	rows, err := d.db.Query(
-		"SELECT id, draft_json, created_at, modified_at FROM local_drafts ORDER BY modified_at DESC")
+		"SELECT id, draft_json, draft_json_ct, created_at, modified_at FROM local_drafts ORDER BY modified_at DESC")
 	if err != nil {
 		return nil, fmt.Errorf("list local drafts: %w", err)
 	}
@@ -71,8 +80,12 @@ func (d *DB) ListLocalDrafts() ([]*LocalDraft, error) {
 	var drafts []*LocalDraft
 	for rows.Next() {
 		draft := &LocalDraft{}
-		if err := rows.Scan(&draft.ID, &draft.DraftJSON, &draft.CreatedAt, &draft.ModifiedAt); err != nil {
+		var ct []byte
+		if err := rows.Scan(&draft.ID, &draft.DraftJSON, &ct, &draft.CreatedAt, &draft.ModifiedAt); err != nil {
 			return nil, fmt.Errorf("scan local draft: %w", err)
+		}
+		if draft.DraftJSON, err = d.decryptDraftJSON(draft.DraftJSON, ct); err != nil {
+			return nil, err
 		}
 		drafts = append(drafts, draft)
 	}

--- a/cli/internal/store/messages.go
+++ b/cli/internal/store/messages.go
@@ -79,6 +79,13 @@ func (d *DB) insertMessageTx(tx *sql.Tx, msg *Message) error {
 	if err != nil {
 		return fmt.Errorf("encrypt cc_addrs: %w", err)
 	}
+	// ADR-0001 step 6: non-boolean flag parts go to flags_other under
+	// the meta sub-key. Booleans (is_seen/is_flagged/is_deleted) are
+	// derived elsewhere in this insert path's downstream tag flow.
+	flagsOtherCT, err := d.encryptMeta(flagsOtherForEncryption(msg.Flags))
+	if err != nil {
+		return fmt.Errorf("encrypt flags_other: %w", err)
+	}
 
 	err = tx.QueryRow(`
 		INSERT INTO messages (
@@ -86,8 +93,8 @@ func (d *DB) insertMessageTx(tx *sql.Tx, msg *Message) error {
 			from_addr, from_addr_ct, to_addrs, to_addrs_ct, cc_addrs, cc_addrs_ct,
 			date, created_at,
 			body_text, body_text_ct, body_html, body_html_ct,
-			mailbox, flags, uid, size, fetched_body, account
-		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+			mailbox, flags, flags_other, uid, size, fetched_body, account
+		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 		ON CONFLICT(message_id, account) DO UPDATE SET
 			subject = excluded.subject,
 			subject_ct = excluded.subject_ct,
@@ -107,6 +114,7 @@ func (d *DB) insertMessageTx(tx *sql.Tx, msg *Message) error {
 			                 THEN excluded.body_html_ct ELSE messages.body_html_ct END,
 			fetched_body = MAX(messages.fetched_body, excluded.fetched_body),
 			flags = excluded.flags,
+			flags_other = excluded.flags_other,
 			uid = CASE WHEN excluded.uid > 0 THEN excluded.uid ELSE messages.uid END,
 			mailbox = CASE WHEN excluded.mailbox != '' THEN excluded.mailbox ELSE messages.mailbox END
 		RETURNING id`,
@@ -114,7 +122,7 @@ func (d *DB) insertMessageTx(tx *sql.Tx, msg *Message) error {
 		msg.FromAddr, fromAddrCT, msg.ToAddrs, toAddrsCT, msg.CCAddrs, ccAddrsCT,
 		msg.Date, msg.CreatedAt,
 		msg.BodyText, bodyTextCT, msg.BodyHTML, bodyHTMLCT,
-		msg.Mailbox, msg.Flags, msg.UID, msg.Size, fetchedBody, msg.Account,
+		msg.Mailbox, msg.Flags, flagsOtherCT, msg.UID, msg.Size, fetchedBody, msg.Account,
 	).Scan(&msg.ID)
 	if err != nil {
 		return fmt.Errorf("upsert message: %w", err)

--- a/cli/internal/store/messages.go
+++ b/cli/internal/store/messages.go
@@ -51,37 +51,70 @@ func (d *DB) insertMessageTx(tx *sql.Tx, msg *Message) error {
 		fetchedBody = 1
 	}
 
-	// ADR-0001 step 5: encrypted subject lives in subject_ct alongside the
-	// plaintext subject column (which FTS5 still indexes until step 7).
+	// ADR-0001 step 5: encrypted subject in subject_ct, plaintext subject
+	// stays for FTS5 until step 7.
 	subjectCT, err := d.encryptSubject(msg.Subject)
 	if err != nil {
 		return fmt.Errorf("encrypt subject: %w", err)
+	}
+	// ADR-0001 step 6: same pattern for body_text / body_html.
+	bodyTextCT, err := d.encryptBody(msg.BodyText)
+	if err != nil {
+		return fmt.Errorf("encrypt body_text: %w", err)
+	}
+	bodyHTMLCT, err := d.encryptBody(msg.BodyHTML)
+	if err != nil {
+		return fmt.Errorf("encrypt body_html: %w", err)
+	}
+	// ADR-0001 step 6: addrs columns.
+	fromAddrCT, err := d.encryptAddr(msg.FromAddr)
+	if err != nil {
+		return fmt.Errorf("encrypt from_addr: %w", err)
+	}
+	toAddrsCT, err := d.encryptAddr(msg.ToAddrs)
+	if err != nil {
+		return fmt.Errorf("encrypt to_addrs: %w", err)
+	}
+	ccAddrsCT, err := d.encryptAddr(msg.CCAddrs)
+	if err != nil {
+		return fmt.Errorf("encrypt cc_addrs: %w", err)
 	}
 
 	err = tx.QueryRow(`
 		INSERT INTO messages (
 			message_id, thread_id, in_reply_to, refs, subject, subject_ct,
-			from_addr, to_addrs, cc_addrs, date, created_at,
-			body_text, body_html, mailbox, flags, uid, size, fetched_body, account
-		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+			from_addr, from_addr_ct, to_addrs, to_addrs_ct, cc_addrs, cc_addrs_ct,
+			date, created_at,
+			body_text, body_text_ct, body_html, body_html_ct,
+			mailbox, flags, uid, size, fetched_body, account
+		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 		ON CONFLICT(message_id, account) DO UPDATE SET
 			subject = excluded.subject,
 			subject_ct = excluded.subject_ct,
 			from_addr = excluded.from_addr,
+			from_addr_ct = excluded.from_addr_ct,
 			to_addrs = excluded.to_addrs,
+			to_addrs_ct = excluded.to_addrs_ct,
 			cc_addrs = excluded.cc_addrs,
+			cc_addrs_ct = excluded.cc_addrs_ct,
 			body_text = CASE WHEN excluded.fetched_body = 1 AND messages.fetched_body = 0
 			                 THEN excluded.body_text ELSE messages.body_text END,
+			body_text_ct = CASE WHEN excluded.fetched_body = 1 AND messages.fetched_body = 0
+			                 THEN excluded.body_text_ct ELSE messages.body_text_ct END,
 			body_html = CASE WHEN excluded.fetched_body = 1 AND messages.fetched_body = 0
 			                 THEN excluded.body_html ELSE messages.body_html END,
+			body_html_ct = CASE WHEN excluded.fetched_body = 1 AND messages.fetched_body = 0
+			                 THEN excluded.body_html_ct ELSE messages.body_html_ct END,
 			fetched_body = MAX(messages.fetched_body, excluded.fetched_body),
 			flags = excluded.flags,
 			uid = CASE WHEN excluded.uid > 0 THEN excluded.uid ELSE messages.uid END,
 			mailbox = CASE WHEN excluded.mailbox != '' THEN excluded.mailbox ELSE messages.mailbox END
 		RETURNING id`,
 		msg.MessageID, threadID, msg.InReplyTo, msg.Refs, msg.Subject, subjectCT,
-		msg.FromAddr, msg.ToAddrs, msg.CCAddrs, msg.Date, msg.CreatedAt,
-		msg.BodyText, msg.BodyHTML, msg.Mailbox, msg.Flags, msg.UID, msg.Size, fetchedBody, msg.Account,
+		msg.FromAddr, fromAddrCT, msg.ToAddrs, toAddrsCT, msg.CCAddrs, ccAddrsCT,
+		msg.Date, msg.CreatedAt,
+		msg.BodyText, bodyTextCT, msg.BodyHTML, bodyHTMLCT,
+		msg.Mailbox, msg.Flags, msg.UID, msg.Size, fetchedBody, msg.Account,
 	).Scan(&msg.ID)
 	if err != nil {
 		return fmt.Errorf("upsert message: %w", err)
@@ -91,11 +124,23 @@ func (d *DB) insertMessageTx(tx *sql.Tx, msg *Message) error {
 }
 
 // UpdateBody updates the body text and HTML for a message (lazy body fetch).
+// Writes both the plaintext columns (FTS5 still indexes body_text until
+// step 7) and the encrypted *_ct columns introduced in v11.
 func (d *DB) UpdateBody(messageID, bodyText, bodyHTML string) error {
+	bodyTextCT, err := d.encryptBody(bodyText)
+	if err != nil {
+		return fmt.Errorf("encrypt body_text: %w", err)
+	}
+	bodyHTMLCT, err := d.encryptBody(bodyHTML)
+	if err != nil {
+		return fmt.Errorf("encrypt body_html: %w", err)
+	}
 	result, err := d.db.Exec(`
-		UPDATE messages SET body_text = ?, body_html = ?, fetched_body = 1
+		UPDATE messages SET body_text = ?, body_text_ct = ?,
+		                    body_html = ?, body_html_ct = ?,
+		                    fetched_body = 1
 		WHERE message_id = ?`,
-		bodyText, bodyHTML, messageID)
+		bodyText, bodyTextCT, bodyHTML, bodyHTMLCT, messageID)
 	if err != nil {
 		return fmt.Errorf("update body: %w", err)
 	}
@@ -134,16 +179,20 @@ func (d *DB) BackfillUID(messageID, account string, uid uint32, mailbox string) 
 func (d *DB) GetByMessageID(messageID string) (*Message, error) {
 	msg := &Message{}
 	var fetchedBody int
-	var subjectCT []byte
+	var subjectCT, fromAddrCT, toAddrsCT, ccAddrsCT, bodyTextCT, bodyHTMLCT []byte
 	err := d.db.QueryRow(`
 		SELECT id, message_id, thread_id, in_reply_to, refs, subject, subject_ct,
-		       from_addr, to_addrs, cc_addrs, date, created_at,
-		       body_text, body_html, mailbox, flags, uid, size, fetched_body, account
+		       from_addr, from_addr_ct, to_addrs, to_addrs_ct, cc_addrs, cc_addrs_ct,
+		       date, created_at,
+		       body_text, body_text_ct, body_html, body_html_ct,
+		       mailbox, flags, uid, size, fetched_body, account
 		FROM messages WHERE message_id = ? LIMIT 1`, messageID,
 	).Scan(
 		&msg.ID, &msg.MessageID, &msg.ThreadID, &msg.InReplyTo, &msg.Refs, &msg.Subject, &subjectCT,
-		&msg.FromAddr, &msg.ToAddrs, &msg.CCAddrs, &msg.Date, &msg.CreatedAt,
-		&msg.BodyText, &msg.BodyHTML, &msg.Mailbox, &msg.Flags, &msg.UID, &msg.Size, &fetchedBody, &msg.Account,
+		&msg.FromAddr, &fromAddrCT, &msg.ToAddrs, &toAddrsCT, &msg.CCAddrs, &ccAddrsCT,
+		&msg.Date, &msg.CreatedAt,
+		&msg.BodyText, &bodyTextCT, &msg.BodyHTML, &bodyHTMLCT,
+		&msg.Mailbox, &msg.Flags, &msg.UID, &msg.Size, &fetchedBody, &msg.Account,
 	)
 	if err == sql.ErrNoRows {
 		return nil, nil
@@ -155,6 +204,21 @@ func (d *DB) GetByMessageID(messageID string) (*Message, error) {
 	if msg.Subject, err = d.decryptSubject(msg.Subject, subjectCT); err != nil {
 		return nil, err
 	}
+	if msg.FromAddr, err = d.decryptAddr(msg.FromAddr, fromAddrCT); err != nil {
+		return nil, err
+	}
+	if msg.ToAddrs, err = d.decryptAddr(msg.ToAddrs, toAddrsCT); err != nil {
+		return nil, err
+	}
+	if msg.CCAddrs, err = d.decryptAddr(msg.CCAddrs, ccAddrsCT); err != nil {
+		return nil, err
+	}
+	if msg.BodyText, err = d.decryptBody(msg.BodyText, bodyTextCT); err != nil {
+		return nil, err
+	}
+	if msg.BodyHTML, err = d.decryptBody(msg.BodyHTML, bodyHTMLCT); err != nil {
+		return nil, err
+	}
 	return msg, nil
 }
 
@@ -163,8 +227,10 @@ func (d *DB) GetByMessageID(messageID string) (*Message, error) {
 func (d *DB) GetByThread(threadID string) ([]*Message, error) {
 	rows, err := d.db.Query(`
 		SELECT id, message_id, thread_id, in_reply_to, refs, subject, subject_ct,
-		       from_addr, to_addrs, cc_addrs, date, created_at,
-		       body_text, body_html, mailbox, flags, uid, size, fetched_body, account
+		       from_addr, from_addr_ct, to_addrs, to_addrs_ct, cc_addrs, cc_addrs_ct,
+		       date, created_at,
+		       body_text, body_text_ct, body_html, body_html_ct,
+		       mailbox, flags, uid, size, fetched_body, account
 		FROM messages WHERE thread_id = ?
 		ORDER BY date ASC`, threadID)
 	if err != nil {
@@ -196,8 +262,10 @@ func (d *DB) GetByThread(threadID string) ([]*Message, error) {
 func (d *DB) GetAllByThread(threadID string) ([]*Message, error) {
 	rows, err := d.db.Query(`
 		SELECT id, message_id, thread_id, in_reply_to, refs, subject, subject_ct,
-		       from_addr, to_addrs, cc_addrs, date, created_at,
-		       body_text, body_html, mailbox, flags, uid, size, fetched_body, account
+		       from_addr, from_addr_ct, to_addrs, to_addrs_ct, cc_addrs, cc_addrs_ct,
+		       date, created_at,
+		       body_text, body_text_ct, body_html, body_html_ct,
+		       mailbox, flags, uid, size, fetched_body, account
 		FROM messages WHERE thread_id = ?
 		ORDER BY date ASC`, threadID)
 	if err != nil {
@@ -315,23 +383,42 @@ func (d *DB) GetRecipientAddresses() ([]string, error) {
 }
 
 // scanMessages scans rows into a slice of Message pointers. Caller's
-// SELECT must include subject_ct between subject and from_addr.
+// SELECT must interleave each encrypted column's *_ct BLOB right after
+// its plaintext column, in this order: subject, from_addr, to_addrs,
+// cc_addrs, body_text, body_html.
 func (d *DB) scanMessages(rows *sql.Rows) ([]*Message, error) {
 	var msgs []*Message
 	for rows.Next() {
 		msg := &Message{}
 		var fetchedBody int
-		var subjectCT []byte
+		var subjectCT, fromAddrCT, toAddrsCT, ccAddrsCT, bodyTextCT, bodyHTMLCT []byte
 		err := rows.Scan(
 			&msg.ID, &msg.MessageID, &msg.ThreadID, &msg.InReplyTo, &msg.Refs, &msg.Subject, &subjectCT,
-			&msg.FromAddr, &msg.ToAddrs, &msg.CCAddrs, &msg.Date, &msg.CreatedAt,
-			&msg.BodyText, &msg.BodyHTML, &msg.Mailbox, &msg.Flags, &msg.UID, &msg.Size, &fetchedBody, &msg.Account,
+			&msg.FromAddr, &fromAddrCT, &msg.ToAddrs, &toAddrsCT, &msg.CCAddrs, &ccAddrsCT,
+			&msg.Date, &msg.CreatedAt,
+			&msg.BodyText, &bodyTextCT, &msg.BodyHTML, &bodyHTMLCT,
+			&msg.Mailbox, &msg.Flags, &msg.UID, &msg.Size, &fetchedBody, &msg.Account,
 		)
 		if err != nil {
 			return nil, fmt.Errorf("scan message: %w", err)
 		}
 		msg.FetchedBody = fetchedBody == 1
 		if msg.Subject, err = d.decryptSubject(msg.Subject, subjectCT); err != nil {
+			return nil, err
+		}
+		if msg.FromAddr, err = d.decryptAddr(msg.FromAddr, fromAddrCT); err != nil {
+			return nil, err
+		}
+		if msg.ToAddrs, err = d.decryptAddr(msg.ToAddrs, toAddrsCT); err != nil {
+			return nil, err
+		}
+		if msg.CCAddrs, err = d.decryptAddr(msg.CCAddrs, ccAddrsCT); err != nil {
+			return nil, err
+		}
+		if msg.BodyText, err = d.decryptBody(msg.BodyText, bodyTextCT); err != nil {
+			return nil, err
+		}
+		if msg.BodyHTML, err = d.decryptBody(msg.BodyHTML, bodyHTMLCT); err != nil {
 			return nil, err
 		}
 		msgs = append(msgs, msg)

--- a/cli/internal/store/outbox.go
+++ b/cli/internal/store/outbox.go
@@ -10,9 +10,13 @@ import (
 // sendAfter is a Unix timestamp before which the worker will not dequeue this item.
 // Use 0 for immediate sending.
 func (d *DB) Enqueue(draftJSON string, sendAfter int64) (int64, error) {
+	ct, err := d.encryptDraftJSON(draftJSON)
+	if err != nil {
+		return 0, fmt.Errorf("encrypt draft_json: %w", err)
+	}
 	result, err := d.db.Exec(
-		"INSERT INTO outbox (draft_json, created_at, send_after) VALUES (?, ?, ?)",
-		draftJSON, time.Now().Unix(), sendAfter)
+		"INSERT INTO outbox (draft_json, draft_json_ct, created_at, send_after) VALUES (?, ?, ?, ?)",
+		draftJSON, ct, time.Now().Unix(), sendAfter)
 	if err != nil {
 		return 0, fmt.Errorf("enqueue: %w", err)
 	}
@@ -27,14 +31,14 @@ func (d *DB) Enqueue(draftJSON string, sendAfter int64) (int64, error) {
 func (d *DB) Dequeue() (*OutboxItem, error) {
 	now := time.Now().Unix()
 	row := d.db.QueryRow(`
-		SELECT id, draft_json, attempts, last_error, created_at
+		SELECT id, draft_json, draft_json_ct, attempts, last_error, created_at
 		FROM outbox
 		WHERE attempts < 5
 		  AND send_after <= ?
 		  AND (attempts = 0 OR last_attempted_at + attempts * attempts * 30 <= ?)
 		ORDER BY attempts ASC, created_at ASC
 		LIMIT 1`, now, now)
-	return scanOutboxItem(row)
+	return d.scanOutboxItem(row)
 }
 
 // MarkAttempted increments the attempt count, records the error, and
@@ -76,7 +80,7 @@ func (d *DB) DeleteOutboxItem(id int64) error {
 // ListOutbox returns all outbox items ordered by creation time (newest first).
 func (d *DB) ListOutbox() ([]OutboxItem, error) {
 	rows, err := d.db.Query(`
-		SELECT id, draft_json, attempts, last_error, created_at
+		SELECT id, draft_json, draft_json_ct, attempts, last_error, created_at
 		FROM outbox
 		ORDER BY created_at DESC`)
 	if err != nil {
@@ -87,9 +91,13 @@ func (d *DB) ListOutbox() ([]OutboxItem, error) {
 	var items []OutboxItem
 	for rows.Next() {
 		var item OutboxItem
+		var ct []byte
 		var lastErr sql.NullString
-		if err := rows.Scan(&item.ID, &item.DraftJSON, &item.Attempts, &lastErr, &item.CreatedAt); err != nil {
+		if err := rows.Scan(&item.ID, &item.DraftJSON, &ct, &item.Attempts, &lastErr, &item.CreatedAt); err != nil {
 			return nil, fmt.Errorf("scan outbox item: %w", err)
+		}
+		if item.DraftJSON, err = d.decryptDraftJSON(item.DraftJSON, ct); err != nil {
+			return nil, err
 		}
 		if lastErr.Valid {
 			item.LastError = lastErr.String
@@ -99,16 +107,21 @@ func (d *DB) ListOutbox() ([]OutboxItem, error) {
 	return items, rows.Err()
 }
 
-// scanOutboxItem scans a single row into an OutboxItem.
-func scanOutboxItem(row *sql.Row) (*OutboxItem, error) {
+// scanOutboxItem scans a single row into an OutboxItem. The caller's
+// SELECT must place draft_json_ct directly after draft_json.
+func (d *DB) scanOutboxItem(row *sql.Row) (*OutboxItem, error) {
 	item := &OutboxItem{}
+	var ct []byte
 	var lastErr sql.NullString
-	err := row.Scan(&item.ID, &item.DraftJSON, &item.Attempts, &lastErr, &item.CreatedAt)
+	err := row.Scan(&item.ID, &item.DraftJSON, &ct, &item.Attempts, &lastErr, &item.CreatedAt)
 	if err == sql.ErrNoRows {
 		return nil, nil
 	}
 	if err != nil {
 		return nil, fmt.Errorf("scan outbox item: %w", err)
+	}
+	if item.DraftJSON, err = d.decryptDraftJSON(item.DraftJSON, ct); err != nil {
+		return nil, err
 	}
 	if lastErr.Valid {
 		item.LastError = lastErr.String

--- a/cli/internal/store/store.go
+++ b/cli/internal/store/store.go
@@ -181,6 +181,30 @@ func (d *DB) Init() error {
 			last_attempted_at INTEGER DEFAULT 0,
 			send_after INTEGER DEFAULT 0
 		)`,
+
+		// local_drafts was first added in the v6→v7 migration. Listing it
+		// here too keeps it created for any fresh DB regardless of which
+		// version Init() lands on, so later ALTER TABLE migrations don't
+		// trip on its absence in tests that seed schema_version > 7.
+		`CREATE TABLE IF NOT EXISTS local_drafts (
+			id TEXT PRIMARY KEY,
+			draft_json TEXT NOT NULL,
+			created_at INTEGER NOT NULL,
+			modified_at INTEGER NOT NULL
+		)`,
+
+		// mailboxes and accounts were first added in the v8→v9 migration
+		// (ADR-0001 step 1). Same idempotency story as local_drafts —
+		// keep them present here so seeds at schema_version > 9 don't
+		// fail later ALTER TABLE migrations that target them.
+		`CREATE TABLE IF NOT EXISTS mailboxes (
+			id INTEGER PRIMARY KEY AUTOINCREMENT,
+			name TEXT NOT NULL UNIQUE
+		)`,
+		`CREATE TABLE IF NOT EXISTS accounts (
+			id INTEGER PRIMARY KEY AUTOINCREMENT,
+			name TEXT NOT NULL UNIQUE
+		)`,
 	}
 
 	for _, stmt := range stmts {
@@ -566,6 +590,67 @@ func (d *DB) migrate() error {
 		if _, err := d.db.Exec("UPDATE schema_version SET version = 13 WHERE rowid = 1"); err != nil {
 			return fmt.Errorf("migrate v12→v13 bump: %w", err)
 		}
+		version = 13
+	}
+
+	if version < 14 {
+		// ADR-0001 step 6: encrypt local_drafts.draft_json and
+		// outbox.draft_json (draft_key). Two separate tables, same
+		// sub-key — both hold pending outgoing mail, both deserve at-rest
+		// protection. Schema is parallel ALTER on each table.
+		for _, table := range []string{"local_drafts", "outbox"} {
+			has, err := hasColumn(d.db, table, "draft_json_ct")
+			if err != nil {
+				return fmt.Errorf("migrate v13→v14 inspect %s.draft_json_ct: %w", table, err)
+			}
+			if !has {
+				if _, err := d.db.Exec("ALTER TABLE " + table + " ADD COLUMN draft_json_ct BLOB"); err != nil {
+					return fmt.Errorf("migrate v13→v14 add %s.draft_json_ct: %w", table, err)
+				}
+			}
+		}
+		if err := d.backfillDraftJSONCt(); err != nil {
+			return fmt.Errorf("migrate v13→v14 backfill: %w", err)
+		}
+		if _, err := d.db.Exec("UPDATE schema_version SET version = 14 WHERE rowid = 1"); err != nil {
+			return fmt.Errorf("migrate v13→v14 bump: %w", err)
+		}
+		version = 14
+	}
+
+	if version < 15 {
+		// ADR-0001 step 6: encrypt the meta_key columns — mailbox names
+		// (folder labels), account names, and the non-boolean parts of
+		// messages.flags. Plaintext columns stay alongside until step 7;
+		// reads keep using them. This commit just lays down the cipher-
+		// text columns plus encrypt-on-write for messages.flags_other.
+		//
+		// mailboxes.name and accounts.name have UNIQUE constraints that
+		// the encrypted (random-nonce) form cannot replicate, so the
+		// plaintext UNIQUE column stays as the lookup key until step 7
+		// introduces deterministic blind-tokens.
+		alters := []struct{ table, col string }{
+			{"mailboxes", "name_ct"},
+			{"accounts", "name_ct"},
+			{"messages", "flags_other"},
+		}
+		for _, a := range alters {
+			has, err := hasColumn(d.db, a.table, a.col)
+			if err != nil {
+				return fmt.Errorf("migrate v14→v15 inspect %s.%s: %w", a.table, a.col, err)
+			}
+			if !has {
+				if _, err := d.db.Exec("ALTER TABLE " + a.table + " ADD COLUMN " + a.col + " BLOB"); err != nil {
+					return fmt.Errorf("migrate v14→v15 add %s.%s: %w", a.table, a.col, err)
+				}
+			}
+		}
+		if err := d.backfillMetaCt(); err != nil {
+			return fmt.Errorf("migrate v14→v15 backfill: %w", err)
+		}
+		if _, err := d.db.Exec("UPDATE schema_version SET version = 15 WHERE rowid = 1"); err != nil {
+			return fmt.Errorf("migrate v14→v15 bump: %w", err)
+		}
 	}
 
 	return nil
@@ -766,6 +851,256 @@ func (d *DB) backfillBodyCt() error {
 		if _, err := stmt.Exec(textCT, htmlCT, p.id); err != nil {
 			return fmt.Errorf("update id=%d: %w", p.id, err)
 		}
+	}
+	return tx.Commit()
+}
+
+// encryptMeta seals plain with the meta sub-key (mailbox/account names,
+// non-boolean flag parts). Empty plaintext maps to nil → NULL column.
+func (d *DB) encryptMeta(plain string) ([]byte, error) {
+	if plain == "" {
+		return nil, nil
+	}
+	return dbcrypto.Encrypt(d.keyring.Meta, []byte(plain))
+}
+
+// decryptMeta returns plaintext for a meta_key column, falling back to
+// the plaintext column when ct IS NULL. Decrypt failures on non-nil ct
+// are hard errors. Not yet called by production reads — step 7 will wire
+// the lookup paths to prefer ct over the plaintext columns that die then.
+func (d *DB) decryptMeta(plain string, ct []byte) (string, error) {
+	if len(ct) == 0 {
+		return plain, nil
+	}
+	out, err := dbcrypto.Decrypt(d.keyring.Meta, ct)
+	if err != nil {
+		return "", fmt.Errorf("decrypt meta: %w", err)
+	}
+	return string(out), nil
+}
+
+// flagsOtherForEncryption returns the subset of a space-separated IMAP
+// flags string that ADR-0001 §3 marks for meta_key encryption: everything
+// except the three boolean-tracked standard flags (\Seen, \Flagged,
+// \Deleted) that already live as O(1) integer columns. The remaining
+// flags include \Answered, \Draft, \Recent, $Sensitive and any
+// user-defined keywords — all preserved verbatim in their original order.
+func flagsOtherForEncryption(flags string) string {
+	if flags == "" {
+		return ""
+	}
+	parts := strings.Fields(flags)
+	out := parts[:0]
+	for _, p := range parts {
+		switch p {
+		case `\Seen`, `\Flagged`, `\Deleted`:
+			// covered by is_seen/is_flagged/is_deleted booleans
+		default:
+			out = append(out, p)
+		}
+	}
+	return strings.Join(out, " ")
+}
+
+// backfillMetaCt encrypts existing mailbox names, account names, and the
+// non-boolean flags subset of each message into the new BLOB columns.
+// Single transaction across all three so a mid-loop failure rolls back
+// cleanly.
+func (d *DB) backfillMetaCt() error {
+	if d.keyring == nil || d.keyring.Meta == nil {
+		return fmt.Errorf("no keyring available for meta backfill")
+	}
+	tx, err := d.db.Begin()
+	if err != nil {
+		return fmt.Errorf("begin tx: %w", err)
+	}
+	defer tx.Rollback() //nolint:errcheck
+
+	// mailboxes + accounts share the same shape: id + name → name_ct.
+	for _, table := range []string{"mailboxes", "accounts"} {
+		rows, err := tx.Query(`SELECT id, name FROM ` + table + `
+			WHERE name IS NOT NULL AND name <> '' AND name_ct IS NULL`)
+		if err != nil {
+			return fmt.Errorf("select %s: %w", table, err)
+		}
+		type pending struct {
+			id   int64
+			name string
+		}
+		var batch []pending
+		for rows.Next() {
+			var p pending
+			if err := rows.Scan(&p.id, &p.name); err != nil {
+				rows.Close()
+				return fmt.Errorf("scan %s: %w", table, err)
+			}
+			batch = append(batch, p)
+		}
+		rows.Close()
+		if err := rows.Err(); err != nil {
+			return fmt.Errorf("iterate %s: %w", table, err)
+		}
+
+		stmt, err := tx.Prepare("UPDATE " + table + " SET name_ct = ? WHERE id = ?")
+		if err != nil {
+			return fmt.Errorf("prepare %s update: %w", table, err)
+		}
+		for _, p := range batch {
+			ct, err := d.encryptMeta(p.name)
+			if err != nil {
+				stmt.Close()
+				return fmt.Errorf("encrypt %s name id=%d: %w", table, p.id, err)
+			}
+			if _, err := stmt.Exec(ct, p.id); err != nil {
+				stmt.Close()
+				return fmt.Errorf("update %s id=%d: %w", table, p.id, err)
+			}
+		}
+		stmt.Close()
+	}
+
+	// messages.flags_other gets the non-boolean subset of the existing
+	// flags TEXT — booleans are already covered by is_{seen,flagged,deleted}.
+	rows, err := tx.Query(`SELECT id, flags FROM messages
+		WHERE flags IS NOT NULL AND flags <> '' AND flags_other IS NULL`)
+	if err != nil {
+		return fmt.Errorf("select messages: %w", err)
+	}
+	type pending struct {
+		id    int64
+		flags string
+	}
+	var batch []pending
+	for rows.Next() {
+		var p pending
+		if err := rows.Scan(&p.id, &p.flags); err != nil {
+			rows.Close()
+			return fmt.Errorf("scan messages: %w", err)
+		}
+		batch = append(batch, p)
+	}
+	rows.Close()
+	if err := rows.Err(); err != nil {
+		return fmt.Errorf("iterate messages: %w", err)
+	}
+
+	stmt, err := tx.Prepare("UPDATE messages SET flags_other = ? WHERE id = ?")
+	if err != nil {
+		return fmt.Errorf("prepare messages update: %w", err)
+	}
+	defer stmt.Close()
+	for _, p := range batch {
+		other := flagsOtherForEncryption(p.flags)
+		ct, err := d.encryptMeta(other)
+		if err != nil {
+			return fmt.Errorf("encrypt flags id=%d: %w", p.id, err)
+		}
+		if _, err := stmt.Exec(ct, p.id); err != nil {
+			return fmt.Errorf("update messages id=%d: %w", p.id, err)
+		}
+	}
+	return tx.Commit()
+}
+
+// encryptDraftJSON seals plain with the draft sub-key. Empty plaintext
+// maps to nil so draft_json_ct stays NULL — same convention as the other
+// encrypt* helpers.
+func (d *DB) encryptDraftJSON(plain string) ([]byte, error) {
+	if plain == "" {
+		return nil, nil
+	}
+	return dbcrypto.Encrypt(d.keyring.Draft, []byte(plain))
+}
+
+// decryptDraftJSON returns plaintext draft JSON, preferring ct when set.
+// Decrypt failures on non-nil ct are hard errors.
+func (d *DB) decryptDraftJSON(plain string, ct []byte) (string, error) {
+	if len(ct) == 0 {
+		return plain, nil
+	}
+	out, err := dbcrypto.Decrypt(d.keyring.Draft, ct)
+	if err != nil {
+		return "", fmt.Errorf("decrypt draft_json: %w", err)
+	}
+	return string(out), nil
+}
+
+// backfillDraftJSONCt encrypts every existing draft_json across both
+// local_drafts and outbox into their new draft_json_ct BLOB columns.
+// One transaction spans both tables so a mid-loop failure rolls back
+// cleanly. Volumes are small in practice (drafts plus pending sends)
+// so a single batch in RAM is fine.
+func (d *DB) backfillDraftJSONCt() error {
+	if d.keyring == nil || d.keyring.Draft == nil {
+		return fmt.Errorf("no keyring available for draft backfill")
+	}
+	tx, err := d.db.Begin()
+	if err != nil {
+		return fmt.Errorf("begin tx: %w", err)
+	}
+	defer tx.Rollback() //nolint:errcheck
+
+	// Two tables, same shape — fold them through one loop.
+	for _, table := range []struct {
+		name    string
+		pkCol   string // primary key column (TEXT for local_drafts, INTEGER for outbox)
+		pkScanT string // "string" or "int64"
+	}{
+		{"local_drafts", "id", "string"},
+		{"outbox", "id", "int64"},
+	} {
+		rows, err := tx.Query(`SELECT ` + table.pkCol + `, draft_json FROM ` + table.name + `
+			WHERE draft_json IS NOT NULL AND draft_json <> '' AND draft_json_ct IS NULL`)
+		if err != nil {
+			return fmt.Errorf("select %s: %w", table.name, err)
+		}
+		type pending struct {
+			idStr string
+			idInt int64
+			json  string
+		}
+		var batch []pending
+		for rows.Next() {
+			var p pending
+			if table.pkScanT == "string" {
+				if err := rows.Scan(&p.idStr, &p.json); err != nil {
+					rows.Close()
+					return fmt.Errorf("scan %s: %w", table.name, err)
+				}
+			} else {
+				if err := rows.Scan(&p.idInt, &p.json); err != nil {
+					rows.Close()
+					return fmt.Errorf("scan %s: %w", table.name, err)
+				}
+			}
+			batch = append(batch, p)
+		}
+		rows.Close()
+		if err := rows.Err(); err != nil {
+			return fmt.Errorf("iterate %s rows: %w", table.name, err)
+		}
+
+		stmt, err := tx.Prepare("UPDATE " + table.name + " SET draft_json_ct = ? WHERE " + table.pkCol + " = ?")
+		if err != nil {
+			return fmt.Errorf("prepare update %s: %w", table.name, err)
+		}
+		for _, p := range batch {
+			ct, err := d.encryptDraftJSON(p.json)
+			if err != nil {
+				stmt.Close()
+				return fmt.Errorf("encrypt %s draft: %w", table.name, err)
+			}
+			if table.pkScanT == "string" {
+				_, err = stmt.Exec(ct, p.idStr)
+			} else {
+				_, err = stmt.Exec(ct, p.idInt)
+			}
+			if err != nil {
+				stmt.Close()
+				return fmt.Errorf("update %s: %w", table.name, err)
+			}
+		}
+		stmt.Close()
 	}
 	return tx.Commit()
 }

--- a/cli/internal/store/store.go
+++ b/cli/internal/store/store.go
@@ -543,6 +543,29 @@ func (d *DB) migrate() error {
 		if _, err := d.db.Exec("UPDATE schema_version SET version = 12 WHERE rowid = 1"); err != nil {
 			return fmt.Errorf("migrate v11→v12 bump: %w", err)
 		}
+		version = 12
+	}
+
+	if version < 13 {
+		// ADR-0001 step 6: encrypt message_headers.value (headers_key).
+		// Header `name` stays plaintext — already a public registry
+		// (Return-Path, Authentication-Results, List-Unsubscribe, etc.)
+		// per ADR-0001 §3, and we need it for rule matching joins.
+		has, err := hasColumn(d.db, "message_headers", "value_ct")
+		if err != nil {
+			return fmt.Errorf("migrate v12→v13 inspect value_ct: %w", err)
+		}
+		if !has {
+			if _, err := d.db.Exec("ALTER TABLE message_headers ADD COLUMN value_ct BLOB"); err != nil {
+				return fmt.Errorf("migrate v12→v13 add value_ct: %w", err)
+			}
+		}
+		if err := d.backfillHeaderValueCt(); err != nil {
+			return fmt.Errorf("migrate v12→v13 backfill: %w", err)
+		}
+		if _, err := d.db.Exec("UPDATE schema_version SET version = 13 WHERE rowid = 1"); err != nil {
+			return fmt.Errorf("migrate v12→v13 bump: %w", err)
+		}
 	}
 
 	return nil
@@ -742,6 +765,86 @@ func (d *DB) backfillBodyCt() error {
 		}
 		if _, err := stmt.Exec(textCT, htmlCT, p.id); err != nil {
 			return fmt.Errorf("update id=%d: %w", p.id, err)
+		}
+	}
+	return tx.Commit()
+}
+
+// encryptHeaderValue seals plain with the headers sub-key. Empty plaintext
+// maps to nil so value_ct stays NULL — same convention as encryptSubject.
+func (d *DB) encryptHeaderValue(plain string) ([]byte, error) {
+	if plain == "" {
+		return nil, nil
+	}
+	return dbcrypto.Encrypt(d.keyring.Headers, []byte(plain))
+}
+
+// decryptHeaderValue returns the plaintext header value, preferring ct
+// when present. Decrypt failures on non-nil ct are hard errors.
+func (d *DB) decryptHeaderValue(plain string, ct []byte) (string, error) {
+	if len(ct) == 0 {
+		return plain, nil
+	}
+	out, err := dbcrypto.Decrypt(d.keyring.Headers, ct)
+	if err != nil {
+		return "", fmt.Errorf("decrypt header value: %w", err)
+	}
+	return string(out), nil
+}
+
+// backfillHeaderValueCt encrypts every existing message_headers.value into
+// the new value_ct BLOB column. Single transaction so a mid-loop failure
+// rolls back and leaves schema_version unbumped. message_headers can be
+// 5-10x the messages row count (each message has several persisted
+// headers); the prepared-statement loop keeps per-row overhead minimal.
+func (d *DB) backfillHeaderValueCt() error {
+	if d.keyring == nil || d.keyring.Headers == nil {
+		return fmt.Errorf("no keyring available for header backfill")
+	}
+	tx, err := d.db.Begin()
+	if err != nil {
+		return fmt.Errorf("begin tx: %w", err)
+	}
+	defer tx.Rollback() //nolint:errcheck
+
+	// message_headers has a composite PK (message_id, name) — both are
+	// needed to address the row in the UPDATE.
+	rows, err := tx.Query(`SELECT message_id, name, value FROM message_headers
+		WHERE value IS NOT NULL AND value <> '' AND value_ct IS NULL`)
+	if err != nil {
+		return fmt.Errorf("select rows: %w", err)
+	}
+	type pending struct {
+		messageID int64
+		name      string
+		value     string
+	}
+	var batch []pending
+	for rows.Next() {
+		var p pending
+		if err := rows.Scan(&p.messageID, &p.name, &p.value); err != nil {
+			rows.Close()
+			return fmt.Errorf("scan: %w", err)
+		}
+		batch = append(batch, p)
+	}
+	rows.Close()
+	if err := rows.Err(); err != nil {
+		return fmt.Errorf("iterate rows: %w", err)
+	}
+
+	stmt, err := tx.Prepare("UPDATE message_headers SET value_ct = ? WHERE message_id = ? AND name = ?")
+	if err != nil {
+		return fmt.Errorf("prepare update: %w", err)
+	}
+	defer stmt.Close()
+	for _, p := range batch {
+		ct, err := d.encryptHeaderValue(p.value)
+		if err != nil {
+			return fmt.Errorf("encrypt header (%d/%s): %w", p.messageID, p.name, err)
+		}
+		if _, err := stmt.Exec(ct, p.messageID, p.name); err != nil {
+			return fmt.Errorf("update (%d/%s): %w", p.messageID, p.name, err)
 		}
 	}
 	return tx.Commit()

--- a/cli/internal/store/store.go
+++ b/cli/internal/store/store.go
@@ -487,6 +487,62 @@ func (d *DB) migrate() error {
 		if _, err := d.db.Exec("UPDATE schema_version SET version = 10 WHERE rowid = 1"); err != nil {
 			return fmt.Errorf("migrate v9→v10 bump: %w", err)
 		}
+		version = 10
+	}
+
+	if version < 11 {
+		// ADR-0001 step 6: extend pilot encryption to messages.body_text
+		// and messages.body_html. Same pattern as v10 (subject) — two new
+		// BLOB columns, plaintext columns stay so FTS5 keeps indexing
+		// body_text until the step-7 rebuild.
+		for _, col := range []string{"body_text_ct", "body_html_ct"} {
+			has, err := hasColumn(d.db, "messages", col)
+			if err != nil {
+				return fmt.Errorf("migrate v10→v11 inspect %s: %w", col, err)
+			}
+			if !has {
+				if _, err := d.db.Exec("ALTER TABLE messages ADD COLUMN " + col + " BLOB"); err != nil {
+					return fmt.Errorf("migrate v10→v11 add %s: %w", col, err)
+				}
+			}
+		}
+		if err := d.backfillBodyCt(); err != nil {
+			return fmt.Errorf("migrate v10→v11 backfill: %w", err)
+		}
+		if _, err := d.db.Exec("UPDATE schema_version SET version = 11 WHERE rowid = 1"); err != nil {
+			return fmt.Errorf("migrate v10→v11 bump: %w", err)
+		}
+		version = 11
+	}
+
+	if version < 12 {
+		// ADR-0001 step 6: extend encryption to messages.from_addr,
+		// to_addrs, cc_addrs (addrs_key). Same column-doubling pattern;
+		// plaintext columns stay so FTS5 keeps indexing from_addr/to_addrs
+		// and search.go's GROUP_CONCAT(from_addr) AS authors keeps working
+		// until step 7.
+		//
+		// idx_messages_from_addr is intentionally NOT dropped yet — the
+		// plaintext column it covers still exists and powers GetSenderCounts
+		// + search. ADR-0001 §3 schedules that index drop for step 7 when
+		// the plaintext column itself goes.
+		for _, col := range []string{"from_addr_ct", "to_addrs_ct", "cc_addrs_ct"} {
+			has, err := hasColumn(d.db, "messages", col)
+			if err != nil {
+				return fmt.Errorf("migrate v11→v12 inspect %s: %w", col, err)
+			}
+			if !has {
+				if _, err := d.db.Exec("ALTER TABLE messages ADD COLUMN " + col + " BLOB"); err != nil {
+					return fmt.Errorf("migrate v11→v12 add %s: %w", col, err)
+				}
+			}
+		}
+		if err := d.backfillAddrsCt(); err != nil {
+			return fmt.Errorf("migrate v11→v12 backfill: %w", err)
+		}
+		if _, err := d.db.Exec("UPDATE schema_version SET version = 12 WHERE rowid = 1"); err != nil {
+			return fmt.Errorf("migrate v11→v12 bump: %w", err)
+		}
 	}
 
 	return nil
@@ -595,6 +651,183 @@ func (d *DB) backfillSubjectCt() error {
 			return fmt.Errorf("encrypt id=%d: %w", p.id, err)
 		}
 		if _, err := stmt.Exec(ct, p.id); err != nil {
+			return fmt.Errorf("update id=%d: %w", p.id, err)
+		}
+	}
+	return tx.Commit()
+}
+
+// encryptBody seals plain with the body sub-key. Empty plaintext maps to
+// nil so the ct column stays NULL — same convention as encryptSubject.
+func (d *DB) encryptBody(plain string) ([]byte, error) {
+	if plain == "" {
+		return nil, nil
+	}
+	return dbcrypto.Encrypt(d.keyring.Body, []byte(plain))
+}
+
+// decryptBody returns the plaintext body for a row, preferring the
+// encrypted ciphertext when present and falling back to the plaintext
+// column only when ct IS NULL (legacy/unmigrated rows). Decrypt failures
+// on a non-nil ct are hard errors — silent fallback would mask a
+// key/cipher mismatch and become data loss in step 7.
+func (d *DB) decryptBody(plain string, ct []byte) (string, error) {
+	if len(ct) == 0 {
+		return plain, nil
+	}
+	out, err := dbcrypto.Decrypt(d.keyring.Body, ct)
+	if err != nil {
+		return "", fmt.Errorf("decrypt body: %w", err)
+	}
+	return string(out), nil
+}
+
+// backfillBodyCt encrypts every existing messages.body_text and
+// body_html into the new BLOB columns. Single transaction so a mid-loop
+// failure rolls back and leaves schema_version unbumped — next Init()
+// retries the migration from scratch.
+//
+// Bodies can be large (KB to MB); we still load the whole batch into RAM
+// before the UPDATE pass to keep the row + tx-prepared-statement lifetimes
+// simple. Memory cap on a typical mailbox (~50k rows × ~50 KB avg) is in
+// the hundreds-of-MB range, acceptable for a one-shot migration.
+func (d *DB) backfillBodyCt() error {
+	if d.keyring == nil || d.keyring.Body == nil {
+		return fmt.Errorf("no keyring available for body backfill")
+	}
+	tx, err := d.db.Begin()
+	if err != nil {
+		return fmt.Errorf("begin tx: %w", err)
+	}
+	defer tx.Rollback() //nolint:errcheck // rolled back if Commit not reached
+
+	rows, err := tx.Query(`SELECT id, body_text, body_html FROM messages
+		WHERE (body_text IS NOT NULL AND body_text <> '' AND body_text_ct IS NULL)
+		   OR (body_html IS NOT NULL AND body_html <> '' AND body_html_ct IS NULL)`)
+	if err != nil {
+		return fmt.Errorf("select rows: %w", err)
+	}
+	type pending struct {
+		id       int64
+		bodyText string
+		bodyHTML string
+	}
+	var batch []pending
+	for rows.Next() {
+		var p pending
+		if err := rows.Scan(&p.id, &p.bodyText, &p.bodyHTML); err != nil {
+			rows.Close()
+			return fmt.Errorf("scan: %w", err)
+		}
+		batch = append(batch, p)
+	}
+	rows.Close()
+	if err := rows.Err(); err != nil {
+		return fmt.Errorf("iterate rows: %w", err)
+	}
+
+	stmt, err := tx.Prepare("UPDATE messages SET body_text_ct = ?, body_html_ct = ? WHERE id = ?")
+	if err != nil {
+		return fmt.Errorf("prepare update: %w", err)
+	}
+	defer stmt.Close()
+	for _, p := range batch {
+		textCT, err := d.encryptBody(p.bodyText)
+		if err != nil {
+			return fmt.Errorf("encrypt body_text id=%d: %w", p.id, err)
+		}
+		htmlCT, err := d.encryptBody(p.bodyHTML)
+		if err != nil {
+			return fmt.Errorf("encrypt body_html id=%d: %w", p.id, err)
+		}
+		if _, err := stmt.Exec(textCT, htmlCT, p.id); err != nil {
+			return fmt.Errorf("update id=%d: %w", p.id, err)
+		}
+	}
+	return tx.Commit()
+}
+
+// encryptAddr seals plain with the addrs sub-key. Empty plaintext maps to
+// nil so the ct column stays NULL — same convention as encryptSubject.
+func (d *DB) encryptAddr(plain string) ([]byte, error) {
+	if plain == "" {
+		return nil, nil
+	}
+	return dbcrypto.Encrypt(d.keyring.Addrs, []byte(plain))
+}
+
+// decryptAddr returns the plaintext address for a row, preferring the
+// encrypted ciphertext and falling back to the plaintext column only when
+// ct IS NULL. Decrypt failures on non-nil ct are hard errors.
+func (d *DB) decryptAddr(plain string, ct []byte) (string, error) {
+	if len(ct) == 0 {
+		return plain, nil
+	}
+	out, err := dbcrypto.Decrypt(d.keyring.Addrs, ct)
+	if err != nil {
+		return "", fmt.Errorf("decrypt addr: %w", err)
+	}
+	return string(out), nil
+}
+
+// backfillAddrsCt encrypts every existing from_addr / to_addrs / cc_addrs
+// into the new BLOB columns. Single transaction so a mid-loop failure
+// rolls back cleanly. Rows where all three are empty/NULL are skipped so
+// their *_ct columns stay NULL.
+func (d *DB) backfillAddrsCt() error {
+	if d.keyring == nil || d.keyring.Addrs == nil {
+		return fmt.Errorf("no keyring available for addrs backfill")
+	}
+	tx, err := d.db.Begin()
+	if err != nil {
+		return fmt.Errorf("begin tx: %w", err)
+	}
+	defer tx.Rollback() //nolint:errcheck // rolled back if Commit not reached
+
+	rows, err := tx.Query(`SELECT id, from_addr, to_addrs, cc_addrs FROM messages
+		WHERE (from_addr IS NOT NULL AND from_addr <> '' AND from_addr_ct IS NULL)
+		   OR (to_addrs  IS NOT NULL AND to_addrs  <> '' AND to_addrs_ct  IS NULL)
+		   OR (cc_addrs  IS NOT NULL AND cc_addrs  <> '' AND cc_addrs_ct  IS NULL)`)
+	if err != nil {
+		return fmt.Errorf("select rows: %w", err)
+	}
+	type pending struct {
+		id                       int64
+		fromAddr, toAddrs, ccAddrs string
+	}
+	var batch []pending
+	for rows.Next() {
+		var p pending
+		if err := rows.Scan(&p.id, &p.fromAddr, &p.toAddrs, &p.ccAddrs); err != nil {
+			rows.Close()
+			return fmt.Errorf("scan: %w", err)
+		}
+		batch = append(batch, p)
+	}
+	rows.Close()
+	if err := rows.Err(); err != nil {
+		return fmt.Errorf("iterate rows: %w", err)
+	}
+
+	stmt, err := tx.Prepare("UPDATE messages SET from_addr_ct = ?, to_addrs_ct = ?, cc_addrs_ct = ? WHERE id = ?")
+	if err != nil {
+		return fmt.Errorf("prepare update: %w", err)
+	}
+	defer stmt.Close()
+	for _, p := range batch {
+		fromCT, err := d.encryptAddr(p.fromAddr)
+		if err != nil {
+			return fmt.Errorf("encrypt from_addr id=%d: %w", p.id, err)
+		}
+		toCT, err := d.encryptAddr(p.toAddrs)
+		if err != nil {
+			return fmt.Errorf("encrypt to_addrs id=%d: %w", p.id, err)
+		}
+		ccCT, err := d.encryptAddr(p.ccAddrs)
+		if err != nil {
+			return fmt.Errorf("encrypt cc_addrs id=%d: %w", p.id, err)
+		}
+		if _, err := stmt.Exec(fromCT, toCT, ccCT, p.id); err != nil {
 			return fmt.Errorf("update id=%d: %w", p.id, err)
 		}
 	}

--- a/cli/internal/store/store_test.go
+++ b/cli/internal/store/store_test.go
@@ -42,8 +42,8 @@ func TestOpenAndInit(t *testing.T) {
 	if err != nil {
 		t.Fatalf("read version: %v", err)
 	}
-	if version != 12 {
-		t.Errorf("version = %d, want 12", version)
+	if version != 13 {
+		t.Errorf("version = %d, want 13", version)
 	}
 }
 
@@ -168,8 +168,8 @@ func TestMigrateV9_PopulatesMailboxesAndAccounts(t *testing.T) {
 	if err := db.QueryRow("SELECT version FROM schema_version WHERE rowid = 1").Scan(&version); err != nil {
 		t.Fatalf("read version: %v", err)
 	}
-	if version != 12 {
-		t.Fatalf("version = %d, want 12", version)
+	if version != 13 {
+		t.Fatalf("version = %d, want 13", version)
 	}
 
 	// mailboxes must contain exactly INBOX and Drafts (case-collapsed).
@@ -349,8 +349,8 @@ func TestMigrateV10_BackfillsSubjectCt(t *testing.T) {
 	if err := sd.db.QueryRow("SELECT version FROM schema_version WHERE rowid = 1").Scan(&version); err != nil {
 		t.Fatalf("read version: %v", err)
 	}
-	if version != 12 {
-		t.Fatalf("version = %d, want 12", version)
+	if version != 13 {
+		t.Fatalf("version = %d, want 13", version)
 	}
 
 	// Raw check: subject_ct must be NULL for empty subject, non-NULL for the
@@ -483,8 +483,8 @@ func TestMigrateV11_BackfillsBodyCt(t *testing.T) {
 	if err := sd.db.QueryRow("SELECT version FROM schema_version WHERE rowid = 1").Scan(&version); err != nil {
 		t.Fatalf("read version: %v", err)
 	}
-	if version != 12 {
-		t.Fatalf("version = %d, want 12", version)
+	if version != 13 {
+		t.Fatalf("version = %d, want 13", version)
 	}
 
 	// Raw check: body_text_ct populated only where body_text non-empty.
@@ -624,8 +624,8 @@ func TestMigrateV12_BackfillsAddrsCt(t *testing.T) {
 	if err := sd.db.QueryRow("SELECT version FROM schema_version WHERE rowid = 1").Scan(&version); err != nil {
 		t.Fatalf("read version: %v", err)
 	}
-	if version != 12 {
-		t.Fatalf("version = %d, want 12", version)
+	if version != 13 {
+		t.Fatalf("version = %d, want 13", version)
 	}
 
 	rows, err := sd.db.Query(`SELECT message_id, from_addr, from_addr_ct,

--- a/cli/internal/store/store_test.go
+++ b/cli/internal/store/store_test.go
@@ -42,8 +42,8 @@ func TestOpenAndInit(t *testing.T) {
 	if err != nil {
 		t.Fatalf("read version: %v", err)
 	}
-	if version != 10 {
-		t.Errorf("version = %d, want 10", version)
+	if version != 12 {
+		t.Errorf("version = %d, want 12", version)
 	}
 }
 
@@ -168,8 +168,8 @@ func TestMigrateV9_PopulatesMailboxesAndAccounts(t *testing.T) {
 	if err := db.QueryRow("SELECT version FROM schema_version WHERE rowid = 1").Scan(&version); err != nil {
 		t.Fatalf("read version: %v", err)
 	}
-	if version != 10 {
-		t.Fatalf("version = %d, want 10", version)
+	if version != 12 {
+		t.Fatalf("version = %d, want 12", version)
 	}
 
 	// mailboxes must contain exactly INBOX and Drafts (case-collapsed).
@@ -349,8 +349,8 @@ func TestMigrateV10_BackfillsSubjectCt(t *testing.T) {
 	if err := sd.db.QueryRow("SELECT version FROM schema_version WHERE rowid = 1").Scan(&version); err != nil {
 		t.Fatalf("read version: %v", err)
 	}
-	if version != 10 {
-		t.Fatalf("version = %d, want 10", version)
+	if version != 12 {
+		t.Fatalf("version = %d, want 12", version)
 	}
 
 	// Raw check: subject_ct must be NULL for empty subject, non-NULL for the
@@ -398,6 +398,294 @@ func TestMigrateV10_BackfillsSubjectCt(t *testing.T) {
 		}
 		if msg.Subject != want.subject {
 			t.Errorf("%s: read subject %q, want %q", want.id, msg.Subject, want.subject)
+		}
+	}
+}
+
+// TestMigrateV11_BackfillsBodyCt seeds a v10-shaped DB with a mix of
+// body_text/body_html populations and asserts the v10→v11 migration
+// encrypts only the non-empty ones, leaves the rest NULL, and that
+// GetByMessageID round-trips through decryptBody.
+func TestMigrateV11_BackfillsBodyCt(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "step6a.db")
+
+	seedDB, err := sql.Open("sqlite", dbPath)
+	if err != nil {
+		t.Fatalf("open seed: %v", err)
+	}
+	seed := []string{
+		`CREATE TABLE schema_version (version INTEGER NOT NULL)`,
+		`INSERT INTO schema_version (rowid, version) VALUES (1, 10)`,
+		`CREATE TABLE messages (
+			id INTEGER PRIMARY KEY AUTOINCREMENT,
+			message_id TEXT NOT NULL,
+			thread_id TEXT NOT NULL,
+			in_reply_to TEXT,
+			refs TEXT,
+			subject TEXT,
+			subject_ct BLOB,
+			from_addr TEXT,
+			to_addrs TEXT,
+			cc_addrs TEXT,
+			date INTEGER,
+			created_at INTEGER NOT NULL,
+			body_text TEXT,
+			body_html TEXT,
+			mailbox TEXT,
+			flags TEXT,
+			uid INTEGER DEFAULT 0,
+			size INTEGER DEFAULT 0,
+			fetched_body INTEGER DEFAULT 0,
+			account TEXT DEFAULT '',
+			mailbox_id INTEGER,
+			account_id INTEGER,
+			is_seen INTEGER NOT NULL DEFAULT 0,
+			is_flagged INTEGER NOT NULL DEFAULT 0,
+			is_deleted INTEGER NOT NULL DEFAULT 0,
+			UNIQUE(message_id, account)
+		)`,
+		`INSERT INTO messages (message_id, thread_id, in_reply_to, refs, subject,
+		    from_addr, to_addrs, cc_addrs, date, created_at,
+		    body_text, body_html, mailbox, flags) VALUES
+		   ('m1', 't1', '', '', '', '', '', '', 0, 1, 'plain text body only', '',          '', ''),
+		   ('m2', 't2', '', '', '', '', '', '', 0, 2, '',                     '<p>html</p>','', ''),
+		   ('m3', 't3', '', '', '', '', '', '', 0, 3, 'both formats',         '<p>both</p>','', ''),
+		   ('m4', 't4', '', '', '', '', '', '', 0, 4, '',                     '',          '', '')`,
+		// FTS5 + content for the AU trigger to operate on. step 5/10 wrote
+		// subject_ct via migration; step 6a leaves both columns plaintext
+		// in this seed because the rows have empty subjects.
+		`CREATE VIRTUAL TABLE messages_fts USING fts5(
+			subject, from_addr, to_addrs, body_text,
+			content='messages',
+			content_rowid='id'
+		)`,
+		`INSERT INTO messages_fts(rowid, subject, from_addr, to_addrs, body_text)
+		 SELECT id, subject, COALESCE(from_addr, ''), COALESCE(to_addrs, ''), COALESCE(body_text, '')
+		 FROM messages`,
+	}
+	for _, stmt := range seed {
+		if _, err := seedDB.Exec(stmt); err != nil {
+			t.Fatalf("seed: %v\nstmt: %s", err, stmt)
+		}
+	}
+	seedDB.Close()
+
+	sd, err := Open(dbPath, testKeyring(t))
+	if err != nil {
+		t.Fatalf("store open: %v", err)
+	}
+	t.Cleanup(func() { sd.Close() })
+	if err := sd.Init(); err != nil {
+		t.Fatalf("init/migrate: %v", err)
+	}
+
+	var version int
+	if err := sd.db.QueryRow("SELECT version FROM schema_version WHERE rowid = 1").Scan(&version); err != nil {
+		t.Fatalf("read version: %v", err)
+	}
+	if version != 12 {
+		t.Fatalf("version = %d, want 12", version)
+	}
+
+	// Raw check: body_text_ct populated only where body_text non-empty.
+	rows, err := sd.db.Query(`SELECT message_id, body_text, body_text_ct, body_html, body_html_ct
+		FROM messages ORDER BY message_id`)
+	if err != nil {
+		t.Fatalf("query messages: %v", err)
+	}
+	defer rows.Close()
+	type row struct {
+		id           string
+		text, html   string
+		textCT, htmlCT []byte
+	}
+	var got []row
+	for rows.Next() {
+		var r row
+		if err := rows.Scan(&r.id, &r.text, &r.textCT, &r.html, &r.htmlCT); err != nil {
+			t.Fatalf("scan: %v", err)
+		}
+		got = append(got, r)
+	}
+	if len(got) != 4 {
+		t.Fatalf("messages = %d, want 4", len(got))
+	}
+	// m1: text only
+	if got[0].text == "" || len(got[0].textCT) == 0 || got[0].htmlCT != nil {
+		t.Errorf("m1 unexpected: text=%q textCT.len=%d htmlCT=%v", got[0].text, len(got[0].textCT), got[0].htmlCT)
+	}
+	// m2: html only
+	if got[1].textCT != nil || len(got[1].htmlCT) == 0 {
+		t.Errorf("m2 unexpected: textCT=%v htmlCT.len=%d", got[1].textCT, len(got[1].htmlCT))
+	}
+	// m3: both
+	if len(got[2].textCT) == 0 || len(got[2].htmlCT) == 0 {
+		t.Errorf("m3 unexpected: textCT.len=%d htmlCT.len=%d", len(got[2].textCT), len(got[2].htmlCT))
+	}
+	// m4: neither
+	if got[3].textCT != nil || got[3].htmlCT != nil {
+		t.Errorf("m4 unexpected: textCT=%v htmlCT=%v", got[3].textCT, got[3].htmlCT)
+	}
+
+	// Round-trip via production read path.
+	for _, want := range got {
+		msg, err := sd.GetByMessageID(want.id)
+		if err != nil {
+			t.Fatalf("get %s: %v", want.id, err)
+		}
+		if msg == nil {
+			t.Fatalf("get %s: nil", want.id)
+		}
+		if msg.BodyText != want.text {
+			t.Errorf("%s: body_text=%q, want %q", want.id, msg.BodyText, want.text)
+		}
+		if msg.BodyHTML != want.html {
+			t.Errorf("%s: body_html=%q, want %q", want.id, msg.BodyHTML, want.html)
+		}
+	}
+}
+
+// TestMigrateV12_BackfillsAddrsCt seeds a v11-shaped DB with a mix of
+// from/to/cc populations and asserts the v11→v12 migration encrypts
+// only the non-empty addresses, leaves the rest NULL, and that
+// GetByMessageID round-trips through decryptAddr.
+func TestMigrateV12_BackfillsAddrsCt(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "step6-addrs.db")
+	seedDB, err := sql.Open("sqlite", dbPath)
+	if err != nil {
+		t.Fatalf("open seed: %v", err)
+	}
+	seed := []string{
+		`CREATE TABLE schema_version (version INTEGER NOT NULL)`,
+		`INSERT INTO schema_version (rowid, version) VALUES (1, 11)`,
+		`CREATE TABLE messages (
+			id INTEGER PRIMARY KEY AUTOINCREMENT,
+			message_id TEXT NOT NULL,
+			thread_id TEXT NOT NULL,
+			in_reply_to TEXT,
+			refs TEXT,
+			subject TEXT,
+			subject_ct BLOB,
+			from_addr TEXT,
+			to_addrs TEXT,
+			cc_addrs TEXT,
+			date INTEGER,
+			created_at INTEGER NOT NULL,
+			body_text TEXT,
+			body_text_ct BLOB,
+			body_html TEXT,
+			body_html_ct BLOB,
+			mailbox TEXT,
+			flags TEXT,
+			uid INTEGER DEFAULT 0,
+			size INTEGER DEFAULT 0,
+			fetched_body INTEGER DEFAULT 0,
+			account TEXT DEFAULT '',
+			mailbox_id INTEGER,
+			account_id INTEGER,
+			is_seen INTEGER NOT NULL DEFAULT 0,
+			is_flagged INTEGER NOT NULL DEFAULT 0,
+			is_deleted INTEGER NOT NULL DEFAULT 0,
+			UNIQUE(message_id, account)
+		)`,
+		`INSERT INTO messages (message_id, thread_id, in_reply_to, refs, subject,
+		    from_addr, to_addrs, cc_addrs, date, created_at,
+		    body_text, body_html, mailbox, flags) VALUES
+		   ('m1', 't1', '', '', '', 'a@x.com',  'b@x.com',  '',         0, 1, '', '', '', ''),
+		   ('m2', 't2', '', '', '', '',         '',         'c@x.com',  0, 2, '', '', '', ''),
+		   ('m3', 't3', '', '', '', 'a@x.com',  'b@x.com',  'c@x.com',  0, 3, '', '', '', ''),
+		   ('m4', 't4', '', '', '', '',         '',         '',         0, 4, '', '', '', '')`,
+		`CREATE VIRTUAL TABLE messages_fts USING fts5(
+			subject, from_addr, to_addrs, body_text,
+			content='messages',
+			content_rowid='id'
+		)`,
+		`INSERT INTO messages_fts(rowid, subject, from_addr, to_addrs, body_text)
+		 SELECT id, COALESCE(subject, ''), COALESCE(from_addr, ''), COALESCE(to_addrs, ''), COALESCE(body_text, '')
+		 FROM messages`,
+	}
+	for _, stmt := range seed {
+		if _, err := seedDB.Exec(stmt); err != nil {
+			t.Fatalf("seed: %v\nstmt: %s", err, stmt)
+		}
+	}
+	seedDB.Close()
+
+	sd, err := Open(dbPath, testKeyring(t))
+	if err != nil {
+		t.Fatalf("store open: %v", err)
+	}
+	t.Cleanup(func() { sd.Close() })
+	if err := sd.Init(); err != nil {
+		t.Fatalf("init/migrate: %v", err)
+	}
+
+	var version int
+	if err := sd.db.QueryRow("SELECT version FROM schema_version WHERE rowid = 1").Scan(&version); err != nil {
+		t.Fatalf("read version: %v", err)
+	}
+	if version != 12 {
+		t.Fatalf("version = %d, want 12", version)
+	}
+
+	rows, err := sd.db.Query(`SELECT message_id, from_addr, from_addr_ct,
+		to_addrs, to_addrs_ct, cc_addrs, cc_addrs_ct
+		FROM messages ORDER BY message_id`)
+	if err != nil {
+		t.Fatalf("query: %v", err)
+	}
+	defer rows.Close()
+	type row struct {
+		id                                       string
+		from, to, cc                             string
+		fromCT, toCT, ccCT                       []byte
+	}
+	var got []row
+	for rows.Next() {
+		var r row
+		if err := rows.Scan(&r.id, &r.from, &r.fromCT, &r.to, &r.toCT, &r.cc, &r.ccCT); err != nil {
+			t.Fatalf("scan: %v", err)
+		}
+		got = append(got, r)
+	}
+	if len(got) != 4 {
+		t.Fatalf("rows = %d, want 4", len(got))
+	}
+	checks := []struct {
+		idx                                 int
+		wantFromCT, wantToCT, wantCCCT bool
+	}{
+		{0, true, true, false},
+		{1, false, false, true},
+		{2, true, true, true},
+		{3, false, false, false},
+	}
+	for _, c := range checks {
+		r := got[c.idx]
+		if (len(r.fromCT) > 0) != c.wantFromCT {
+			t.Errorf("%s from_addr_ct populated=%v, want %v", r.id, len(r.fromCT) > 0, c.wantFromCT)
+		}
+		if (len(r.toCT) > 0) != c.wantToCT {
+			t.Errorf("%s to_addrs_ct populated=%v, want %v", r.id, len(r.toCT) > 0, c.wantToCT)
+		}
+		if (len(r.ccCT) > 0) != c.wantCCCT {
+			t.Errorf("%s cc_addrs_ct populated=%v, want %v", r.id, len(r.ccCT) > 0, c.wantCCCT)
+		}
+	}
+
+	// Round-trip via the production read path.
+	for _, want := range got {
+		msg, err := sd.GetByMessageID(want.id)
+		if err != nil {
+			t.Fatalf("get %s: %v", want.id, err)
+		}
+		if msg == nil {
+			t.Fatalf("get %s: nil", want.id)
+		}
+		if msg.FromAddr != want.from || msg.ToAddrs != want.to || msg.CCAddrs != want.cc {
+			t.Errorf("%s addrs mismatch: got (%q/%q/%q), want (%q/%q/%q)",
+				want.id, msg.FromAddr, msg.ToAddrs, msg.CCAddrs,
+				want.from, want.to, want.cc)
 		}
 	}
 }

--- a/cli/internal/store/store_test.go
+++ b/cli/internal/store/store_test.go
@@ -42,8 +42,8 @@ func TestOpenAndInit(t *testing.T) {
 	if err != nil {
 		t.Fatalf("read version: %v", err)
 	}
-	if version != 13 {
-		t.Errorf("version = %d, want 13", version)
+	if version != 15 {
+		t.Errorf("version = %d, want 15", version)
 	}
 }
 
@@ -168,8 +168,8 @@ func TestMigrateV9_PopulatesMailboxesAndAccounts(t *testing.T) {
 	if err := db.QueryRow("SELECT version FROM schema_version WHERE rowid = 1").Scan(&version); err != nil {
 		t.Fatalf("read version: %v", err)
 	}
-	if version != 13 {
-		t.Fatalf("version = %d, want 13", version)
+	if version != 15 {
+		t.Fatalf("version = %d, want 15", version)
 	}
 
 	// mailboxes must contain exactly INBOX and Drafts (case-collapsed).
@@ -349,8 +349,8 @@ func TestMigrateV10_BackfillsSubjectCt(t *testing.T) {
 	if err := sd.db.QueryRow("SELECT version FROM schema_version WHERE rowid = 1").Scan(&version); err != nil {
 		t.Fatalf("read version: %v", err)
 	}
-	if version != 13 {
-		t.Fatalf("version = %d, want 13", version)
+	if version != 15 {
+		t.Fatalf("version = %d, want 15", version)
 	}
 
 	// Raw check: subject_ct must be NULL for empty subject, non-NULL for the
@@ -483,8 +483,8 @@ func TestMigrateV11_BackfillsBodyCt(t *testing.T) {
 	if err := sd.db.QueryRow("SELECT version FROM schema_version WHERE rowid = 1").Scan(&version); err != nil {
 		t.Fatalf("read version: %v", err)
 	}
-	if version != 13 {
-		t.Fatalf("version = %d, want 13", version)
+	if version != 15 {
+		t.Fatalf("version = %d, want 15", version)
 	}
 
 	// Raw check: body_text_ct populated only where body_text non-empty.
@@ -624,8 +624,8 @@ func TestMigrateV12_BackfillsAddrsCt(t *testing.T) {
 	if err := sd.db.QueryRow("SELECT version FROM schema_version WHERE rowid = 1").Scan(&version); err != nil {
 		t.Fatalf("read version: %v", err)
 	}
-	if version != 13 {
-		t.Fatalf("version = %d, want 13", version)
+	if version != 15 {
+		t.Fatalf("version = %d, want 15", version)
 	}
 
 	rows, err := sd.db.Query(`SELECT message_id, from_addr, from_addr_ct,


### PR DESCRIPTION
## Summary

Extends ADR-0001 pilot encryption from step 5's `messages.subject` to the rest of the encrypted-column registry in **`messages.db`**. Three commits, sharing the same encrypt-on-write / decrypt-on-read pattern as step 5. Contacts (the only ADR §3 column-group left) is the stacked follow-up PR.

| Commit | Migration | Columns | Sub-key |
|---|---|---|---|
| 1 | v10→v12 | `body_text`+`body_html`, then `from_addr`+`to_addrs`+`cc_addrs` (combined commit, see note) | `body`, `addrs` |
| 2 | v12→v13 | `message_headers.value` | `headers` |
| 3 | v13→v15 | `local_drafts.draft_json`+`outbox.draft_json`, then `mailboxes.name`+`accounts.name`+`messages.flags_other` (combined) | `draft`, `meta` |

**Note on combined commits**: commits 1 and 3 each bundle two column-groups (missed a `jj new` between them while iterating). All content documented in commit bodies. Per-column-group granularity preserved; the diff is still cleanly traceable.

## Live migration on prod email.db (979 MB → 1.7 GB)

| Step | Live time | Rows encrypted |
|---|---|---|
| body | 30 s | 20715 body_text + 18885 body_html |
| addrs | 35 s | 20766 from + 20674 to + 1589 cc |
| headers | (combined run with addrs) | 47176 / 47176 |
| drafts + meta | 29 s | 109 local_drafts + 5 outbox + 86 mailboxes + 13 accounts + 3691 flags_other |

DB grew 980 MB → 1.7 GB while plaintext columns co-exist with ciphertext. Step 7 drops plaintexts + VACUUMs.

Round-trip verified via \`durian show <thread>\` and \`GET /api/v1/threads/<id>\` — decrypted columns match the still-present plaintext column byte-for-byte.

## Test plan

- [x] \`bazel test //cli/...\` — all 19 targets pass locally
- [x] dbcrypto_test keyring matrix grows to 6 sub-keys
- [x] store_test: per-step migration tests seed v10/v11 and round-trip via GetByMessageID
- [x] integration_test API contract still passes
- [x] encryption-grep-gate.sh clean
- [x] Real-DB validation on user's prod email.db (20834 messages, 47176 headers) — all migrations apply, reads return decrypted values byte-identical to plaintext column

## Design invariants preserved

- Plaintext columns alive until step 7 (FTS5 / UNIQUE / index lookups still need them)
- decrypt* helpers hard-error on AEAD failure — critical for step 7 safety
- Empty plaintext → NULL ct column ("encrypted empty string" is unambiguously distinct)
- ALTER TABLE idempotent via PRAGMA table_info — partial migrations can retry
- mailboxes.name + accounts.name keep plaintext for FK lookup until step 7's deterministic blind-tokens

## Stacked

Base for [adr-0001-step-6-contacts](https://github.com/julion2/durian/compare/adr-0001-step-6-encryption...adr-0001-step-6-contacts) which adds contacts.db encryption.