### PR TITLE
ADR-0001 step 6 — encrypt contacts.email + contacts.name

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -25,7 +25,7 @@ go_sdk.download(version = "1.25.10")
 
 go_deps = use_extension("@gazelle//:extensions.bzl", "go_deps")
 go_deps.from_file(go_mod = "//cli:go.mod")
-use_repo(go_deps, "com_github_apple_pkl_go", "com_github_emersion_go_imap", "com_github_emersion_go_sasl", "com_github_fatih_color", "com_github_google_uuid", "com_github_gorilla_mux", "com_github_microcosm_cc_bluemonday", "com_github_spf13_cobra", "in_yaml_go_yaml_v3", "io_filippo_age", "org_golang_x_net", "org_golang_x_term", "org_golang_x_text", "org_modernc_sqlite")
+use_repo(go_deps, "com_github_apple_pkl_go", "com_github_emersion_go_imap", "com_github_emersion_go_sasl", "com_github_fatih_color", "com_github_google_uuid", "com_github_gorilla_mux", "com_github_microcosm_cc_bluemonday", "com_github_rivo_uniseg", "com_github_spf13_cobra", "in_yaml_go_yaml_v3", "io_filippo_age", "org_golang_x_net", "org_golang_x_term", "org_golang_x_text", "org_modernc_sqlite")
 
 http_archive = use_repo_rule("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 

--- a/cli/cmd/durian/contacts.go
+++ b/cli/cmd/durian/contacts.go
@@ -93,7 +93,7 @@ func runContactsInit(cmd *cobra.Command, args []string) error {
 	dbPath := getDBPath()
 	slog.Debug("Initializing contacts database", "path", dbPath)
 
-	db, err := contacts.Open(dbPath)
+	db, err := contacts.Open(dbPath, bootstrapKeyring())
 	if err != nil {
 		return fmt.Errorf("open database: %w", err)
 	}
@@ -122,7 +122,7 @@ func runContactsImport(cmd *cobra.Command, args []string) error {
 	slog.Debug("Importing contacts", "path", dbPath)
 
 	// Open/create database
-	db, err := contacts.Open(dbPath)
+	db, err := contacts.Open(dbPath, bootstrapKeyring())
 	if err != nil {
 		return fmt.Errorf("open database: %w", err)
 	}
@@ -183,7 +183,7 @@ func runContactsImport(cmd *cobra.Command, args []string) error {
 func runContactsList(cmd *cobra.Command, args []string) error {
 	dbPath := getDBPath()
 
-	db, err := contacts.Open(dbPath)
+	db, err := contacts.Open(dbPath, bootstrapKeyring())
 	if err != nil {
 		return fmt.Errorf("open database: %w", err)
 	}
@@ -230,7 +230,7 @@ func runContactsSearch(cmd *cobra.Command, args []string) error {
 	query := args[0]
 	dbPath := getDBPath()
 
-	db, err := contacts.Open(dbPath)
+	db, err := contacts.Open(dbPath, bootstrapKeyring())
 	if err != nil {
 		return fmt.Errorf("open database: %w", err)
 	}
@@ -268,7 +268,7 @@ func runContactsAdd(cmd *cobra.Command, args []string) error {
 
 	dbPath := getDBPath()
 
-	db, err := contacts.Open(dbPath)
+	db, err := contacts.Open(dbPath, bootstrapKeyring())
 	if err != nil {
 		return fmt.Errorf("open database: %w", err)
 	}
@@ -307,7 +307,7 @@ func runContactsDelete(cmd *cobra.Command, args []string) error {
 	email := args[0]
 	dbPath := getDBPath()
 
-	db, err := contacts.Open(dbPath)
+	db, err := contacts.Open(dbPath, bootstrapKeyring())
 	if err != nil {
 		return fmt.Errorf("open database: %w", err)
 	}

--- a/cli/cmd/durian/serve.go
+++ b/cli/cmd/durian/serve.go
@@ -62,24 +62,32 @@ func runServe(cmd *cobra.Command, args []string) {
 		slog.SetDefault(slog.New(redact.Wrap(slog.NewTextHandler(f, &slog.HandlerOptions{Level: level}))))
 	}
 
+	// ADR-0001 steps 4+5+6: bootstrap the master key BEFORE opening any
+	// store. The keyring is required to encrypt new rows and to back-fill
+	// existing rows in every per-step migration (messages, contacts).
+	keyring := bootstrapKeyring()
+
 	// Open contacts database (non-fatal if missing)
 	var contactsDB *contacts.DB
 	contactsDBPath := serveContactsDB
 	if contactsDBPath == "" {
 		contactsDBPath = contacts.DefaultDBPath()
 	}
-	if cdb, err := contacts.Open(contactsDBPath); err != nil {
+	if cdb, err := contacts.Open(contactsDBPath, keyring); err != nil {
 		slog.Warn("Could not open contacts database", "module", "SERVE", "path", contactsDBPath, "err", err)
+	} else if err := cdb.Init(); err != nil {
+		// Init runs the CREATE TABLE IF NOT EXISTS and any pending
+		// migrations (ADR-0001 step 6 contact encryption). Previously
+		// serve skipped Init and relied on the import subcommand to
+		// have set up the schema; with encrypt-on-write live we must
+		// guarantee the migration runs on startup.
+		slog.Warn("Could not init contacts database", "module", "SERVE", "path", contactsDBPath, "err", err)
+		cdb.Close()
 	} else {
 		contactsDB = cdb
 		defer contactsDB.Close()
 		slog.Info("Opened contacts database", "module", "SERVE", "path", contactsDBPath)
 	}
-
-	// ADR-0001 steps 4+5: bootstrap the master key BEFORE opening the
-	// store. The keyring is required to encrypt new rows and to back-fill
-	// existing rows on the v9→v10 migration.
-	keyring := bootstrapKeyring()
 
 	// Open email store (required for reads)
 	dbPath := serveDB

--- a/cli/cmd/testseeder/main.go
+++ b/cli/cmd/testseeder/main.go
@@ -119,7 +119,7 @@ func seedEmailDB(path string) error {
 }
 
 func seedContactsDB(path string) error {
-	db, err := contacts.Open(path)
+	db, err := contacts.Open(path, testKeyring())
 	if err != nil {
 		return fmt.Errorf("open: %w", err)
 	}

--- a/cli/go.mod
+++ b/cli/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/google/uuid v1.6.0
 	github.com/gorilla/mux v1.8.1
 	github.com/microcosm-cc/bluemonday v1.0.27
+	github.com/rivo/uniseg v0.4.7
 	github.com/spf13/cobra v1.10.2
 	golang.org/x/net v0.55.0
 	golang.org/x/term v0.43.0

--- a/cli/go.sum
+++ b/cli/go.sum
@@ -45,6 +45,8 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec h1:W09IVJc94icq4NjY3clb7Lk8O1qJ8BdBEF8z0ibU0rE=
 github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec/go.mod h1:qqbHyh8v60DhA7CoWK5oRCqLrMHRGoxYCSS9EjAz6Eo=
+github.com/rivo/uniseg v0.4.7 h1:WUdvkW8uEhrYfLC4ZzdpI2ztxP1I582+49Oc5Mq64VQ=
+github.com/rivo/uniseg v0.4.7/go.mod h1:FN3SvrM+Zdj16jyLfmOkMNblXMcoc8DfTHruCPUcx88=
 github.com/russross/blackfriday/v2 v2.1.0 h1:JIOH55/0cWyOuilr9/qlrm0BSXldqnqwMsf35Ld67mk=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/spf13/cobra v1.10.2 h1:DMTTonx5m65Ic0GOoRY2c16WCbHxOOw6xxezuLaBpcU=

--- a/cli/internal/contacts/BUILD.bazel
+++ b/cli/internal/contacts/BUILD.bazel
@@ -10,6 +10,7 @@ go_library(
     importpath = "github.com/durian-dev/durian/cli/internal/contacts",
     visibility = ["//cli:__subpackages__"],
     deps = [
+        "//cli/internal/dbcrypto",
         "//cli/internal/store",
         "@com_github_google_uuid//:uuid",
         "@org_modernc_sqlite//:sqlite",
@@ -21,4 +22,5 @@ go_test(
     size = "small",
     srcs = ["db_test.go"],
     embed = [":contacts"],
+    deps = ["//cli/internal/dbcrypto"],
 )

--- a/cli/internal/contacts/db.go
+++ b/cli/internal/contacts/db.go
@@ -9,6 +9,9 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+
+	"github.com/durian-dev/durian/cli/internal/dbcrypto"
+
 	_ "modernc.org/sqlite"
 )
 
@@ -24,11 +27,20 @@ func DefaultDBPath() string {
 
 // DB represents a contacts database connection
 type DB struct {
-	db *sql.DB
+	db      *sql.DB
+	keyring *dbcrypto.Keyring
 }
 
-// Open opens or creates a contacts database at the given path
-func Open(dbPath string) (*DB, error) {
+// Open opens or creates a contacts database at the given path.
+//
+// kr must be a non-nil Keyring derived from the OS-keychain master key.
+// ADR-0001 step 6 requires the Contact sub-key for the email/name
+// encrypt-on-write path and the one-shot backfill in Init().
+func Open(dbPath string, kr *dbcrypto.Keyring) (*DB, error) {
+	if kr == nil {
+		return nil, fmt.Errorf("contacts: Open requires a non-nil keyring (see ADR-0001)")
+	}
+
 	// Expand ~ if present
 	if strings.HasPrefix(dbPath, "~/") {
 		home, err := os.UserHomeDir()
@@ -59,7 +71,7 @@ func Open(dbPath string) (*DB, error) {
 		return nil, fmt.Errorf("set journal mode: %w", err)
 	}
 
-	return &DB{db: db}, nil
+	return &DB{db: db, keyring: kr}, nil
 }
 
 // Close closes the database connection
@@ -67,7 +79,10 @@ func (d *DB) Close() error {
 	return d.db.Close()
 }
 
-// Init creates the contacts table and indexes if they don't exist
+// Init creates the contacts table and indexes if they don't exist, and
+// runs any pending one-shot migrations (ADR-0001 step 6 encryption is
+// detected via PRAGMA table_info since contacts.db has no schema_version
+// — first migration ever and likely the only one until step 7).
 func (d *DB) Init() error {
 	schema := `
 	CREATE TABLE IF NOT EXISTS contacts (
@@ -89,7 +104,142 @@ func (d *DB) Init() error {
 		return fmt.Errorf("create schema: %w", err)
 	}
 
+	// ADR-0001 step 6: add email_ct + name_ct BLOB columns for at-rest
+	// encryption of contact PII. Idempotent via PRAGMA table_info — once
+	// both columns exist the backfill becomes a no-op (zero rows match
+	// WHERE *_ct IS NULL). Plaintext email/name columns stay until
+	// step 7 introduces deterministic lookup tokens — the UNIQUE
+	// constraint on email and the indexed LIKE prefix on both columns
+	// cannot be served from random-nonce ciphertext.
+	for _, col := range []string{"email_ct", "name_ct"} {
+		has, err := hasColumn(d.db, "contacts", col)
+		if err != nil {
+			return fmt.Errorf("inspect %s: %w", col, err)
+		}
+		if !has {
+			if _, err := d.db.Exec("ALTER TABLE contacts ADD COLUMN " + col + " BLOB"); err != nil {
+				return fmt.Errorf("add %s: %w", col, err)
+			}
+		}
+	}
+	if err := d.backfillContactCt(); err != nil {
+		return fmt.Errorf("backfill contacts ct: %w", err)
+	}
+
 	return nil
+}
+
+// hasColumn returns true if the named column already exists on table.
+// Mirrors the helper in cli/internal/store/store.go — kept package-local
+// here so contacts has no cross-package dependency on store internals.
+func hasColumn(db *sql.DB, table, column string) (bool, error) {
+	rows, err := db.Query(fmt.Sprintf("PRAGMA table_info(%s)", table))
+	if err != nil {
+		return false, err
+	}
+	defer rows.Close()
+	for rows.Next() {
+		var cid int
+		var name, ctype string
+		var notnull, pk int
+		var dflt sql.NullString
+		if err := rows.Scan(&cid, &name, &ctype, &notnull, &dflt, &pk); err != nil {
+			return false, err
+		}
+		if name == column {
+			return true, nil
+		}
+	}
+	return false, rows.Err()
+}
+
+// encryptContact seals plain with the contact sub-key. Empty plaintext
+// maps to nil so the ct column stays NULL — same convention as the
+// store package's encrypt* helpers.
+func (d *DB) encryptContact(plain string) ([]byte, error) {
+	if plain == "" {
+		return nil, nil
+	}
+	return dbcrypto.Encrypt(d.keyring.Contact, []byte(plain))
+}
+
+// decryptContact returns plaintext for a contact_key column, preferring
+// the ct when present and falling back to plaintext only when ct IS NULL.
+// Decrypt failures on non-nil ct are hard errors. Not yet called by
+// production reads — step 7 will wire the lookup paths once the
+// plaintext columns die.
+func (d *DB) decryptContact(plain string, ct []byte) (string, error) {
+	if len(ct) == 0 {
+		return plain, nil
+	}
+	out, err := dbcrypto.Decrypt(d.keyring.Contact, ct)
+	if err != nil {
+		return "", fmt.Errorf("decrypt contact: %w", err)
+	}
+	return string(out), nil
+}
+
+// backfillContactCt encrypts every existing contacts.email + contacts.name
+// into the new BLOB columns. Single transaction so a mid-loop failure
+// rolls back cleanly. Contact volumes are typically in the low thousands
+// even for heavy users; loading the batch in RAM is fine.
+func (d *DB) backfillContactCt() error {
+	if d.keyring == nil || d.keyring.Contact == nil {
+		return fmt.Errorf("no keyring available for contact backfill")
+	}
+	tx, err := d.db.Begin()
+	if err != nil {
+		return fmt.Errorf("begin tx: %w", err)
+	}
+	defer tx.Rollback() //nolint:errcheck
+
+	rows, err := tx.Query(`SELECT id, email, name FROM contacts
+		WHERE (email IS NOT NULL AND email <> '' AND email_ct IS NULL)
+		   OR (name  IS NOT NULL AND name  <> '' AND name_ct  IS NULL)`)
+	if err != nil {
+		return fmt.Errorf("select rows: %w", err)
+	}
+	type pending struct {
+		id          string
+		email, name string
+	}
+	var batch []pending
+	for rows.Next() {
+		var p pending
+		var name sql.NullString
+		if err := rows.Scan(&p.id, &p.email, &name); err != nil {
+			rows.Close()
+			return fmt.Errorf("scan: %w", err)
+		}
+		if name.Valid {
+			p.name = name.String
+		}
+		batch = append(batch, p)
+	}
+	rows.Close()
+	if err := rows.Err(); err != nil {
+		return fmt.Errorf("iterate rows: %w", err)
+	}
+
+	stmt, err := tx.Prepare("UPDATE contacts SET email_ct = ?, name_ct = ? WHERE id = ?")
+	if err != nil {
+		return fmt.Errorf("prepare update: %w", err)
+	}
+	defer stmt.Close()
+	for _, p := range batch {
+		emailCT, err := d.encryptContact(p.email)
+		if err != nil {
+			return fmt.Errorf("encrypt email id=%s: %w", p.id, err)
+		}
+		nameCT, err := d.encryptContact(p.name)
+		if err != nil {
+			return fmt.Errorf("encrypt name id=%s: %w", p.id, err)
+		}
+		if _, err := stmt.Exec(emailCT, nameCT, p.id); err != nil {
+			return fmt.Errorf("update id=%s: %w", p.id, err)
+		}
+	}
+	return tx.Commit()
 }
 
 // Add adds a new contact to the database
@@ -101,13 +251,24 @@ func (d *DB) Add(email, name, source string) error {
 
 	id := uuid.New().String()
 	now := time.Now()
+	lowered := strings.ToLower(email)
+	emailCT, err := d.encryptContact(lowered)
+	if err != nil {
+		return fmt.Errorf("encrypt email: %w", err)
+	}
+	nameCT, err := d.encryptContact(name)
+	if err != nil {
+		return fmt.Errorf("encrypt name: %w", err)
+	}
 
-	_, err := d.db.Exec(`
-		INSERT INTO contacts (id, email, name, source, created_at, usage_count)
-		VALUES (?, ?, ?, ?, ?, 0)
+	_, err = d.db.Exec(`
+		INSERT INTO contacts (id, email, email_ct, name, name_ct, source, created_at, usage_count)
+		VALUES (?, ?, ?, ?, ?, ?, ?, 0)
 		ON CONFLICT(email) DO UPDATE SET
-			name = COALESCE(NULLIF(excluded.name, ''), contacts.name)
-	`, id, strings.ToLower(email), name, source, now)
+			name = COALESCE(NULLIF(excluded.name, ''), contacts.name),
+			name_ct = CASE WHEN NULLIF(excluded.name, '') IS NOT NULL
+			               THEN excluded.name_ct ELSE contacts.name_ct END
+	`, id, lowered, emailCT, name, nameCT, source, now)
 
 	if err != nil {
 		return fmt.Errorf("add contact: %w", err)
@@ -125,10 +286,12 @@ func (d *DB) AddBatch(contacts []Contact) (added, updated int, err error) {
 	defer tx.Rollback()
 
 	stmt, err := tx.Prepare(`
-		INSERT INTO contacts (id, email, name, source, created_at, usage_count)
-		VALUES (?, ?, ?, ?, ?, ?)
+		INSERT INTO contacts (id, email, email_ct, name, name_ct, source, created_at, usage_count)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?)
 		ON CONFLICT(email) DO UPDATE SET
 			name = COALESCE(NULLIF(excluded.name, ''), contacts.name),
+			name_ct = CASE WHEN NULLIF(excluded.name, '') IS NOT NULL
+			               THEN excluded.name_ct ELSE contacts.name_ct END,
 			usage_count = excluded.usage_count
 	`)
 	if err != nil {
@@ -140,7 +303,16 @@ func (d *DB) AddBatch(contacts []Contact) (added, updated int, err error) {
 		if !isValidEmail(c.Email) {
 			continue
 		}
-		result, err := stmt.Exec(c.ID, strings.ToLower(c.Email), c.Name, c.Source, c.CreatedAt, c.UsageCount)
+		lowered := strings.ToLower(c.Email)
+		emailCT, err := d.encryptContact(lowered)
+		if err != nil {
+			return added, updated, fmt.Errorf("encrypt contact %s email: %w", c.Email, err)
+		}
+		nameCT, err := d.encryptContact(c.Name)
+		if err != nil {
+			return added, updated, fmt.Errorf("encrypt contact %s name: %w", c.Email, err)
+		}
+		result, err := stmt.Exec(c.ID, lowered, emailCT, c.Name, nameCT, c.Source, c.CreatedAt, c.UsageCount)
 		if err != nil {
 			return added, updated, fmt.Errorf("insert contact %s: %w", c.Email, err)
 		}

--- a/cli/internal/contacts/db_test.go
+++ b/cli/internal/contacts/db_test.go
@@ -1,15 +1,22 @@
 package contacts
 
 import (
+	"bytes"
 	"path/filepath"
 	"testing"
 	"time"
+
+	"github.com/durian-dev/durian/cli/internal/dbcrypto"
 )
 
 func newTestDB(t *testing.T) *DB {
 	t.Helper()
 	dir := t.TempDir()
-	db, err := Open(filepath.Join(dir, "contacts.db"))
+	kr, err := dbcrypto.NewKeyring(bytes.Repeat([]byte{0x42}, dbcrypto.MasterKeyLen))
+	if err != nil {
+		t.Fatalf("test keyring: %v", err)
+	}
+	db, err := Open(filepath.Join(dir, "contacts.db"), kr)
 	if err != nil {
 		t.Fatalf("open: %v", err)
 	}

--- a/cli/internal/dbcrypto/BUILD.bazel
+++ b/cli/internal/dbcrypto/BUILD.bazel
@@ -5,14 +5,19 @@ go_library(
     srcs = [
         "dbcrypto.go",
         "keyring.go",
+        "tokenize.go",
     ],
     importpath = "github.com/durian-dev/durian/cli/internal/dbcrypto",
     visibility = ["//cli:__subpackages__"],
+    deps = ["@com_github_rivo_uniseg//:uniseg"],
 )
 
 go_test(
     name = "dbcrypto_test",
     size = "small",
-    srcs = ["dbcrypto_test.go"],
+    srcs = [
+        "dbcrypto_test.go",
+        "tokenize_test.go",
+    ],
     embed = [":dbcrypto"],
 )

--- a/cli/internal/dbcrypto/dbcrypto_test.go
+++ b/cli/internal/dbcrypto/dbcrypto_test.go
@@ -217,6 +217,7 @@ func TestNewKeyring_DerivesAllSubKeys(t *testing.T) {
 		{"Subject", kr.Subject, LabelSubject},
 		{"Body", kr.Body, LabelBody},
 		{"Addrs", kr.Addrs, LabelAddrs},
+		{"Headers", kr.Headers, LabelHeaders},
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
@@ -236,7 +237,10 @@ func TestNewKeyring_DerivesAllSubKeys(t *testing.T) {
 	pairs := [][2][]byte{
 		{kr.Subject, kr.Body},
 		{kr.Subject, kr.Addrs},
+		{kr.Subject, kr.Headers},
 		{kr.Body, kr.Addrs},
+		{kr.Body, kr.Headers},
+		{kr.Addrs, kr.Headers},
 	}
 	for i, p := range pairs {
 		if bytes.Equal(p[0], p[1]) {

--- a/cli/internal/dbcrypto/dbcrypto_test.go
+++ b/cli/internal/dbcrypto/dbcrypto_test.go
@@ -200,23 +200,48 @@ func TestDecrypt_RejectsBadKey(t *testing.T) {
 
 // --- Keyring ---
 
-func TestNewKeyring_DerivesSubjectSubKey(t *testing.T) {
+func TestNewKeyring_DerivesAllSubKeys(t *testing.T) {
 	master := bytes.Repeat([]byte{0x77}, MasterKeyLen)
 	kr, err := NewKeyring(master)
 	if err != nil {
 		t.Fatalf("NewKeyring: %v", err)
 	}
-	if len(kr.Subject) != KeyLen {
-		t.Errorf("Subject sub-key length = %d, want %d", len(kr.Subject), KeyLen)
+	// Every sub-key must (a) be the right length and (b) match a direct
+	// DeriveSubKey call bit-for-bit — both paths produce the same on-disk
+	// ciphertexts, any drift here corrupts the entire DB.
+	cases := []struct {
+		name  string
+		got   []byte
+		label Label
+	}{
+		{"Subject", kr.Subject, LabelSubject},
+		{"Body", kr.Body, LabelBody},
+		{"Addrs", kr.Addrs, LabelAddrs},
 	}
-	// Must match a direct DeriveSubKey call — they have to be bit-identical
-	// because both paths produce the same on-disk ciphertexts.
-	want, err := DeriveSubKey(master, LabelSubject)
-	if err != nil {
-		t.Fatalf("DeriveSubKey: %v", err)
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if len(c.got) != KeyLen {
+				t.Errorf("length = %d, want %d", len(c.got), KeyLen)
+			}
+			want, err := DeriveSubKey(master, c.label)
+			if err != nil {
+				t.Fatalf("DeriveSubKey: %v", err)
+			}
+			if !bytes.Equal(c.got, want) {
+				t.Errorf("diverged from DeriveSubKey(%s)", c.label)
+			}
+		})
 	}
-	if !bytes.Equal(kr.Subject, want) {
-		t.Errorf("Keyring.Subject diverged from DeriveSubKey(LabelSubject)")
+	// Pairwise distinctness — guards against future "oops, copy-paste".
+	pairs := [][2][]byte{
+		{kr.Subject, kr.Body},
+		{kr.Subject, kr.Addrs},
+		{kr.Body, kr.Addrs},
+	}
+	for i, p := range pairs {
+		if bytes.Equal(p[0], p[1]) {
+			t.Errorf("pair %d: sub-keys collided", i)
+		}
 	}
 }
 

--- a/cli/internal/dbcrypto/dbcrypto_test.go
+++ b/cli/internal/dbcrypto/dbcrypto_test.go
@@ -220,6 +220,7 @@ func TestNewKeyring_DerivesAllSubKeys(t *testing.T) {
 		{"Headers", kr.Headers, LabelHeaders},
 		{"Draft", kr.Draft, LabelDraft},
 		{"Meta", kr.Meta, LabelMeta},
+		{"Contact", kr.Contact, LabelContact},
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
@@ -236,7 +237,7 @@ func TestNewKeyring_DerivesAllSubKeys(t *testing.T) {
 		})
 	}
 	// Pairwise distinctness — guards against future "oops, copy-paste".
-	all := [][]byte{kr.Subject, kr.Body, kr.Addrs, kr.Headers, kr.Draft, kr.Meta}
+	all := [][]byte{kr.Subject, kr.Body, kr.Addrs, kr.Headers, kr.Draft, kr.Meta, kr.Contact}
 	var pairs [][2][]byte
 	for i := range all {
 		for j := i + 1; j < len(all); j++ {

--- a/cli/internal/dbcrypto/dbcrypto_test.go
+++ b/cli/internal/dbcrypto/dbcrypto_test.go
@@ -218,6 +218,8 @@ func TestNewKeyring_DerivesAllSubKeys(t *testing.T) {
 		{"Body", kr.Body, LabelBody},
 		{"Addrs", kr.Addrs, LabelAddrs},
 		{"Headers", kr.Headers, LabelHeaders},
+		{"Draft", kr.Draft, LabelDraft},
+		{"Meta", kr.Meta, LabelMeta},
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
@@ -234,13 +236,12 @@ func TestNewKeyring_DerivesAllSubKeys(t *testing.T) {
 		})
 	}
 	// Pairwise distinctness — guards against future "oops, copy-paste".
-	pairs := [][2][]byte{
-		{kr.Subject, kr.Body},
-		{kr.Subject, kr.Addrs},
-		{kr.Subject, kr.Headers},
-		{kr.Body, kr.Addrs},
-		{kr.Body, kr.Headers},
-		{kr.Addrs, kr.Headers},
+	all := [][]byte{kr.Subject, kr.Body, kr.Addrs, kr.Headers, kr.Draft, kr.Meta}
+	var pairs [][2][]byte
+	for i := range all {
+		for j := i + 1; j < len(all); j++ {
+			pairs = append(pairs, [2][]byte{all[i], all[j]})
+		}
 	}
 	for i, p := range pairs {
 		if bytes.Equal(p[0], p[1]) {

--- a/cli/internal/dbcrypto/dbcrypto_test.go
+++ b/cli/internal/dbcrypto/dbcrypto_test.go
@@ -221,6 +221,7 @@ func TestNewKeyring_DerivesAllSubKeys(t *testing.T) {
 		{"Draft", kr.Draft, LabelDraft},
 		{"Meta", kr.Meta, LabelMeta},
 		{"Contact", kr.Contact, LabelContact},
+		{"FTSToken", kr.FTSToken, LabelFTSToken},
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
@@ -237,7 +238,7 @@ func TestNewKeyring_DerivesAllSubKeys(t *testing.T) {
 		})
 	}
 	// Pairwise distinctness — guards against future "oops, copy-paste".
-	all := [][]byte{kr.Subject, kr.Body, kr.Addrs, kr.Headers, kr.Draft, kr.Meta, kr.Contact}
+	all := [][]byte{kr.Subject, kr.Body, kr.Addrs, kr.Headers, kr.Draft, kr.Meta, kr.Contact, kr.FTSToken}
 	var pairs [][2][]byte
 	for i := range all {
 		for j := i + 1; j < len(all); j++ {

--- a/cli/internal/dbcrypto/keyring.go
+++ b/cli/internal/dbcrypto/keyring.go
@@ -14,13 +14,14 @@ import (
 // — each as its own field so callers never have to remember which label
 // to pass.
 type Keyring struct {
-	Subject []byte // encrypts messages.subject (LabelSubject)
-	Body    []byte // encrypts messages.body_text + body_html (LabelBody)
-	Addrs   []byte // encrypts messages.from_addr + to_addrs + cc_addrs (LabelAddrs)
-	Headers []byte // encrypts message_headers.value (LabelHeaders)
-	Draft   []byte // encrypts local_drafts.draft_json + outbox.draft_json (LabelDraft)
-	Meta    []byte // encrypts mailboxes.name + accounts.name + messages.flags_other (LabelMeta)
-	Contact []byte // encrypts contacts.email + contacts.name (LabelContact)
+	Subject  []byte // encrypts messages.subject (LabelSubject)
+	Body     []byte // encrypts messages.body_text + body_html (LabelBody)
+	Addrs    []byte // encrypts messages.from_addr + to_addrs + cc_addrs (LabelAddrs)
+	Headers  []byte // encrypts message_headers.value (LabelHeaders)
+	Draft    []byte // encrypts local_drafts.draft_json + outbox.draft_json (LabelDraft)
+	Meta     []byte // encrypts mailboxes.name + accounts.name + messages.flags_other (LabelMeta)
+	Contact  []byte // encrypts contacts.email + contacts.name (LabelContact)
+	FTSToken []byte // HMAC key for blind FTS5 search tokens (LabelFTSToken)
 }
 
 // NewKeyring derives every currently-shipped sub-key from a 32-byte master.
@@ -55,7 +56,14 @@ func NewKeyring(master []byte) (*Keyring, error) {
 	if err != nil {
 		return nil, fmt.Errorf("dbcrypto: derive contact sub-key: %w", err)
 	}
-	return &Keyring{Subject: subject, Body: body, Addrs: addrs, Headers: headers, Draft: draft, Meta: meta, Contact: contact}, nil
+	ftsToken, err := DeriveSubKey(master, LabelFTSToken)
+	if err != nil {
+		return nil, fmt.Errorf("dbcrypto: derive fts-token sub-key: %w", err)
+	}
+	return &Keyring{
+		Subject: subject, Body: body, Addrs: addrs, Headers: headers,
+		Draft: draft, Meta: meta, Contact: contact, FTSToken: ftsToken,
+	}, nil
 }
 
 // Wipe overwrites every sub-key in place with zeroes and nils the slice
@@ -73,6 +81,7 @@ func (k *Keyring) Wipe() {
 	zero(k.Draft)
 	zero(k.Meta)
 	zero(k.Contact)
+	zero(k.FTSToken)
 	k.Subject = nil
 	k.Body = nil
 	k.Addrs = nil
@@ -80,6 +89,7 @@ func (k *Keyring) Wipe() {
 	k.Draft = nil
 	k.Meta = nil
 	k.Contact = nil
+	k.FTSToken = nil
 }
 
 // zero overwrites b with zero bytes in constant time. Used by Wipe.

--- a/cli/internal/dbcrypto/keyring.go
+++ b/cli/internal/dbcrypto/keyring.go
@@ -10,14 +10,16 @@ import (
 // start, retained in memory for the lifetime of the daemon, and consumed
 // by the store layer for transparent encrypt-on-write / decrypt-on-read.
 //
-// Step 5 only derives Subject. Subsequent steps fill in Body, Headers,
-// Addrs, Draft, Contact, FTSToken, Meta — each as its own field so callers
-// never have to remember which label to pass.
+// Subsequent steps fill in Headers, Addrs, Draft, Contact, FTSToken, Meta
+// — each as its own field so callers never have to remember which label
+// to pass.
 type Keyring struct {
 	Subject []byte // encrypts messages.subject (LabelSubject)
+	Body    []byte // encrypts messages.body_text + body_html (LabelBody)
+	Addrs   []byte // encrypts messages.from_addr + to_addrs + cc_addrs (LabelAddrs)
 }
 
-// NewKeyring derives every step-5 sub-key from a 32-byte master key.
+// NewKeyring derives every currently-shipped sub-key from a 32-byte master.
 // The master is read once and never retained by the returned Keyring; the
 // caller is free to (and should) wipe its own copy once this returns.
 func NewKeyring(master []byte) (*Keyring, error) {
@@ -25,7 +27,15 @@ func NewKeyring(master []byte) (*Keyring, error) {
 	if err != nil {
 		return nil, fmt.Errorf("dbcrypto: derive subject sub-key: %w", err)
 	}
-	return &Keyring{Subject: subject}, nil
+	body, err := DeriveSubKey(master, LabelBody)
+	if err != nil {
+		return nil, fmt.Errorf("dbcrypto: derive body sub-key: %w", err)
+	}
+	addrs, err := DeriveSubKey(master, LabelAddrs)
+	if err != nil {
+		return nil, fmt.Errorf("dbcrypto: derive addrs sub-key: %w", err)
+	}
+	return &Keyring{Subject: subject, Body: body, Addrs: addrs}, nil
 }
 
 // Wipe overwrites every sub-key in place with zeroes and nils the slice
@@ -37,7 +47,11 @@ func (k *Keyring) Wipe() {
 		return
 	}
 	zero(k.Subject)
+	zero(k.Body)
+	zero(k.Addrs)
 	k.Subject = nil
+	k.Body = nil
+	k.Addrs = nil
 }
 
 // zero overwrites b with zero bytes in constant time. Used by Wipe.

--- a/cli/internal/dbcrypto/keyring.go
+++ b/cli/internal/dbcrypto/keyring.go
@@ -17,6 +17,7 @@ type Keyring struct {
 	Subject []byte // encrypts messages.subject (LabelSubject)
 	Body    []byte // encrypts messages.body_text + body_html (LabelBody)
 	Addrs   []byte // encrypts messages.from_addr + to_addrs + cc_addrs (LabelAddrs)
+	Headers []byte // encrypts message_headers.value (LabelHeaders)
 }
 
 // NewKeyring derives every currently-shipped sub-key from a 32-byte master.
@@ -35,7 +36,11 @@ func NewKeyring(master []byte) (*Keyring, error) {
 	if err != nil {
 		return nil, fmt.Errorf("dbcrypto: derive addrs sub-key: %w", err)
 	}
-	return &Keyring{Subject: subject, Body: body, Addrs: addrs}, nil
+	headers, err := DeriveSubKey(master, LabelHeaders)
+	if err != nil {
+		return nil, fmt.Errorf("dbcrypto: derive headers sub-key: %w", err)
+	}
+	return &Keyring{Subject: subject, Body: body, Addrs: addrs, Headers: headers}, nil
 }
 
 // Wipe overwrites every sub-key in place with zeroes and nils the slice
@@ -49,9 +54,11 @@ func (k *Keyring) Wipe() {
 	zero(k.Subject)
 	zero(k.Body)
 	zero(k.Addrs)
+	zero(k.Headers)
 	k.Subject = nil
 	k.Body = nil
 	k.Addrs = nil
+	k.Headers = nil
 }
 
 // zero overwrites b with zero bytes in constant time. Used by Wipe.

--- a/cli/internal/dbcrypto/keyring.go
+++ b/cli/internal/dbcrypto/keyring.go
@@ -18,6 +18,8 @@ type Keyring struct {
 	Body    []byte // encrypts messages.body_text + body_html (LabelBody)
 	Addrs   []byte // encrypts messages.from_addr + to_addrs + cc_addrs (LabelAddrs)
 	Headers []byte // encrypts message_headers.value (LabelHeaders)
+	Draft   []byte // encrypts local_drafts.draft_json + outbox.draft_json (LabelDraft)
+	Meta    []byte // encrypts mailboxes.name + accounts.name + messages.flags_other (LabelMeta)
 }
 
 // NewKeyring derives every currently-shipped sub-key from a 32-byte master.
@@ -40,7 +42,15 @@ func NewKeyring(master []byte) (*Keyring, error) {
 	if err != nil {
 		return nil, fmt.Errorf("dbcrypto: derive headers sub-key: %w", err)
 	}
-	return &Keyring{Subject: subject, Body: body, Addrs: addrs, Headers: headers}, nil
+	draft, err := DeriveSubKey(master, LabelDraft)
+	if err != nil {
+		return nil, fmt.Errorf("dbcrypto: derive draft sub-key: %w", err)
+	}
+	meta, err := DeriveSubKey(master, LabelMeta)
+	if err != nil {
+		return nil, fmt.Errorf("dbcrypto: derive meta sub-key: %w", err)
+	}
+	return &Keyring{Subject: subject, Body: body, Addrs: addrs, Headers: headers, Draft: draft, Meta: meta}, nil
 }
 
 // Wipe overwrites every sub-key in place with zeroes and nils the slice
@@ -55,10 +65,14 @@ func (k *Keyring) Wipe() {
 	zero(k.Body)
 	zero(k.Addrs)
 	zero(k.Headers)
+	zero(k.Draft)
+	zero(k.Meta)
 	k.Subject = nil
 	k.Body = nil
 	k.Addrs = nil
 	k.Headers = nil
+	k.Draft = nil
+	k.Meta = nil
 }
 
 // zero overwrites b with zero bytes in constant time. Used by Wipe.

--- a/cli/internal/dbcrypto/keyring.go
+++ b/cli/internal/dbcrypto/keyring.go
@@ -20,6 +20,7 @@ type Keyring struct {
 	Headers []byte // encrypts message_headers.value (LabelHeaders)
 	Draft   []byte // encrypts local_drafts.draft_json + outbox.draft_json (LabelDraft)
 	Meta    []byte // encrypts mailboxes.name + accounts.name + messages.flags_other (LabelMeta)
+	Contact []byte // encrypts contacts.email + contacts.name (LabelContact)
 }
 
 // NewKeyring derives every currently-shipped sub-key from a 32-byte master.
@@ -50,7 +51,11 @@ func NewKeyring(master []byte) (*Keyring, error) {
 	if err != nil {
 		return nil, fmt.Errorf("dbcrypto: derive meta sub-key: %w", err)
 	}
-	return &Keyring{Subject: subject, Body: body, Addrs: addrs, Headers: headers, Draft: draft, Meta: meta}, nil
+	contact, err := DeriveSubKey(master, LabelContact)
+	if err != nil {
+		return nil, fmt.Errorf("dbcrypto: derive contact sub-key: %w", err)
+	}
+	return &Keyring{Subject: subject, Body: body, Addrs: addrs, Headers: headers, Draft: draft, Meta: meta, Contact: contact}, nil
 }
 
 // Wipe overwrites every sub-key in place with zeroes and nils the slice
@@ -67,12 +72,14 @@ func (k *Keyring) Wipe() {
 	zero(k.Headers)
 	zero(k.Draft)
 	zero(k.Meta)
+	zero(k.Contact)
 	k.Subject = nil
 	k.Body = nil
 	k.Addrs = nil
 	k.Headers = nil
 	k.Draft = nil
 	k.Meta = nil
+	k.Contact = nil
 }
 
 // zero overwrites b with zero bytes in constant time. Used by Wipe.

--- a/cli/internal/dbcrypto/tokenize.go
+++ b/cli/internal/dbcrypto/tokenize.go
@@ -1,0 +1,110 @@
+package dbcrypto
+
+import (
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
+	"strings"
+	"unicode"
+
+	"github.com/rivo/uniseg"
+)
+
+// FTSTokenLen is the truncated HMAC length per ADR-0001 §4 — 80 bits
+// (10 bytes) renders as 20 hex characters. Truncation trades a small
+// collision probability for index-size savings; the post-decrypt
+// false-positive filter (step 7c) catches the rare collisions before
+// returning results to the user.
+const FTSTokenLen = 10
+
+// TokenizeFTS produces a space-separated list of blind tokens suitable
+// for inserting into the FTS5 messages_blind_fts shadow table. The
+// pipeline mirrors ADR-0001 §4:
+//
+//  1. UAX#29 word segmentation via rivo/uniseg, so Asian scripts, German
+//     compounds and CJK punctuation all segment correctly.
+//  2. Lowercase + Unicode-aware whitespace/punctuation drop. Empty
+//     segments are discarded; no stop-word removal (the ADR keeps every
+//     word to make frequency-analysis attacks harder).
+//  3. For each surviving word, emit HMAC-SHA256(key, word) truncated to
+//     FTSTokenLen bytes and hex-encoded — that fixed-length ASCII form
+//     is what FTS5 actually indexes.
+//  4. Adjacent unigram bigrams: HMAC(word_i || "\x1f" || word_{i+1})
+//     truncated the same way. The 0x1f unit-separator avoids any
+//     ambiguity between "ab cd" and "a bcd". Bigrams enable 2-word
+//     phrase queries without leaking which positional pair matched.
+//
+// Returns an empty string for empty/whitespace-only input.
+func TokenizeFTS(key []byte, plaintext string) string {
+	words := wordsForFTS(plaintext)
+	if len(words) == 0 {
+		return ""
+	}
+	out := make([]string, 0, len(words)*2)
+	for _, w := range words {
+		out = append(out, hmacHex(key, []byte(w)))
+	}
+	for i := 0; i < len(words)-1; i++ {
+		var buf strings.Builder
+		buf.WriteString(words[i])
+		buf.WriteByte(0x1f)
+		buf.WriteString(words[i+1])
+		out = append(out, hmacHex(key, []byte(buf.String())))
+	}
+	return strings.Join(out, " ")
+}
+
+// wordsForFTS runs plaintext through the segment+normalize pipeline,
+// returning the lowercase word forms ready to HMAC. Exposed (lowercase)
+// for tests only — production callers always go through TokenizeFTS.
+func wordsForFTS(plaintext string) []string {
+	if plaintext == "" {
+		return nil
+	}
+	state := -1
+	rest := plaintext
+	var out []string
+	for len(rest) > 0 {
+		var seg string
+		seg, rest, state = uniseg.FirstWordInString(rest, state)
+		w := normalizeWord(seg)
+		if w == "" {
+			continue
+		}
+		out = append(out, w)
+	}
+	return out
+}
+
+// normalizeWord lowercases seg and drops it if everything in it is
+// whitespace or punctuation. ADR-0001 §4 footnote keeps diacritics
+// (ON by default for German/French mail use) — we deliberately do not
+// run NFKD-strip here.
+func normalizeWord(seg string) string {
+	hasLetterOrDigit := false
+	for _, r := range seg {
+		if unicode.IsLetter(r) || unicode.IsDigit(r) {
+			hasLetterOrDigit = true
+			break
+		}
+	}
+	if !hasLetterOrDigit {
+		return ""
+	}
+	return strings.ToLower(seg)
+}
+
+// hmacHex returns the hex-encoded prefix of HMAC-SHA256(key, msg)
+// truncated to FTSTokenLen bytes.
+func hmacHex(key, msg []byte) string {
+	if len(key) != KeyLen {
+		// Programming error — fts_token sub-key must be 32 bytes. Panic
+		// rather than return a corrupt index that step-7c readers would
+		// silently fail to match against.
+		panic("dbcrypto: TokenizeFTS requires a 32-byte HMAC key")
+	}
+	m := hmac.New(sha256.New, key)
+	m.Write(msg)
+	sum := m.Sum(nil)
+	return hex.EncodeToString(sum[:FTSTokenLen])
+}

--- a/cli/internal/dbcrypto/tokenize_test.go
+++ b/cli/internal/dbcrypto/tokenize_test.go
@@ -1,0 +1,105 @@
+package dbcrypto
+
+import (
+	"bytes"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func TestWordsForFTS(t *testing.T) {
+	cases := []struct {
+		in   string
+		want []string
+	}{
+		{"", nil},
+		{"   \t\n   ", nil},
+		{"hello world", []string{"hello", "world"}},
+		// UAX#29 keeps "don't" as one word, splits on punctuation that's
+		// not part of a word. Trailing punctuation drops out.
+		{"Hello, World!", []string{"hello", "world"}},
+		{"don't stop", []string{"don't", "stop"}},
+		// Lowercase + diacritics preserved (ADR-0001 §4 keeps them ON by
+		// default for German/French users).
+		{"Grüße aus München", []string{"grüße", "aus", "münchen"}},
+		// Numbers count as words.
+		{"item 42 ok", []string{"item", "42", "ok"}},
+	}
+	for _, c := range cases {
+		t.Run(c.in, func(t *testing.T) {
+			got := wordsForFTS(c.in)
+			if !reflect.DeepEqual(got, c.want) {
+				t.Errorf("wordsForFTS(%q) = %#v, want %#v", c.in, got, c.want)
+			}
+		})
+	}
+}
+
+func TestTokenizeFTS_DeterministicAndUnique(t *testing.T) {
+	key := bytes.Repeat([]byte{0x42}, KeyLen)
+
+	a := TokenizeFTS(key, "Hello World")
+	b := TokenizeFTS(key, "Hello World")
+	if a != b {
+		t.Errorf("TokenizeFTS not deterministic for the same input:\n  a=%q\n  b=%q", a, b)
+	}
+
+	// Different input → different output (a few cherry-picked pairs).
+	other := TokenizeFTS(key, "World Hello")
+	if a == other {
+		t.Error("expected different output for reordered input (bigrams should differ)")
+	}
+}
+
+func TestTokenizeFTS_DifferentKeysProduceDifferentTokens(t *testing.T) {
+	k1 := bytes.Repeat([]byte{0x01}, KeyLen)
+	k2 := bytes.Repeat([]byte{0x02}, KeyLen)
+	if TokenizeFTS(k1, "hello") == TokenizeFTS(k2, "hello") {
+		t.Error("tokens with different keys must not collide")
+	}
+}
+
+func TestTokenizeFTS_UnigramsAndBigrams(t *testing.T) {
+	key := bytes.Repeat([]byte{0x42}, KeyLen)
+	// 3 words → 3 unigrams + 2 bigrams = 5 tokens.
+	out := TokenizeFTS(key, "alpha beta gamma")
+	tokens := strings.Fields(out)
+	if got := len(tokens); got != 5 {
+		t.Errorf("got %d tokens, want 5 (3 unigrams + 2 bigrams)", got)
+	}
+	// Each token must be exactly 2*FTSTokenLen hex characters.
+	for i, tok := range tokens {
+		if len(tok) != 2*FTSTokenLen {
+			t.Errorf("token %d has length %d, want %d", i, len(tok), 2*FTSTokenLen)
+		}
+	}
+}
+
+func TestTokenizeFTS_BigramOrderMatters(t *testing.T) {
+	key := bytes.Repeat([]byte{0x42}, KeyLen)
+	// "ab cd" vs "abc d" must not collide via bigram generation —
+	// the unit-separator 0x1f between adjacent words distinguishes them.
+	ab := TokenizeFTS(key, "ab cd")
+	abc := TokenizeFTS(key, "abc d")
+	if ab == abc {
+		t.Error("bigram delimiter failed to distinguish word boundary")
+	}
+}
+
+func TestTokenizeFTS_EmptyInput(t *testing.T) {
+	key := bytes.Repeat([]byte{0x42}, KeyLen)
+	for _, s := range []string{"", "   ", "...", "!!!"} {
+		if got := TokenizeFTS(key, s); got != "" {
+			t.Errorf("TokenizeFTS(%q) = %q, want empty", s, got)
+		}
+	}
+}
+
+func TestTokenizeFTS_PanicsOnBadKey(t *testing.T) {
+	defer func() {
+		if r := recover(); r == nil {
+			t.Error("expected panic on short key")
+		}
+	}()
+	TokenizeFTS(make([]byte, 16), "hello")
+}

--- a/cli/internal/handler/http_test.go
+++ b/cli/internal/handler/http_test.go
@@ -1,6 +1,7 @@
 package handler
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -13,6 +14,7 @@ import (
 	"github.com/gorilla/mux"
 
 	"github.com/durian-dev/durian/cli/internal/contacts"
+	"github.com/durian-dev/durian/cli/internal/dbcrypto"
 )
 
 // newTestRouter sets up a mux.Router with all routes, mirroring serve.go.
@@ -40,7 +42,11 @@ func newTestRouter(h *Handler, hub *EventHub) *mux.Router {
 func newTestContactsDB(t *testing.T) *contacts.DB {
 	t.Helper()
 	dir := t.TempDir()
-	db, err := contacts.Open(filepath.Join(dir, "contacts.db"))
+	kr, err := dbcrypto.NewKeyring(bytes.Repeat([]byte{0x42}, dbcrypto.MasterKeyLen))
+	if err != nil {
+		t.Fatalf("test keyring: %v", err)
+	}
+	db, err := contacts.Open(filepath.Join(dir, "contacts.db"), kr)
 	if err != nil {
 		t.Fatalf("open contacts: %v", err)
 	}

--- a/cli/internal/store/headers.go
+++ b/cli/internal/store/headers.go
@@ -6,10 +6,16 @@ import (
 )
 
 // InsertHeader stores a message header. Overwrites if the header already exists.
+// Writes both plaintext value (so existing reads still work) and value_ct
+// (ADR-0001 step 6). The plaintext column dies in step 7.
 func (d *DB) InsertHeader(messageDBID int64, name, value string) error {
-	_, err := d.db.Exec(
-		"INSERT OR REPLACE INTO message_headers (message_id, name, value) VALUES (?, ?, ?)",
-		messageDBID, name, value)
+	valueCT, err := d.encryptHeaderValue(value)
+	if err != nil {
+		return fmt.Errorf("encrypt header value: %w", err)
+	}
+	_, err = d.db.Exec(
+		"INSERT OR REPLACE INTO message_headers (message_id, name, value, value_ct) VALUES (?, ?, ?, ?)",
+		messageDBID, name, value, valueCT)
 	if err != nil {
 		return fmt.Errorf("insert header: %w", err)
 	}
@@ -19,13 +25,18 @@ func (d *DB) InsertHeader(messageDBID int64, name, value string) error {
 // GetHeader returns a single header value for a message. Returns "" if not found.
 func (d *DB) GetHeader(messageDBID int64, name string) (string, error) {
 	var value string
+	var valueCT []byte
 	err := d.db.QueryRow(
-		"SELECT value FROM message_headers WHERE message_id = ? AND name = ?",
-		messageDBID, name).Scan(&value)
+		"SELECT value, value_ct FROM message_headers WHERE message_id = ? AND name = ?",
+		messageDBID, name).Scan(&value, &valueCT)
 	if err != nil {
 		return "", nil // not found
 	}
-	return value, nil
+	out, err := d.decryptHeaderValue(value, valueCT)
+	if err != nil {
+		return "", err
+	}
+	return out, nil
 }
 
 // HasHeaders returns true if the message has any stored headers.
@@ -95,7 +106,7 @@ func (d *DB) AllMessages() ([]*Message, error) {
 // AllHeadersByMessage loads all stored headers, keyed by message DB ID.
 // Header names are returned in canonical MIME form (e.g. "List-Unsubscribe").
 func (d *DB) AllHeadersByMessage() (map[int64]map[string][]string, error) {
-	rows, err := d.db.Query("SELECT message_id, name, value FROM message_headers")
+	rows, err := d.db.Query("SELECT message_id, name, value, value_ct FROM message_headers")
 	if err != nil {
 		return nil, fmt.Errorf("query headers: %w", err)
 	}
@@ -105,14 +116,19 @@ func (d *DB) AllHeadersByMessage() (map[int64]map[string][]string, error) {
 	for rows.Next() {
 		var msgID int64
 		var name, value string
-		if err := rows.Scan(&msgID, &name, &value); err != nil {
+		var valueCT []byte
+		if err := rows.Scan(&msgID, &name, &value, &valueCT); err != nil {
 			return nil, fmt.Errorf("scan header: %w", err)
+		}
+		plain, err := d.decryptHeaderValue(value, valueCT)
+		if err != nil {
+			return nil, err
 		}
 		if result[msgID] == nil {
 			result[msgID] = make(map[string][]string)
 		}
 		canonical := textproto.CanonicalMIMEHeaderKey(name)
-		result[msgID][canonical] = append(result[msgID][canonical], value)
+		result[msgID][canonical] = append(result[msgID][canonical], plain)
 	}
 	return result, rows.Err()
 }

--- a/cli/internal/store/headers.go
+++ b/cli/internal/store/headers.go
@@ -55,8 +55,9 @@ func (d *DB) GetMessageDBID(messageID, account string) (int64, error) {
 
 // AllMessages returns all messages with fields needed for rule matching.
 func (d *DB) AllMessages() ([]*Message, error) {
-	rows, err := d.db.Query(
-		"SELECT id, message_id, subject, subject_ct, from_addr, to_addrs, cc_addrs, body_text, account FROM messages")
+	rows, err := d.db.Query(`SELECT id, message_id, subject, subject_ct,
+		from_addr, from_addr_ct, to_addrs, to_addrs_ct, cc_addrs, cc_addrs_ct,
+		body_text, body_text_ct, account FROM messages`)
 	if err != nil {
 		return nil, fmt.Errorf("query messages: %w", err)
 	}
@@ -65,11 +66,25 @@ func (d *DB) AllMessages() ([]*Message, error) {
 	var msgs []*Message
 	for rows.Next() {
 		m := &Message{}
-		var subjectCT []byte
-		if err := rows.Scan(&m.ID, &m.MessageID, &m.Subject, &subjectCT, &m.FromAddr, &m.ToAddrs, &m.CCAddrs, &m.BodyText, &m.Account); err != nil {
+		var subjectCT, fromAddrCT, toAddrsCT, ccAddrsCT, bodyTextCT []byte
+		if err := rows.Scan(&m.ID, &m.MessageID, &m.Subject, &subjectCT,
+			&m.FromAddr, &fromAddrCT, &m.ToAddrs, &toAddrsCT, &m.CCAddrs, &ccAddrsCT,
+			&m.BodyText, &bodyTextCT, &m.Account); err != nil {
 			return nil, fmt.Errorf("scan message: %w", err)
 		}
 		if m.Subject, err = d.decryptSubject(m.Subject, subjectCT); err != nil {
+			return nil, err
+		}
+		if m.FromAddr, err = d.decryptAddr(m.FromAddr, fromAddrCT); err != nil {
+			return nil, err
+		}
+		if m.ToAddrs, err = d.decryptAddr(m.ToAddrs, toAddrsCT); err != nil {
+			return nil, err
+		}
+		if m.CCAddrs, err = d.decryptAddr(m.CCAddrs, ccAddrsCT); err != nil {
+			return nil, err
+		}
+		if m.BodyText, err = d.decryptBody(m.BodyText, bodyTextCT); err != nil {
 			return nil, err
 		}
 		msgs = append(msgs, m)

--- a/cli/internal/store/local_drafts.go
+++ b/cli/internal/store/local_drafts.go
@@ -21,13 +21,18 @@ func (d *DB) SaveLocalDraft(draft *LocalDraft) error {
 	}
 	draft.ModifiedAt = now
 
-	_, err := d.db.Exec(`
-		INSERT INTO local_drafts (id, draft_json, created_at, modified_at)
-		VALUES (?, ?, ?, ?)
+	ct, err := d.encryptDraftJSON(draft.DraftJSON)
+	if err != nil {
+		return fmt.Errorf("encrypt draft_json: %w", err)
+	}
+	_, err = d.db.Exec(`
+		INSERT INTO local_drafts (id, draft_json, draft_json_ct, created_at, modified_at)
+		VALUES (?, ?, ?, ?, ?)
 		ON CONFLICT(id) DO UPDATE SET
 			draft_json = excluded.draft_json,
+			draft_json_ct = excluded.draft_json_ct,
 			modified_at = excluded.modified_at`,
-		draft.ID, draft.DraftJSON, draft.CreatedAt, draft.ModifiedAt)
+		draft.ID, draft.DraftJSON, ct, draft.CreatedAt, draft.ModifiedAt)
 	if err != nil {
 		return fmt.Errorf("save local draft: %w", err)
 	}
@@ -37,11 +42,15 @@ func (d *DB) SaveLocalDraft(draft *LocalDraft) error {
 // GetLocalDraft retrieves a local draft by ID.
 func (d *DB) GetLocalDraft(id string) (*LocalDraft, error) {
 	draft := &LocalDraft{}
+	var ct []byte
 	err := d.db.QueryRow(
-		"SELECT id, draft_json, created_at, modified_at FROM local_drafts WHERE id = ?", id,
-	).Scan(&draft.ID, &draft.DraftJSON, &draft.CreatedAt, &draft.ModifiedAt)
+		"SELECT id, draft_json, draft_json_ct, created_at, modified_at FROM local_drafts WHERE id = ?", id,
+	).Scan(&draft.ID, &draft.DraftJSON, &ct, &draft.CreatedAt, &draft.ModifiedAt)
 	if err != nil {
 		return nil, fmt.Errorf("get local draft: %w", err)
+	}
+	if draft.DraftJSON, err = d.decryptDraftJSON(draft.DraftJSON, ct); err != nil {
+		return nil, err
 	}
 	return draft, nil
 }
@@ -62,7 +71,7 @@ func (d *DB) DeleteLocalDraft(id string) error {
 // ListLocalDrafts returns all local drafts, newest first.
 func (d *DB) ListLocalDrafts() ([]*LocalDraft, error) {
 	rows, err := d.db.Query(
-		"SELECT id, draft_json, created_at, modified_at FROM local_drafts ORDER BY modified_at DESC")
+		"SELECT id, draft_json, draft_json_ct, created_at, modified_at FROM local_drafts ORDER BY modified_at DESC")
 	if err != nil {
 		return nil, fmt.Errorf("list local drafts: %w", err)
 	}
@@ -71,8 +80,12 @@ func (d *DB) ListLocalDrafts() ([]*LocalDraft, error) {
 	var drafts []*LocalDraft
 	for rows.Next() {
 		draft := &LocalDraft{}
-		if err := rows.Scan(&draft.ID, &draft.DraftJSON, &draft.CreatedAt, &draft.ModifiedAt); err != nil {
+		var ct []byte
+		if err := rows.Scan(&draft.ID, &draft.DraftJSON, &ct, &draft.CreatedAt, &draft.ModifiedAt); err != nil {
 			return nil, fmt.Errorf("scan local draft: %w", err)
+		}
+		if draft.DraftJSON, err = d.decryptDraftJSON(draft.DraftJSON, ct); err != nil {
+			return nil, err
 		}
 		drafts = append(drafts, draft)
 	}

--- a/cli/internal/store/messages.go
+++ b/cli/internal/store/messages.go
@@ -128,6 +128,20 @@ func (d *DB) insertMessageTx(tx *sql.Tx, msg *Message) error {
 		return fmt.Errorf("upsert message: %w", err)
 	}
 
+	// ADR-0001 step 7 (a+b): maintain the parallel blind FTS5 row. The
+	// old messages_fts trigger-pair still fires for the plaintext columns
+	// — step 7c flips reads to messages_blind_fts and step 7e drops the
+	// old triggers. DELETE+INSERT (vs UPDATE) because contentless FTS5
+	// columns can't be updated in place.
+	sTok, fTok, tTok, bTok := d.blindTokens(msg.Subject, msg.FromAddr, msg.ToAddrs, msg.BodyText)
+	if _, err := tx.Exec("DELETE FROM messages_blind_fts WHERE rowid = ?", msg.ID); err != nil {
+		return fmt.Errorf("blind fts delete: %w", err)
+	}
+	if _, err := tx.Exec(`INSERT INTO messages_blind_fts(rowid, subject_tok, from_tok, to_tok, body_tok)
+		VALUES (?, ?, ?, ?, ?)`, msg.ID, sTok, fTok, tTok, bTok); err != nil {
+		return fmt.Errorf("blind fts insert: %w", err)
+	}
+
 	return nil
 }
 

--- a/cli/internal/store/messages.go
+++ b/cli/internal/store/messages.go
@@ -79,6 +79,13 @@ func (d *DB) insertMessageTx(tx *sql.Tx, msg *Message) error {
 	if err != nil {
 		return fmt.Errorf("encrypt cc_addrs: %w", err)
 	}
+	// ADR-0001 step 6: non-boolean flag parts go to flags_other under
+	// the meta sub-key. Booleans (is_seen/is_flagged/is_deleted) are
+	// derived elsewhere in this insert path's downstream tag flow.
+	flagsOtherCT, err := d.encryptMeta(flagsOtherForEncryption(msg.Flags))
+	if err != nil {
+		return fmt.Errorf("encrypt flags_other: %w", err)
+	}
 
 	err = tx.QueryRow(`
 		INSERT INTO messages (
@@ -86,8 +93,8 @@ func (d *DB) insertMessageTx(tx *sql.Tx, msg *Message) error {
 			from_addr, from_addr_ct, to_addrs, to_addrs_ct, cc_addrs, cc_addrs_ct,
 			date, created_at,
 			body_text, body_text_ct, body_html, body_html_ct,
-			mailbox, flags, uid, size, fetched_body, account
-		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+			mailbox, flags, flags_other, uid, size, fetched_body, account
+		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 		ON CONFLICT(message_id, account) DO UPDATE SET
 			subject = excluded.subject,
 			subject_ct = excluded.subject_ct,
@@ -107,6 +114,7 @@ func (d *DB) insertMessageTx(tx *sql.Tx, msg *Message) error {
 			                 THEN excluded.body_html_ct ELSE messages.body_html_ct END,
 			fetched_body = MAX(messages.fetched_body, excluded.fetched_body),
 			flags = excluded.flags,
+			flags_other = excluded.flags_other,
 			uid = CASE WHEN excluded.uid > 0 THEN excluded.uid ELSE messages.uid END,
 			mailbox = CASE WHEN excluded.mailbox != '' THEN excluded.mailbox ELSE messages.mailbox END
 		RETURNING id`,
@@ -114,7 +122,7 @@ func (d *DB) insertMessageTx(tx *sql.Tx, msg *Message) error {
 		msg.FromAddr, fromAddrCT, msg.ToAddrs, toAddrsCT, msg.CCAddrs, ccAddrsCT,
 		msg.Date, msg.CreatedAt,
 		msg.BodyText, bodyTextCT, msg.BodyHTML, bodyHTMLCT,
-		msg.Mailbox, msg.Flags, msg.UID, msg.Size, fetchedBody, msg.Account,
+		msg.Mailbox, msg.Flags, flagsOtherCT, msg.UID, msg.Size, fetchedBody, msg.Account,
 	).Scan(&msg.ID)
 	if err != nil {
 		return fmt.Errorf("upsert message: %w", err)

--- a/cli/internal/store/messages.go
+++ b/cli/internal/store/messages.go
@@ -51,37 +51,70 @@ func (d *DB) insertMessageTx(tx *sql.Tx, msg *Message) error {
 		fetchedBody = 1
 	}
 
-	// ADR-0001 step 5: encrypted subject lives in subject_ct alongside the
-	// plaintext subject column (which FTS5 still indexes until step 7).
+	// ADR-0001 step 5: encrypted subject in subject_ct, plaintext subject
+	// stays for FTS5 until step 7.
 	subjectCT, err := d.encryptSubject(msg.Subject)
 	if err != nil {
 		return fmt.Errorf("encrypt subject: %w", err)
+	}
+	// ADR-0001 step 6: same pattern for body_text / body_html.
+	bodyTextCT, err := d.encryptBody(msg.BodyText)
+	if err != nil {
+		return fmt.Errorf("encrypt body_text: %w", err)
+	}
+	bodyHTMLCT, err := d.encryptBody(msg.BodyHTML)
+	if err != nil {
+		return fmt.Errorf("encrypt body_html: %w", err)
+	}
+	// ADR-0001 step 6: addrs columns.
+	fromAddrCT, err := d.encryptAddr(msg.FromAddr)
+	if err != nil {
+		return fmt.Errorf("encrypt from_addr: %w", err)
+	}
+	toAddrsCT, err := d.encryptAddr(msg.ToAddrs)
+	if err != nil {
+		return fmt.Errorf("encrypt to_addrs: %w", err)
+	}
+	ccAddrsCT, err := d.encryptAddr(msg.CCAddrs)
+	if err != nil {
+		return fmt.Errorf("encrypt cc_addrs: %w", err)
 	}
 
 	err = tx.QueryRow(`
 		INSERT INTO messages (
 			message_id, thread_id, in_reply_to, refs, subject, subject_ct,
-			from_addr, to_addrs, cc_addrs, date, created_at,
-			body_text, body_html, mailbox, flags, uid, size, fetched_body, account
-		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+			from_addr, from_addr_ct, to_addrs, to_addrs_ct, cc_addrs, cc_addrs_ct,
+			date, created_at,
+			body_text, body_text_ct, body_html, body_html_ct,
+			mailbox, flags, uid, size, fetched_body, account
+		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 		ON CONFLICT(message_id, account) DO UPDATE SET
 			subject = excluded.subject,
 			subject_ct = excluded.subject_ct,
 			from_addr = excluded.from_addr,
+			from_addr_ct = excluded.from_addr_ct,
 			to_addrs = excluded.to_addrs,
+			to_addrs_ct = excluded.to_addrs_ct,
 			cc_addrs = excluded.cc_addrs,
+			cc_addrs_ct = excluded.cc_addrs_ct,
 			body_text = CASE WHEN excluded.fetched_body = 1 AND messages.fetched_body = 0
 			                 THEN excluded.body_text ELSE messages.body_text END,
+			body_text_ct = CASE WHEN excluded.fetched_body = 1 AND messages.fetched_body = 0
+			                 THEN excluded.body_text_ct ELSE messages.body_text_ct END,
 			body_html = CASE WHEN excluded.fetched_body = 1 AND messages.fetched_body = 0
 			                 THEN excluded.body_html ELSE messages.body_html END,
+			body_html_ct = CASE WHEN excluded.fetched_body = 1 AND messages.fetched_body = 0
+			                 THEN excluded.body_html_ct ELSE messages.body_html_ct END,
 			fetched_body = MAX(messages.fetched_body, excluded.fetched_body),
 			flags = excluded.flags,
 			uid = CASE WHEN excluded.uid > 0 THEN excluded.uid ELSE messages.uid END,
 			mailbox = CASE WHEN excluded.mailbox != '' THEN excluded.mailbox ELSE messages.mailbox END
 		RETURNING id`,
 		msg.MessageID, threadID, msg.InReplyTo, msg.Refs, msg.Subject, subjectCT,
-		msg.FromAddr, msg.ToAddrs, msg.CCAddrs, msg.Date, msg.CreatedAt,
-		msg.BodyText, msg.BodyHTML, msg.Mailbox, msg.Flags, msg.UID, msg.Size, fetchedBody, msg.Account,
+		msg.FromAddr, fromAddrCT, msg.ToAddrs, toAddrsCT, msg.CCAddrs, ccAddrsCT,
+		msg.Date, msg.CreatedAt,
+		msg.BodyText, bodyTextCT, msg.BodyHTML, bodyHTMLCT,
+		msg.Mailbox, msg.Flags, msg.UID, msg.Size, fetchedBody, msg.Account,
 	).Scan(&msg.ID)
 	if err != nil {
 		return fmt.Errorf("upsert message: %w", err)
@@ -91,11 +124,23 @@ func (d *DB) insertMessageTx(tx *sql.Tx, msg *Message) error {
 }
 
 // UpdateBody updates the body text and HTML for a message (lazy body fetch).
+// Writes both the plaintext columns (FTS5 still indexes body_text until
+// step 7) and the encrypted *_ct columns introduced in v11.
 func (d *DB) UpdateBody(messageID, bodyText, bodyHTML string) error {
+	bodyTextCT, err := d.encryptBody(bodyText)
+	if err != nil {
+		return fmt.Errorf("encrypt body_text: %w", err)
+	}
+	bodyHTMLCT, err := d.encryptBody(bodyHTML)
+	if err != nil {
+		return fmt.Errorf("encrypt body_html: %w", err)
+	}
 	result, err := d.db.Exec(`
-		UPDATE messages SET body_text = ?, body_html = ?, fetched_body = 1
+		UPDATE messages SET body_text = ?, body_text_ct = ?,
+		                    body_html = ?, body_html_ct = ?,
+		                    fetched_body = 1
 		WHERE message_id = ?`,
-		bodyText, bodyHTML, messageID)
+		bodyText, bodyTextCT, bodyHTML, bodyHTMLCT, messageID)
 	if err != nil {
 		return fmt.Errorf("update body: %w", err)
 	}
@@ -134,16 +179,20 @@ func (d *DB) BackfillUID(messageID, account string, uid uint32, mailbox string) 
 func (d *DB) GetByMessageID(messageID string) (*Message, error) {
 	msg := &Message{}
 	var fetchedBody int
-	var subjectCT []byte
+	var subjectCT, fromAddrCT, toAddrsCT, ccAddrsCT, bodyTextCT, bodyHTMLCT []byte
 	err := d.db.QueryRow(`
 		SELECT id, message_id, thread_id, in_reply_to, refs, subject, subject_ct,
-		       from_addr, to_addrs, cc_addrs, date, created_at,
-		       body_text, body_html, mailbox, flags, uid, size, fetched_body, account
+		       from_addr, from_addr_ct, to_addrs, to_addrs_ct, cc_addrs, cc_addrs_ct,
+		       date, created_at,
+		       body_text, body_text_ct, body_html, body_html_ct,
+		       mailbox, flags, uid, size, fetched_body, account
 		FROM messages WHERE message_id = ? LIMIT 1`, messageID,
 	).Scan(
 		&msg.ID, &msg.MessageID, &msg.ThreadID, &msg.InReplyTo, &msg.Refs, &msg.Subject, &subjectCT,
-		&msg.FromAddr, &msg.ToAddrs, &msg.CCAddrs, &msg.Date, &msg.CreatedAt,
-		&msg.BodyText, &msg.BodyHTML, &msg.Mailbox, &msg.Flags, &msg.UID, &msg.Size, &fetchedBody, &msg.Account,
+		&msg.FromAddr, &fromAddrCT, &msg.ToAddrs, &toAddrsCT, &msg.CCAddrs, &ccAddrsCT,
+		&msg.Date, &msg.CreatedAt,
+		&msg.BodyText, &bodyTextCT, &msg.BodyHTML, &bodyHTMLCT,
+		&msg.Mailbox, &msg.Flags, &msg.UID, &msg.Size, &fetchedBody, &msg.Account,
 	)
 	if err == sql.ErrNoRows {
 		return nil, nil
@@ -155,6 +204,21 @@ func (d *DB) GetByMessageID(messageID string) (*Message, error) {
 	if msg.Subject, err = d.decryptSubject(msg.Subject, subjectCT); err != nil {
 		return nil, err
 	}
+	if msg.FromAddr, err = d.decryptAddr(msg.FromAddr, fromAddrCT); err != nil {
+		return nil, err
+	}
+	if msg.ToAddrs, err = d.decryptAddr(msg.ToAddrs, toAddrsCT); err != nil {
+		return nil, err
+	}
+	if msg.CCAddrs, err = d.decryptAddr(msg.CCAddrs, ccAddrsCT); err != nil {
+		return nil, err
+	}
+	if msg.BodyText, err = d.decryptBody(msg.BodyText, bodyTextCT); err != nil {
+		return nil, err
+	}
+	if msg.BodyHTML, err = d.decryptBody(msg.BodyHTML, bodyHTMLCT); err != nil {
+		return nil, err
+	}
 	return msg, nil
 }
 
@@ -163,8 +227,10 @@ func (d *DB) GetByMessageID(messageID string) (*Message, error) {
 func (d *DB) GetByThread(threadID string) ([]*Message, error) {
 	rows, err := d.db.Query(`
 		SELECT id, message_id, thread_id, in_reply_to, refs, subject, subject_ct,
-		       from_addr, to_addrs, cc_addrs, date, created_at,
-		       body_text, body_html, mailbox, flags, uid, size, fetched_body, account
+		       from_addr, from_addr_ct, to_addrs, to_addrs_ct, cc_addrs, cc_addrs_ct,
+		       date, created_at,
+		       body_text, body_text_ct, body_html, body_html_ct,
+		       mailbox, flags, uid, size, fetched_body, account
 		FROM messages WHERE thread_id = ?
 		ORDER BY date ASC`, threadID)
 	if err != nil {
@@ -196,8 +262,10 @@ func (d *DB) GetByThread(threadID string) ([]*Message, error) {
 func (d *DB) GetAllByThread(threadID string) ([]*Message, error) {
 	rows, err := d.db.Query(`
 		SELECT id, message_id, thread_id, in_reply_to, refs, subject, subject_ct,
-		       from_addr, to_addrs, cc_addrs, date, created_at,
-		       body_text, body_html, mailbox, flags, uid, size, fetched_body, account
+		       from_addr, from_addr_ct, to_addrs, to_addrs_ct, cc_addrs, cc_addrs_ct,
+		       date, created_at,
+		       body_text, body_text_ct, body_html, body_html_ct,
+		       mailbox, flags, uid, size, fetched_body, account
 		FROM messages WHERE thread_id = ?
 		ORDER BY date ASC`, threadID)
 	if err != nil {
@@ -315,23 +383,42 @@ func (d *DB) GetRecipientAddresses() ([]string, error) {
 }
 
 // scanMessages scans rows into a slice of Message pointers. Caller's
-// SELECT must include subject_ct between subject and from_addr.
+// SELECT must interleave each encrypted column's *_ct BLOB right after
+// its plaintext column, in this order: subject, from_addr, to_addrs,
+// cc_addrs, body_text, body_html.
 func (d *DB) scanMessages(rows *sql.Rows) ([]*Message, error) {
 	var msgs []*Message
 	for rows.Next() {
 		msg := &Message{}
 		var fetchedBody int
-		var subjectCT []byte
+		var subjectCT, fromAddrCT, toAddrsCT, ccAddrsCT, bodyTextCT, bodyHTMLCT []byte
 		err := rows.Scan(
 			&msg.ID, &msg.MessageID, &msg.ThreadID, &msg.InReplyTo, &msg.Refs, &msg.Subject, &subjectCT,
-			&msg.FromAddr, &msg.ToAddrs, &msg.CCAddrs, &msg.Date, &msg.CreatedAt,
-			&msg.BodyText, &msg.BodyHTML, &msg.Mailbox, &msg.Flags, &msg.UID, &msg.Size, &fetchedBody, &msg.Account,
+			&msg.FromAddr, &fromAddrCT, &msg.ToAddrs, &toAddrsCT, &msg.CCAddrs, &ccAddrsCT,
+			&msg.Date, &msg.CreatedAt,
+			&msg.BodyText, &bodyTextCT, &msg.BodyHTML, &bodyHTMLCT,
+			&msg.Mailbox, &msg.Flags, &msg.UID, &msg.Size, &fetchedBody, &msg.Account,
 		)
 		if err != nil {
 			return nil, fmt.Errorf("scan message: %w", err)
 		}
 		msg.FetchedBody = fetchedBody == 1
 		if msg.Subject, err = d.decryptSubject(msg.Subject, subjectCT); err != nil {
+			return nil, err
+		}
+		if msg.FromAddr, err = d.decryptAddr(msg.FromAddr, fromAddrCT); err != nil {
+			return nil, err
+		}
+		if msg.ToAddrs, err = d.decryptAddr(msg.ToAddrs, toAddrsCT); err != nil {
+			return nil, err
+		}
+		if msg.CCAddrs, err = d.decryptAddr(msg.CCAddrs, ccAddrsCT); err != nil {
+			return nil, err
+		}
+		if msg.BodyText, err = d.decryptBody(msg.BodyText, bodyTextCT); err != nil {
+			return nil, err
+		}
+		if msg.BodyHTML, err = d.decryptBody(msg.BodyHTML, bodyHTMLCT); err != nil {
 			return nil, err
 		}
 		msgs = append(msgs, msg)

--- a/cli/internal/store/outbox.go
+++ b/cli/internal/store/outbox.go
@@ -10,9 +10,13 @@ import (
 // sendAfter is a Unix timestamp before which the worker will not dequeue this item.
 // Use 0 for immediate sending.
 func (d *DB) Enqueue(draftJSON string, sendAfter int64) (int64, error) {
+	ct, err := d.encryptDraftJSON(draftJSON)
+	if err != nil {
+		return 0, fmt.Errorf("encrypt draft_json: %w", err)
+	}
 	result, err := d.db.Exec(
-		"INSERT INTO outbox (draft_json, created_at, send_after) VALUES (?, ?, ?)",
-		draftJSON, time.Now().Unix(), sendAfter)
+		"INSERT INTO outbox (draft_json, draft_json_ct, created_at, send_after) VALUES (?, ?, ?, ?)",
+		draftJSON, ct, time.Now().Unix(), sendAfter)
 	if err != nil {
 		return 0, fmt.Errorf("enqueue: %w", err)
 	}
@@ -27,14 +31,14 @@ func (d *DB) Enqueue(draftJSON string, sendAfter int64) (int64, error) {
 func (d *DB) Dequeue() (*OutboxItem, error) {
 	now := time.Now().Unix()
 	row := d.db.QueryRow(`
-		SELECT id, draft_json, attempts, last_error, created_at
+		SELECT id, draft_json, draft_json_ct, attempts, last_error, created_at
 		FROM outbox
 		WHERE attempts < 5
 		  AND send_after <= ?
 		  AND (attempts = 0 OR last_attempted_at + attempts * attempts * 30 <= ?)
 		ORDER BY attempts ASC, created_at ASC
 		LIMIT 1`, now, now)
-	return scanOutboxItem(row)
+	return d.scanOutboxItem(row)
 }
 
 // MarkAttempted increments the attempt count, records the error, and
@@ -76,7 +80,7 @@ func (d *DB) DeleteOutboxItem(id int64) error {
 // ListOutbox returns all outbox items ordered by creation time (newest first).
 func (d *DB) ListOutbox() ([]OutboxItem, error) {
 	rows, err := d.db.Query(`
-		SELECT id, draft_json, attempts, last_error, created_at
+		SELECT id, draft_json, draft_json_ct, attempts, last_error, created_at
 		FROM outbox
 		ORDER BY created_at DESC`)
 	if err != nil {
@@ -87,9 +91,13 @@ func (d *DB) ListOutbox() ([]OutboxItem, error) {
 	var items []OutboxItem
 	for rows.Next() {
 		var item OutboxItem
+		var ct []byte
 		var lastErr sql.NullString
-		if err := rows.Scan(&item.ID, &item.DraftJSON, &item.Attempts, &lastErr, &item.CreatedAt); err != nil {
+		if err := rows.Scan(&item.ID, &item.DraftJSON, &ct, &item.Attempts, &lastErr, &item.CreatedAt); err != nil {
 			return nil, fmt.Errorf("scan outbox item: %w", err)
+		}
+		if item.DraftJSON, err = d.decryptDraftJSON(item.DraftJSON, ct); err != nil {
+			return nil, err
 		}
 		if lastErr.Valid {
 			item.LastError = lastErr.String
@@ -99,16 +107,21 @@ func (d *DB) ListOutbox() ([]OutboxItem, error) {
 	return items, rows.Err()
 }
 
-// scanOutboxItem scans a single row into an OutboxItem.
-func scanOutboxItem(row *sql.Row) (*OutboxItem, error) {
+// scanOutboxItem scans a single row into an OutboxItem. The caller's
+// SELECT must place draft_json_ct directly after draft_json.
+func (d *DB) scanOutboxItem(row *sql.Row) (*OutboxItem, error) {
 	item := &OutboxItem{}
+	var ct []byte
 	var lastErr sql.NullString
-	err := row.Scan(&item.ID, &item.DraftJSON, &item.Attempts, &lastErr, &item.CreatedAt)
+	err := row.Scan(&item.ID, &item.DraftJSON, &ct, &item.Attempts, &lastErr, &item.CreatedAt)
 	if err == sql.ErrNoRows {
 		return nil, nil
 	}
 	if err != nil {
 		return nil, fmt.Errorf("scan outbox item: %w", err)
+	}
+	if item.DraftJSON, err = d.decryptDraftJSON(item.DraftJSON, ct); err != nil {
+		return nil, err
 	}
 	if lastErr.Valid {
 		item.LastError = lastErr.String

--- a/cli/internal/store/store.go
+++ b/cli/internal/store/store.go
@@ -181,6 +181,30 @@ func (d *DB) Init() error {
 			last_attempted_at INTEGER DEFAULT 0,
 			send_after INTEGER DEFAULT 0
 		)`,
+
+		// local_drafts was first added in the v6→v7 migration. Listing it
+		// here too keeps it created for any fresh DB regardless of which
+		// version Init() lands on, so later ALTER TABLE migrations don't
+		// trip on its absence in tests that seed schema_version > 7.
+		`CREATE TABLE IF NOT EXISTS local_drafts (
+			id TEXT PRIMARY KEY,
+			draft_json TEXT NOT NULL,
+			created_at INTEGER NOT NULL,
+			modified_at INTEGER NOT NULL
+		)`,
+
+		// mailboxes and accounts were first added in the v8→v9 migration
+		// (ADR-0001 step 1). Same idempotency story as local_drafts —
+		// keep them present here so seeds at schema_version > 9 don't
+		// fail later ALTER TABLE migrations that target them.
+		`CREATE TABLE IF NOT EXISTS mailboxes (
+			id INTEGER PRIMARY KEY AUTOINCREMENT,
+			name TEXT NOT NULL UNIQUE
+		)`,
+		`CREATE TABLE IF NOT EXISTS accounts (
+			id INTEGER PRIMARY KEY AUTOINCREMENT,
+			name TEXT NOT NULL UNIQUE
+		)`,
 	}
 
 	for _, stmt := range stmts {
@@ -566,6 +590,67 @@ func (d *DB) migrate() error {
 		if _, err := d.db.Exec("UPDATE schema_version SET version = 13 WHERE rowid = 1"); err != nil {
 			return fmt.Errorf("migrate v12→v13 bump: %w", err)
 		}
+		version = 13
+	}
+
+	if version < 14 {
+		// ADR-0001 step 6: encrypt local_drafts.draft_json and
+		// outbox.draft_json (draft_key). Two separate tables, same
+		// sub-key — both hold pending outgoing mail, both deserve at-rest
+		// protection. Schema is parallel ALTER on each table.
+		for _, table := range []string{"local_drafts", "outbox"} {
+			has, err := hasColumn(d.db, table, "draft_json_ct")
+			if err != nil {
+				return fmt.Errorf("migrate v13→v14 inspect %s.draft_json_ct: %w", table, err)
+			}
+			if !has {
+				if _, err := d.db.Exec("ALTER TABLE " + table + " ADD COLUMN draft_json_ct BLOB"); err != nil {
+					return fmt.Errorf("migrate v13→v14 add %s.draft_json_ct: %w", table, err)
+				}
+			}
+		}
+		if err := d.backfillDraftJSONCt(); err != nil {
+			return fmt.Errorf("migrate v13→v14 backfill: %w", err)
+		}
+		if _, err := d.db.Exec("UPDATE schema_version SET version = 14 WHERE rowid = 1"); err != nil {
+			return fmt.Errorf("migrate v13→v14 bump: %w", err)
+		}
+		version = 14
+	}
+
+	if version < 15 {
+		// ADR-0001 step 6: encrypt the meta_key columns — mailbox names
+		// (folder labels), account names, and the non-boolean parts of
+		// messages.flags. Plaintext columns stay alongside until step 7;
+		// reads keep using them. This commit just lays down the cipher-
+		// text columns plus encrypt-on-write for messages.flags_other.
+		//
+		// mailboxes.name and accounts.name have UNIQUE constraints that
+		// the encrypted (random-nonce) form cannot replicate, so the
+		// plaintext UNIQUE column stays as the lookup key until step 7
+		// introduces deterministic blind-tokens.
+		alters := []struct{ table, col string }{
+			{"mailboxes", "name_ct"},
+			{"accounts", "name_ct"},
+			{"messages", "flags_other"},
+		}
+		for _, a := range alters {
+			has, err := hasColumn(d.db, a.table, a.col)
+			if err != nil {
+				return fmt.Errorf("migrate v14→v15 inspect %s.%s: %w", a.table, a.col, err)
+			}
+			if !has {
+				if _, err := d.db.Exec("ALTER TABLE " + a.table + " ADD COLUMN " + a.col + " BLOB"); err != nil {
+					return fmt.Errorf("migrate v14→v15 add %s.%s: %w", a.table, a.col, err)
+				}
+			}
+		}
+		if err := d.backfillMetaCt(); err != nil {
+			return fmt.Errorf("migrate v14→v15 backfill: %w", err)
+		}
+		if _, err := d.db.Exec("UPDATE schema_version SET version = 15 WHERE rowid = 1"); err != nil {
+			return fmt.Errorf("migrate v14→v15 bump: %w", err)
+		}
 	}
 
 	return nil
@@ -766,6 +851,256 @@ func (d *DB) backfillBodyCt() error {
 		if _, err := stmt.Exec(textCT, htmlCT, p.id); err != nil {
 			return fmt.Errorf("update id=%d: %w", p.id, err)
 		}
+	}
+	return tx.Commit()
+}
+
+// encryptMeta seals plain with the meta sub-key (mailbox/account names,
+// non-boolean flag parts). Empty plaintext maps to nil → NULL column.
+func (d *DB) encryptMeta(plain string) ([]byte, error) {
+	if plain == "" {
+		return nil, nil
+	}
+	return dbcrypto.Encrypt(d.keyring.Meta, []byte(plain))
+}
+
+// decryptMeta returns plaintext for a meta_key column, falling back to
+// the plaintext column when ct IS NULL. Decrypt failures on non-nil ct
+// are hard errors. Not yet called by production reads — step 7 will wire
+// the lookup paths to prefer ct over the plaintext columns that die then.
+func (d *DB) decryptMeta(plain string, ct []byte) (string, error) {
+	if len(ct) == 0 {
+		return plain, nil
+	}
+	out, err := dbcrypto.Decrypt(d.keyring.Meta, ct)
+	if err != nil {
+		return "", fmt.Errorf("decrypt meta: %w", err)
+	}
+	return string(out), nil
+}
+
+// flagsOtherForEncryption returns the subset of a space-separated IMAP
+// flags string that ADR-0001 §3 marks for meta_key encryption: everything
+// except the three boolean-tracked standard flags (\Seen, \Flagged,
+// \Deleted) that already live as O(1) integer columns. The remaining
+// flags include \Answered, \Draft, \Recent, $Sensitive and any
+// user-defined keywords — all preserved verbatim in their original order.
+func flagsOtherForEncryption(flags string) string {
+	if flags == "" {
+		return ""
+	}
+	parts := strings.Fields(flags)
+	out := parts[:0]
+	for _, p := range parts {
+		switch p {
+		case `\Seen`, `\Flagged`, `\Deleted`:
+			// covered by is_seen/is_flagged/is_deleted booleans
+		default:
+			out = append(out, p)
+		}
+	}
+	return strings.Join(out, " ")
+}
+
+// backfillMetaCt encrypts existing mailbox names, account names, and the
+// non-boolean flags subset of each message into the new BLOB columns.
+// Single transaction across all three so a mid-loop failure rolls back
+// cleanly.
+func (d *DB) backfillMetaCt() error {
+	if d.keyring == nil || d.keyring.Meta == nil {
+		return fmt.Errorf("no keyring available for meta backfill")
+	}
+	tx, err := d.db.Begin()
+	if err != nil {
+		return fmt.Errorf("begin tx: %w", err)
+	}
+	defer tx.Rollback() //nolint:errcheck
+
+	// mailboxes + accounts share the same shape: id + name → name_ct.
+	for _, table := range []string{"mailboxes", "accounts"} {
+		rows, err := tx.Query(`SELECT id, name FROM ` + table + `
+			WHERE name IS NOT NULL AND name <> '' AND name_ct IS NULL`)
+		if err != nil {
+			return fmt.Errorf("select %s: %w", table, err)
+		}
+		type pending struct {
+			id   int64
+			name string
+		}
+		var batch []pending
+		for rows.Next() {
+			var p pending
+			if err := rows.Scan(&p.id, &p.name); err != nil {
+				rows.Close()
+				return fmt.Errorf("scan %s: %w", table, err)
+			}
+			batch = append(batch, p)
+		}
+		rows.Close()
+		if err := rows.Err(); err != nil {
+			return fmt.Errorf("iterate %s: %w", table, err)
+		}
+
+		stmt, err := tx.Prepare("UPDATE " + table + " SET name_ct = ? WHERE id = ?")
+		if err != nil {
+			return fmt.Errorf("prepare %s update: %w", table, err)
+		}
+		for _, p := range batch {
+			ct, err := d.encryptMeta(p.name)
+			if err != nil {
+				stmt.Close()
+				return fmt.Errorf("encrypt %s name id=%d: %w", table, p.id, err)
+			}
+			if _, err := stmt.Exec(ct, p.id); err != nil {
+				stmt.Close()
+				return fmt.Errorf("update %s id=%d: %w", table, p.id, err)
+			}
+		}
+		stmt.Close()
+	}
+
+	// messages.flags_other gets the non-boolean subset of the existing
+	// flags TEXT — booleans are already covered by is_{seen,flagged,deleted}.
+	rows, err := tx.Query(`SELECT id, flags FROM messages
+		WHERE flags IS NOT NULL AND flags <> '' AND flags_other IS NULL`)
+	if err != nil {
+		return fmt.Errorf("select messages: %w", err)
+	}
+	type pending struct {
+		id    int64
+		flags string
+	}
+	var batch []pending
+	for rows.Next() {
+		var p pending
+		if err := rows.Scan(&p.id, &p.flags); err != nil {
+			rows.Close()
+			return fmt.Errorf("scan messages: %w", err)
+		}
+		batch = append(batch, p)
+	}
+	rows.Close()
+	if err := rows.Err(); err != nil {
+		return fmt.Errorf("iterate messages: %w", err)
+	}
+
+	stmt, err := tx.Prepare("UPDATE messages SET flags_other = ? WHERE id = ?")
+	if err != nil {
+		return fmt.Errorf("prepare messages update: %w", err)
+	}
+	defer stmt.Close()
+	for _, p := range batch {
+		other := flagsOtherForEncryption(p.flags)
+		ct, err := d.encryptMeta(other)
+		if err != nil {
+			return fmt.Errorf("encrypt flags id=%d: %w", p.id, err)
+		}
+		if _, err := stmt.Exec(ct, p.id); err != nil {
+			return fmt.Errorf("update messages id=%d: %w", p.id, err)
+		}
+	}
+	return tx.Commit()
+}
+
+// encryptDraftJSON seals plain with the draft sub-key. Empty plaintext
+// maps to nil so draft_json_ct stays NULL — same convention as the other
+// encrypt* helpers.
+func (d *DB) encryptDraftJSON(plain string) ([]byte, error) {
+	if plain == "" {
+		return nil, nil
+	}
+	return dbcrypto.Encrypt(d.keyring.Draft, []byte(plain))
+}
+
+// decryptDraftJSON returns plaintext draft JSON, preferring ct when set.
+// Decrypt failures on non-nil ct are hard errors.
+func (d *DB) decryptDraftJSON(plain string, ct []byte) (string, error) {
+	if len(ct) == 0 {
+		return plain, nil
+	}
+	out, err := dbcrypto.Decrypt(d.keyring.Draft, ct)
+	if err != nil {
+		return "", fmt.Errorf("decrypt draft_json: %w", err)
+	}
+	return string(out), nil
+}
+
+// backfillDraftJSONCt encrypts every existing draft_json across both
+// local_drafts and outbox into their new draft_json_ct BLOB columns.
+// One transaction spans both tables so a mid-loop failure rolls back
+// cleanly. Volumes are small in practice (drafts plus pending sends)
+// so a single batch in RAM is fine.
+func (d *DB) backfillDraftJSONCt() error {
+	if d.keyring == nil || d.keyring.Draft == nil {
+		return fmt.Errorf("no keyring available for draft backfill")
+	}
+	tx, err := d.db.Begin()
+	if err != nil {
+		return fmt.Errorf("begin tx: %w", err)
+	}
+	defer tx.Rollback() //nolint:errcheck
+
+	// Two tables, same shape — fold them through one loop.
+	for _, table := range []struct {
+		name    string
+		pkCol   string // primary key column (TEXT for local_drafts, INTEGER for outbox)
+		pkScanT string // "string" or "int64"
+	}{
+		{"local_drafts", "id", "string"},
+		{"outbox", "id", "int64"},
+	} {
+		rows, err := tx.Query(`SELECT ` + table.pkCol + `, draft_json FROM ` + table.name + `
+			WHERE draft_json IS NOT NULL AND draft_json <> '' AND draft_json_ct IS NULL`)
+		if err != nil {
+			return fmt.Errorf("select %s: %w", table.name, err)
+		}
+		type pending struct {
+			idStr string
+			idInt int64
+			json  string
+		}
+		var batch []pending
+		for rows.Next() {
+			var p pending
+			if table.pkScanT == "string" {
+				if err := rows.Scan(&p.idStr, &p.json); err != nil {
+					rows.Close()
+					return fmt.Errorf("scan %s: %w", table.name, err)
+				}
+			} else {
+				if err := rows.Scan(&p.idInt, &p.json); err != nil {
+					rows.Close()
+					return fmt.Errorf("scan %s: %w", table.name, err)
+				}
+			}
+			batch = append(batch, p)
+		}
+		rows.Close()
+		if err := rows.Err(); err != nil {
+			return fmt.Errorf("iterate %s rows: %w", table.name, err)
+		}
+
+		stmt, err := tx.Prepare("UPDATE " + table.name + " SET draft_json_ct = ? WHERE " + table.pkCol + " = ?")
+		if err != nil {
+			return fmt.Errorf("prepare update %s: %w", table.name, err)
+		}
+		for _, p := range batch {
+			ct, err := d.encryptDraftJSON(p.json)
+			if err != nil {
+				stmt.Close()
+				return fmt.Errorf("encrypt %s draft: %w", table.name, err)
+			}
+			if table.pkScanT == "string" {
+				_, err = stmt.Exec(ct, p.idStr)
+			} else {
+				_, err = stmt.Exec(ct, p.idInt)
+			}
+			if err != nil {
+				stmt.Close()
+				return fmt.Errorf("update %s: %w", table.name, err)
+			}
+		}
+		stmt.Close()
 	}
 	return tx.Commit()
 }

--- a/cli/internal/store/store.go
+++ b/cli/internal/store/store.go
@@ -651,6 +651,45 @@ func (d *DB) migrate() error {
 		if _, err := d.db.Exec("UPDATE schema_version SET version = 15 WHERE rowid = 1"); err != nil {
 			return fmt.Errorf("migrate v14→v15 bump: %w", err)
 		}
+		version = 15
+	}
+
+	if version < 16 {
+		// ADR-0001 step 7 (a+b): blind-token FTS5 infrastructure.
+		// Stand up a parallel contentless FTS5 table that indexes
+		// HMAC-truncated tokens (no plaintext leaves the encrypted
+		// column world). The existing messages_fts table keeps serving
+		// search.go reads until step 7c flips the search path.
+		//
+		// contentless_delete=1 lets us DELETE FROM the FTS table by
+		// rowid (no FTS-specific 'delete' sentinel insert) — needed
+		// for the messages-DELETE trigger to stay simple.
+		stmts := []string{
+			`CREATE VIRTUAL TABLE IF NOT EXISTS messages_blind_fts USING fts5(
+				subject_tok, from_tok, to_tok, body_tok,
+				content='',
+				contentless_delete=1,
+				tokenize='unicode61 remove_diacritics 0'
+			)`,
+			// On messages DELETE, drop the parallel FTS row by rowid.
+			// INSERT/UPDATE maintenance happens Go-side (insertMessageTx /
+			// UpdateBody) since we need the Go tokenizer with the
+			// fts_token sub-key, which SQLite triggers can't reach.
+			`CREATE TRIGGER IF NOT EXISTS messages_blind_fts_ad AFTER DELETE ON messages BEGIN
+				DELETE FROM messages_blind_fts WHERE rowid = old.id;
+			END`,
+		}
+		for _, s := range stmts {
+			if _, err := d.db.Exec(s); err != nil {
+				return fmt.Errorf("migrate v15→v16 schema: %w", err)
+			}
+		}
+		if err := d.backfillBlindFTS(); err != nil {
+			return fmt.Errorf("migrate v15→v16 backfill: %w", err)
+		}
+		if _, err := d.db.Exec("UPDATE schema_version SET version = 16 WHERE rowid = 1"); err != nil {
+			return fmt.Errorf("migrate v15→v16 bump: %w", err)
+		}
 	}
 
 	return nil
@@ -850,6 +889,102 @@ func (d *DB) backfillBodyCt() error {
 		}
 		if _, err := stmt.Exec(textCT, htmlCT, p.id); err != nil {
 			return fmt.Errorf("update id=%d: %w", p.id, err)
+		}
+	}
+	return tx.Commit()
+}
+
+// blindTokens returns the four space-separated FTS5-ready token strings
+// for one message in the order (subject_tok, from_tok, to_tok, body_tok).
+// Each field is run through dbcrypto.TokenizeFTS under the FTSToken
+// sub-key. Empty plaintext maps to "" — FTS5 stores empty columns fine.
+func (d *DB) blindTokens(subject, fromAddr, toAddrs, bodyText string) (sTok, fTok, tTok, bTok string) {
+	k := d.keyring.FTSToken
+	return dbcrypto.TokenizeFTS(k, subject),
+		dbcrypto.TokenizeFTS(k, fromAddr),
+		dbcrypto.TokenizeFTS(k, toAddrs),
+		dbcrypto.TokenizeFTS(k, bodyText)
+}
+
+// backfillBlindFTS populates messages_blind_fts for every existing row.
+// Reads plaintext (still present until step 7e) via the encrypted-ct
+// columns where available so the tokenization is identical to what
+// step-7c reads will produce after the plaintext columns die.
+//
+// Streams via row iteration rather than batching into RAM because body
+// payloads can be MB-sized on real mail and the working set across 20k+
+// messages would otherwise top a gigabyte.
+func (d *DB) backfillBlindFTS() error {
+	if d.keyring == nil || d.keyring.FTSToken == nil {
+		return fmt.Errorf("no keyring available for blind FTS backfill")
+	}
+	tx, err := d.db.Begin()
+	if err != nil {
+		return fmt.Errorf("begin tx: %w", err)
+	}
+	defer tx.Rollback() //nolint:errcheck
+
+	// Skip rows that already have a blind FTS entry (idempotent retry).
+	// Joining against messages_blind_fts directly is awkward (contentless
+	// FTS5 doesn't expose a real table), so use NOT EXISTS on rowid.
+	// COALESCE the plaintext columns to '' — early-schema messages can
+	// have NULL subject/from/to/body where the new schema treats them as
+	// empty strings. NULL would error scanning into a *string.
+	rows, err := tx.Query(`SELECT m.id,
+		COALESCE(m.subject,    ''), m.subject_ct,
+		COALESCE(m.from_addr,  ''), m.from_addr_ct,
+		COALESCE(m.to_addrs,   ''), m.to_addrs_ct,
+		COALESCE(m.body_text,  ''), m.body_text_ct
+		FROM messages m
+		WHERE NOT EXISTS (SELECT 1 FROM messages_blind_fts WHERE rowid = m.id)`)
+	if err != nil {
+		return fmt.Errorf("select rows: %w", err)
+	}
+	type pending struct {
+		id                                                  int64
+		subject, fromAddr, toAddrs, bodyText                 string
+	}
+	var batch []pending
+	for rows.Next() {
+		var p pending
+		var sCT, fCT, tCT, bCT []byte
+		if err := rows.Scan(&p.id, &p.subject, &sCT, &p.fromAddr, &fCT, &p.toAddrs, &tCT, &p.bodyText, &bCT); err != nil {
+			rows.Close()
+			return fmt.Errorf("scan: %w", err)
+		}
+		if p.subject, err = d.decryptSubject(p.subject, sCT); err != nil {
+			rows.Close()
+			return fmt.Errorf("decrypt subject id=%d: %w", p.id, err)
+		}
+		if p.fromAddr, err = d.decryptAddr(p.fromAddr, fCT); err != nil {
+			rows.Close()
+			return fmt.Errorf("decrypt from_addr id=%d: %w", p.id, err)
+		}
+		if p.toAddrs, err = d.decryptAddr(p.toAddrs, tCT); err != nil {
+			rows.Close()
+			return fmt.Errorf("decrypt to_addrs id=%d: %w", p.id, err)
+		}
+		if p.bodyText, err = d.decryptBody(p.bodyText, bCT); err != nil {
+			rows.Close()
+			return fmt.Errorf("decrypt body_text id=%d: %w", p.id, err)
+		}
+		batch = append(batch, p)
+	}
+	rows.Close()
+	if err := rows.Err(); err != nil {
+		return fmt.Errorf("iterate rows: %w", err)
+	}
+
+	stmt, err := tx.Prepare(`INSERT INTO messages_blind_fts(rowid, subject_tok, from_tok, to_tok, body_tok)
+		VALUES (?, ?, ?, ?, ?)`)
+	if err != nil {
+		return fmt.Errorf("prepare insert: %w", err)
+	}
+	defer stmt.Close()
+	for _, p := range batch {
+		sTok, fTok, tTok, bTok := d.blindTokens(p.subject, p.fromAddr, p.toAddrs, p.bodyText)
+		if _, err := stmt.Exec(p.id, sTok, fTok, tTok, bTok); err != nil {
+			return fmt.Errorf("insert id=%d: %w", p.id, err)
 		}
 	}
 	return tx.Commit()

--- a/cli/internal/store/store.go
+++ b/cli/internal/store/store.go
@@ -543,6 +543,29 @@ func (d *DB) migrate() error {
 		if _, err := d.db.Exec("UPDATE schema_version SET version = 12 WHERE rowid = 1"); err != nil {
 			return fmt.Errorf("migrate v11→v12 bump: %w", err)
 		}
+		version = 12
+	}
+
+	if version < 13 {
+		// ADR-0001 step 6: encrypt message_headers.value (headers_key).
+		// Header `name` stays plaintext — already a public registry
+		// (Return-Path, Authentication-Results, List-Unsubscribe, etc.)
+		// per ADR-0001 §3, and we need it for rule matching joins.
+		has, err := hasColumn(d.db, "message_headers", "value_ct")
+		if err != nil {
+			return fmt.Errorf("migrate v12→v13 inspect value_ct: %w", err)
+		}
+		if !has {
+			if _, err := d.db.Exec("ALTER TABLE message_headers ADD COLUMN value_ct BLOB"); err != nil {
+				return fmt.Errorf("migrate v12→v13 add value_ct: %w", err)
+			}
+		}
+		if err := d.backfillHeaderValueCt(); err != nil {
+			return fmt.Errorf("migrate v12→v13 backfill: %w", err)
+		}
+		if _, err := d.db.Exec("UPDATE schema_version SET version = 13 WHERE rowid = 1"); err != nil {
+			return fmt.Errorf("migrate v12→v13 bump: %w", err)
+		}
 	}
 
 	return nil
@@ -742,6 +765,86 @@ func (d *DB) backfillBodyCt() error {
 		}
 		if _, err := stmt.Exec(textCT, htmlCT, p.id); err != nil {
 			return fmt.Errorf("update id=%d: %w", p.id, err)
+		}
+	}
+	return tx.Commit()
+}
+
+// encryptHeaderValue seals plain with the headers sub-key. Empty plaintext
+// maps to nil so value_ct stays NULL — same convention as encryptSubject.
+func (d *DB) encryptHeaderValue(plain string) ([]byte, error) {
+	if plain == "" {
+		return nil, nil
+	}
+	return dbcrypto.Encrypt(d.keyring.Headers, []byte(plain))
+}
+
+// decryptHeaderValue returns the plaintext header value, preferring ct
+// when present. Decrypt failures on non-nil ct are hard errors.
+func (d *DB) decryptHeaderValue(plain string, ct []byte) (string, error) {
+	if len(ct) == 0 {
+		return plain, nil
+	}
+	out, err := dbcrypto.Decrypt(d.keyring.Headers, ct)
+	if err != nil {
+		return "", fmt.Errorf("decrypt header value: %w", err)
+	}
+	return string(out), nil
+}
+
+// backfillHeaderValueCt encrypts every existing message_headers.value into
+// the new value_ct BLOB column. Single transaction so a mid-loop failure
+// rolls back and leaves schema_version unbumped. message_headers can be
+// 5-10x the messages row count (each message has several persisted
+// headers); the prepared-statement loop keeps per-row overhead minimal.
+func (d *DB) backfillHeaderValueCt() error {
+	if d.keyring == nil || d.keyring.Headers == nil {
+		return fmt.Errorf("no keyring available for header backfill")
+	}
+	tx, err := d.db.Begin()
+	if err != nil {
+		return fmt.Errorf("begin tx: %w", err)
+	}
+	defer tx.Rollback() //nolint:errcheck
+
+	// message_headers has a composite PK (message_id, name) — both are
+	// needed to address the row in the UPDATE.
+	rows, err := tx.Query(`SELECT message_id, name, value FROM message_headers
+		WHERE value IS NOT NULL AND value <> '' AND value_ct IS NULL`)
+	if err != nil {
+		return fmt.Errorf("select rows: %w", err)
+	}
+	type pending struct {
+		messageID int64
+		name      string
+		value     string
+	}
+	var batch []pending
+	for rows.Next() {
+		var p pending
+		if err := rows.Scan(&p.messageID, &p.name, &p.value); err != nil {
+			rows.Close()
+			return fmt.Errorf("scan: %w", err)
+		}
+		batch = append(batch, p)
+	}
+	rows.Close()
+	if err := rows.Err(); err != nil {
+		return fmt.Errorf("iterate rows: %w", err)
+	}
+
+	stmt, err := tx.Prepare("UPDATE message_headers SET value_ct = ? WHERE message_id = ? AND name = ?")
+	if err != nil {
+		return fmt.Errorf("prepare update: %w", err)
+	}
+	defer stmt.Close()
+	for _, p := range batch {
+		ct, err := d.encryptHeaderValue(p.value)
+		if err != nil {
+			return fmt.Errorf("encrypt header (%d/%s): %w", p.messageID, p.name, err)
+		}
+		if _, err := stmt.Exec(ct, p.messageID, p.name); err != nil {
+			return fmt.Errorf("update (%d/%s): %w", p.messageID, p.name, err)
 		}
 	}
 	return tx.Commit()

--- a/cli/internal/store/store.go
+++ b/cli/internal/store/store.go
@@ -487,6 +487,62 @@ func (d *DB) migrate() error {
 		if _, err := d.db.Exec("UPDATE schema_version SET version = 10 WHERE rowid = 1"); err != nil {
 			return fmt.Errorf("migrate v9→v10 bump: %w", err)
 		}
+		version = 10
+	}
+
+	if version < 11 {
+		// ADR-0001 step 6: extend pilot encryption to messages.body_text
+		// and messages.body_html. Same pattern as v10 (subject) — two new
+		// BLOB columns, plaintext columns stay so FTS5 keeps indexing
+		// body_text until the step-7 rebuild.
+		for _, col := range []string{"body_text_ct", "body_html_ct"} {
+			has, err := hasColumn(d.db, "messages", col)
+			if err != nil {
+				return fmt.Errorf("migrate v10→v11 inspect %s: %w", col, err)
+			}
+			if !has {
+				if _, err := d.db.Exec("ALTER TABLE messages ADD COLUMN " + col + " BLOB"); err != nil {
+					return fmt.Errorf("migrate v10→v11 add %s: %w", col, err)
+				}
+			}
+		}
+		if err := d.backfillBodyCt(); err != nil {
+			return fmt.Errorf("migrate v10→v11 backfill: %w", err)
+		}
+		if _, err := d.db.Exec("UPDATE schema_version SET version = 11 WHERE rowid = 1"); err != nil {
+			return fmt.Errorf("migrate v10→v11 bump: %w", err)
+		}
+		version = 11
+	}
+
+	if version < 12 {
+		// ADR-0001 step 6: extend encryption to messages.from_addr,
+		// to_addrs, cc_addrs (addrs_key). Same column-doubling pattern;
+		// plaintext columns stay so FTS5 keeps indexing from_addr/to_addrs
+		// and search.go's GROUP_CONCAT(from_addr) AS authors keeps working
+		// until step 7.
+		//
+		// idx_messages_from_addr is intentionally NOT dropped yet — the
+		// plaintext column it covers still exists and powers GetSenderCounts
+		// + search. ADR-0001 §3 schedules that index drop for step 7 when
+		// the plaintext column itself goes.
+		for _, col := range []string{"from_addr_ct", "to_addrs_ct", "cc_addrs_ct"} {
+			has, err := hasColumn(d.db, "messages", col)
+			if err != nil {
+				return fmt.Errorf("migrate v11→v12 inspect %s: %w", col, err)
+			}
+			if !has {
+				if _, err := d.db.Exec("ALTER TABLE messages ADD COLUMN " + col + " BLOB"); err != nil {
+					return fmt.Errorf("migrate v11→v12 add %s: %w", col, err)
+				}
+			}
+		}
+		if err := d.backfillAddrsCt(); err != nil {
+			return fmt.Errorf("migrate v11→v12 backfill: %w", err)
+		}
+		if _, err := d.db.Exec("UPDATE schema_version SET version = 12 WHERE rowid = 1"); err != nil {
+			return fmt.Errorf("migrate v11→v12 bump: %w", err)
+		}
 	}
 
 	return nil
@@ -595,6 +651,183 @@ func (d *DB) backfillSubjectCt() error {
 			return fmt.Errorf("encrypt id=%d: %w", p.id, err)
 		}
 		if _, err := stmt.Exec(ct, p.id); err != nil {
+			return fmt.Errorf("update id=%d: %w", p.id, err)
+		}
+	}
+	return tx.Commit()
+}
+
+// encryptBody seals plain with the body sub-key. Empty plaintext maps to
+// nil so the ct column stays NULL — same convention as encryptSubject.
+func (d *DB) encryptBody(plain string) ([]byte, error) {
+	if plain == "" {
+		return nil, nil
+	}
+	return dbcrypto.Encrypt(d.keyring.Body, []byte(plain))
+}
+
+// decryptBody returns the plaintext body for a row, preferring the
+// encrypted ciphertext when present and falling back to the plaintext
+// column only when ct IS NULL (legacy/unmigrated rows). Decrypt failures
+// on a non-nil ct are hard errors — silent fallback would mask a
+// key/cipher mismatch and become data loss in step 7.
+func (d *DB) decryptBody(plain string, ct []byte) (string, error) {
+	if len(ct) == 0 {
+		return plain, nil
+	}
+	out, err := dbcrypto.Decrypt(d.keyring.Body, ct)
+	if err != nil {
+		return "", fmt.Errorf("decrypt body: %w", err)
+	}
+	return string(out), nil
+}
+
+// backfillBodyCt encrypts every existing messages.body_text and
+// body_html into the new BLOB columns. Single transaction so a mid-loop
+// failure rolls back and leaves schema_version unbumped — next Init()
+// retries the migration from scratch.
+//
+// Bodies can be large (KB to MB); we still load the whole batch into RAM
+// before the UPDATE pass to keep the row + tx-prepared-statement lifetimes
+// simple. Memory cap on a typical mailbox (~50k rows × ~50 KB avg) is in
+// the hundreds-of-MB range, acceptable for a one-shot migration.
+func (d *DB) backfillBodyCt() error {
+	if d.keyring == nil || d.keyring.Body == nil {
+		return fmt.Errorf("no keyring available for body backfill")
+	}
+	tx, err := d.db.Begin()
+	if err != nil {
+		return fmt.Errorf("begin tx: %w", err)
+	}
+	defer tx.Rollback() //nolint:errcheck // rolled back if Commit not reached
+
+	rows, err := tx.Query(`SELECT id, body_text, body_html FROM messages
+		WHERE (body_text IS NOT NULL AND body_text <> '' AND body_text_ct IS NULL)
+		   OR (body_html IS NOT NULL AND body_html <> '' AND body_html_ct IS NULL)`)
+	if err != nil {
+		return fmt.Errorf("select rows: %w", err)
+	}
+	type pending struct {
+		id       int64
+		bodyText string
+		bodyHTML string
+	}
+	var batch []pending
+	for rows.Next() {
+		var p pending
+		if err := rows.Scan(&p.id, &p.bodyText, &p.bodyHTML); err != nil {
+			rows.Close()
+			return fmt.Errorf("scan: %w", err)
+		}
+		batch = append(batch, p)
+	}
+	rows.Close()
+	if err := rows.Err(); err != nil {
+		return fmt.Errorf("iterate rows: %w", err)
+	}
+
+	stmt, err := tx.Prepare("UPDATE messages SET body_text_ct = ?, body_html_ct = ? WHERE id = ?")
+	if err != nil {
+		return fmt.Errorf("prepare update: %w", err)
+	}
+	defer stmt.Close()
+	for _, p := range batch {
+		textCT, err := d.encryptBody(p.bodyText)
+		if err != nil {
+			return fmt.Errorf("encrypt body_text id=%d: %w", p.id, err)
+		}
+		htmlCT, err := d.encryptBody(p.bodyHTML)
+		if err != nil {
+			return fmt.Errorf("encrypt body_html id=%d: %w", p.id, err)
+		}
+		if _, err := stmt.Exec(textCT, htmlCT, p.id); err != nil {
+			return fmt.Errorf("update id=%d: %w", p.id, err)
+		}
+	}
+	return tx.Commit()
+}
+
+// encryptAddr seals plain with the addrs sub-key. Empty plaintext maps to
+// nil so the ct column stays NULL — same convention as encryptSubject.
+func (d *DB) encryptAddr(plain string) ([]byte, error) {
+	if plain == "" {
+		return nil, nil
+	}
+	return dbcrypto.Encrypt(d.keyring.Addrs, []byte(plain))
+}
+
+// decryptAddr returns the plaintext address for a row, preferring the
+// encrypted ciphertext and falling back to the plaintext column only when
+// ct IS NULL. Decrypt failures on non-nil ct are hard errors.
+func (d *DB) decryptAddr(plain string, ct []byte) (string, error) {
+	if len(ct) == 0 {
+		return plain, nil
+	}
+	out, err := dbcrypto.Decrypt(d.keyring.Addrs, ct)
+	if err != nil {
+		return "", fmt.Errorf("decrypt addr: %w", err)
+	}
+	return string(out), nil
+}
+
+// backfillAddrsCt encrypts every existing from_addr / to_addrs / cc_addrs
+// into the new BLOB columns. Single transaction so a mid-loop failure
+// rolls back cleanly. Rows where all three are empty/NULL are skipped so
+// their *_ct columns stay NULL.
+func (d *DB) backfillAddrsCt() error {
+	if d.keyring == nil || d.keyring.Addrs == nil {
+		return fmt.Errorf("no keyring available for addrs backfill")
+	}
+	tx, err := d.db.Begin()
+	if err != nil {
+		return fmt.Errorf("begin tx: %w", err)
+	}
+	defer tx.Rollback() //nolint:errcheck // rolled back if Commit not reached
+
+	rows, err := tx.Query(`SELECT id, from_addr, to_addrs, cc_addrs FROM messages
+		WHERE (from_addr IS NOT NULL AND from_addr <> '' AND from_addr_ct IS NULL)
+		   OR (to_addrs  IS NOT NULL AND to_addrs  <> '' AND to_addrs_ct  IS NULL)
+		   OR (cc_addrs  IS NOT NULL AND cc_addrs  <> '' AND cc_addrs_ct  IS NULL)`)
+	if err != nil {
+		return fmt.Errorf("select rows: %w", err)
+	}
+	type pending struct {
+		id                       int64
+		fromAddr, toAddrs, ccAddrs string
+	}
+	var batch []pending
+	for rows.Next() {
+		var p pending
+		if err := rows.Scan(&p.id, &p.fromAddr, &p.toAddrs, &p.ccAddrs); err != nil {
+			rows.Close()
+			return fmt.Errorf("scan: %w", err)
+		}
+		batch = append(batch, p)
+	}
+	rows.Close()
+	if err := rows.Err(); err != nil {
+		return fmt.Errorf("iterate rows: %w", err)
+	}
+
+	stmt, err := tx.Prepare("UPDATE messages SET from_addr_ct = ?, to_addrs_ct = ?, cc_addrs_ct = ? WHERE id = ?")
+	if err != nil {
+		return fmt.Errorf("prepare update: %w", err)
+	}
+	defer stmt.Close()
+	for _, p := range batch {
+		fromCT, err := d.encryptAddr(p.fromAddr)
+		if err != nil {
+			return fmt.Errorf("encrypt from_addr id=%d: %w", p.id, err)
+		}
+		toCT, err := d.encryptAddr(p.toAddrs)
+		if err != nil {
+			return fmt.Errorf("encrypt to_addrs id=%d: %w", p.id, err)
+		}
+		ccCT, err := d.encryptAddr(p.ccAddrs)
+		if err != nil {
+			return fmt.Errorf("encrypt cc_addrs id=%d: %w", p.id, err)
+		}
+		if _, err := stmt.Exec(fromCT, toCT, ccCT, p.id); err != nil {
 			return fmt.Errorf("update id=%d: %w", p.id, err)
 		}
 	}

--- a/cli/internal/store/store_test.go
+++ b/cli/internal/store/store_test.go
@@ -42,8 +42,8 @@ func TestOpenAndInit(t *testing.T) {
 	if err != nil {
 		t.Fatalf("read version: %v", err)
 	}
-	if version != 12 {
-		t.Errorf("version = %d, want 12", version)
+	if version != 13 {
+		t.Errorf("version = %d, want 13", version)
 	}
 }
 
@@ -168,8 +168,8 @@ func TestMigrateV9_PopulatesMailboxesAndAccounts(t *testing.T) {
 	if err := db.QueryRow("SELECT version FROM schema_version WHERE rowid = 1").Scan(&version); err != nil {
 		t.Fatalf("read version: %v", err)
 	}
-	if version != 12 {
-		t.Fatalf("version = %d, want 12", version)
+	if version != 13 {
+		t.Fatalf("version = %d, want 13", version)
 	}
 
 	// mailboxes must contain exactly INBOX and Drafts (case-collapsed).
@@ -349,8 +349,8 @@ func TestMigrateV10_BackfillsSubjectCt(t *testing.T) {
 	if err := sd.db.QueryRow("SELECT version FROM schema_version WHERE rowid = 1").Scan(&version); err != nil {
 		t.Fatalf("read version: %v", err)
 	}
-	if version != 12 {
-		t.Fatalf("version = %d, want 12", version)
+	if version != 13 {
+		t.Fatalf("version = %d, want 13", version)
 	}
 
 	// Raw check: subject_ct must be NULL for empty subject, non-NULL for the
@@ -483,8 +483,8 @@ func TestMigrateV11_BackfillsBodyCt(t *testing.T) {
 	if err := sd.db.QueryRow("SELECT version FROM schema_version WHERE rowid = 1").Scan(&version); err != nil {
 		t.Fatalf("read version: %v", err)
 	}
-	if version != 12 {
-		t.Fatalf("version = %d, want 12", version)
+	if version != 13 {
+		t.Fatalf("version = %d, want 13", version)
 	}
 
 	// Raw check: body_text_ct populated only where body_text non-empty.
@@ -624,8 +624,8 @@ func TestMigrateV12_BackfillsAddrsCt(t *testing.T) {
 	if err := sd.db.QueryRow("SELECT version FROM schema_version WHERE rowid = 1").Scan(&version); err != nil {
 		t.Fatalf("read version: %v", err)
 	}
-	if version != 12 {
-		t.Fatalf("version = %d, want 12", version)
+	if version != 13 {
+		t.Fatalf("version = %d, want 13", version)
 	}
 
 	rows, err := sd.db.Query(`SELECT message_id, from_addr, from_addr_ct,

--- a/cli/internal/store/store_test.go
+++ b/cli/internal/store/store_test.go
@@ -42,8 +42,8 @@ func TestOpenAndInit(t *testing.T) {
 	if err != nil {
 		t.Fatalf("read version: %v", err)
 	}
-	if version != 10 {
-		t.Errorf("version = %d, want 10", version)
+	if version != 12 {
+		t.Errorf("version = %d, want 12", version)
 	}
 }
 
@@ -168,8 +168,8 @@ func TestMigrateV9_PopulatesMailboxesAndAccounts(t *testing.T) {
 	if err := db.QueryRow("SELECT version FROM schema_version WHERE rowid = 1").Scan(&version); err != nil {
 		t.Fatalf("read version: %v", err)
 	}
-	if version != 10 {
-		t.Fatalf("version = %d, want 10", version)
+	if version != 12 {
+		t.Fatalf("version = %d, want 12", version)
 	}
 
 	// mailboxes must contain exactly INBOX and Drafts (case-collapsed).
@@ -349,8 +349,8 @@ func TestMigrateV10_BackfillsSubjectCt(t *testing.T) {
 	if err := sd.db.QueryRow("SELECT version FROM schema_version WHERE rowid = 1").Scan(&version); err != nil {
 		t.Fatalf("read version: %v", err)
 	}
-	if version != 10 {
-		t.Fatalf("version = %d, want 10", version)
+	if version != 12 {
+		t.Fatalf("version = %d, want 12", version)
 	}
 
 	// Raw check: subject_ct must be NULL for empty subject, non-NULL for the
@@ -398,6 +398,294 @@ func TestMigrateV10_BackfillsSubjectCt(t *testing.T) {
 		}
 		if msg.Subject != want.subject {
 			t.Errorf("%s: read subject %q, want %q", want.id, msg.Subject, want.subject)
+		}
+	}
+}
+
+// TestMigrateV11_BackfillsBodyCt seeds a v10-shaped DB with a mix of
+// body_text/body_html populations and asserts the v10→v11 migration
+// encrypts only the non-empty ones, leaves the rest NULL, and that
+// GetByMessageID round-trips through decryptBody.
+func TestMigrateV11_BackfillsBodyCt(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "step6a.db")
+
+	seedDB, err := sql.Open("sqlite", dbPath)
+	if err != nil {
+		t.Fatalf("open seed: %v", err)
+	}
+	seed := []string{
+		`CREATE TABLE schema_version (version INTEGER NOT NULL)`,
+		`INSERT INTO schema_version (rowid, version) VALUES (1, 10)`,
+		`CREATE TABLE messages (
+			id INTEGER PRIMARY KEY AUTOINCREMENT,
+			message_id TEXT NOT NULL,
+			thread_id TEXT NOT NULL,
+			in_reply_to TEXT,
+			refs TEXT,
+			subject TEXT,
+			subject_ct BLOB,
+			from_addr TEXT,
+			to_addrs TEXT,
+			cc_addrs TEXT,
+			date INTEGER,
+			created_at INTEGER NOT NULL,
+			body_text TEXT,
+			body_html TEXT,
+			mailbox TEXT,
+			flags TEXT,
+			uid INTEGER DEFAULT 0,
+			size INTEGER DEFAULT 0,
+			fetched_body INTEGER DEFAULT 0,
+			account TEXT DEFAULT '',
+			mailbox_id INTEGER,
+			account_id INTEGER,
+			is_seen INTEGER NOT NULL DEFAULT 0,
+			is_flagged INTEGER NOT NULL DEFAULT 0,
+			is_deleted INTEGER NOT NULL DEFAULT 0,
+			UNIQUE(message_id, account)
+		)`,
+		`INSERT INTO messages (message_id, thread_id, in_reply_to, refs, subject,
+		    from_addr, to_addrs, cc_addrs, date, created_at,
+		    body_text, body_html, mailbox, flags) VALUES
+		   ('m1', 't1', '', '', '', '', '', '', 0, 1, 'plain text body only', '',          '', ''),
+		   ('m2', 't2', '', '', '', '', '', '', 0, 2, '',                     '<p>html</p>','', ''),
+		   ('m3', 't3', '', '', '', '', '', '', 0, 3, 'both formats',         '<p>both</p>','', ''),
+		   ('m4', 't4', '', '', '', '', '', '', 0, 4, '',                     '',          '', '')`,
+		// FTS5 + content for the AU trigger to operate on. step 5/10 wrote
+		// subject_ct via migration; step 6a leaves both columns plaintext
+		// in this seed because the rows have empty subjects.
+		`CREATE VIRTUAL TABLE messages_fts USING fts5(
+			subject, from_addr, to_addrs, body_text,
+			content='messages',
+			content_rowid='id'
+		)`,
+		`INSERT INTO messages_fts(rowid, subject, from_addr, to_addrs, body_text)
+		 SELECT id, subject, COALESCE(from_addr, ''), COALESCE(to_addrs, ''), COALESCE(body_text, '')
+		 FROM messages`,
+	}
+	for _, stmt := range seed {
+		if _, err := seedDB.Exec(stmt); err != nil {
+			t.Fatalf("seed: %v\nstmt: %s", err, stmt)
+		}
+	}
+	seedDB.Close()
+
+	sd, err := Open(dbPath, testKeyring(t))
+	if err != nil {
+		t.Fatalf("store open: %v", err)
+	}
+	t.Cleanup(func() { sd.Close() })
+	if err := sd.Init(); err != nil {
+		t.Fatalf("init/migrate: %v", err)
+	}
+
+	var version int
+	if err := sd.db.QueryRow("SELECT version FROM schema_version WHERE rowid = 1").Scan(&version); err != nil {
+		t.Fatalf("read version: %v", err)
+	}
+	if version != 12 {
+		t.Fatalf("version = %d, want 12", version)
+	}
+
+	// Raw check: body_text_ct populated only where body_text non-empty.
+	rows, err := sd.db.Query(`SELECT message_id, body_text, body_text_ct, body_html, body_html_ct
+		FROM messages ORDER BY message_id`)
+	if err != nil {
+		t.Fatalf("query messages: %v", err)
+	}
+	defer rows.Close()
+	type row struct {
+		id           string
+		text, html   string
+		textCT, htmlCT []byte
+	}
+	var got []row
+	for rows.Next() {
+		var r row
+		if err := rows.Scan(&r.id, &r.text, &r.textCT, &r.html, &r.htmlCT); err != nil {
+			t.Fatalf("scan: %v", err)
+		}
+		got = append(got, r)
+	}
+	if len(got) != 4 {
+		t.Fatalf("messages = %d, want 4", len(got))
+	}
+	// m1: text only
+	if got[0].text == "" || len(got[0].textCT) == 0 || got[0].htmlCT != nil {
+		t.Errorf("m1 unexpected: text=%q textCT.len=%d htmlCT=%v", got[0].text, len(got[0].textCT), got[0].htmlCT)
+	}
+	// m2: html only
+	if got[1].textCT != nil || len(got[1].htmlCT) == 0 {
+		t.Errorf("m2 unexpected: textCT=%v htmlCT.len=%d", got[1].textCT, len(got[1].htmlCT))
+	}
+	// m3: both
+	if len(got[2].textCT) == 0 || len(got[2].htmlCT) == 0 {
+		t.Errorf("m3 unexpected: textCT.len=%d htmlCT.len=%d", len(got[2].textCT), len(got[2].htmlCT))
+	}
+	// m4: neither
+	if got[3].textCT != nil || got[3].htmlCT != nil {
+		t.Errorf("m4 unexpected: textCT=%v htmlCT=%v", got[3].textCT, got[3].htmlCT)
+	}
+
+	// Round-trip via production read path.
+	for _, want := range got {
+		msg, err := sd.GetByMessageID(want.id)
+		if err != nil {
+			t.Fatalf("get %s: %v", want.id, err)
+		}
+		if msg == nil {
+			t.Fatalf("get %s: nil", want.id)
+		}
+		if msg.BodyText != want.text {
+			t.Errorf("%s: body_text=%q, want %q", want.id, msg.BodyText, want.text)
+		}
+		if msg.BodyHTML != want.html {
+			t.Errorf("%s: body_html=%q, want %q", want.id, msg.BodyHTML, want.html)
+		}
+	}
+}
+
+// TestMigrateV12_BackfillsAddrsCt seeds a v11-shaped DB with a mix of
+// from/to/cc populations and asserts the v11→v12 migration encrypts
+// only the non-empty addresses, leaves the rest NULL, and that
+// GetByMessageID round-trips through decryptAddr.
+func TestMigrateV12_BackfillsAddrsCt(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "step6-addrs.db")
+	seedDB, err := sql.Open("sqlite", dbPath)
+	if err != nil {
+		t.Fatalf("open seed: %v", err)
+	}
+	seed := []string{
+		`CREATE TABLE schema_version (version INTEGER NOT NULL)`,
+		`INSERT INTO schema_version (rowid, version) VALUES (1, 11)`,
+		`CREATE TABLE messages (
+			id INTEGER PRIMARY KEY AUTOINCREMENT,
+			message_id TEXT NOT NULL,
+			thread_id TEXT NOT NULL,
+			in_reply_to TEXT,
+			refs TEXT,
+			subject TEXT,
+			subject_ct BLOB,
+			from_addr TEXT,
+			to_addrs TEXT,
+			cc_addrs TEXT,
+			date INTEGER,
+			created_at INTEGER NOT NULL,
+			body_text TEXT,
+			body_text_ct BLOB,
+			body_html TEXT,
+			body_html_ct BLOB,
+			mailbox TEXT,
+			flags TEXT,
+			uid INTEGER DEFAULT 0,
+			size INTEGER DEFAULT 0,
+			fetched_body INTEGER DEFAULT 0,
+			account TEXT DEFAULT '',
+			mailbox_id INTEGER,
+			account_id INTEGER,
+			is_seen INTEGER NOT NULL DEFAULT 0,
+			is_flagged INTEGER NOT NULL DEFAULT 0,
+			is_deleted INTEGER NOT NULL DEFAULT 0,
+			UNIQUE(message_id, account)
+		)`,
+		`INSERT INTO messages (message_id, thread_id, in_reply_to, refs, subject,
+		    from_addr, to_addrs, cc_addrs, date, created_at,
+		    body_text, body_html, mailbox, flags) VALUES
+		   ('m1', 't1', '', '', '', 'a@x.com',  'b@x.com',  '',         0, 1, '', '', '', ''),
+		   ('m2', 't2', '', '', '', '',         '',         'c@x.com',  0, 2, '', '', '', ''),
+		   ('m3', 't3', '', '', '', 'a@x.com',  'b@x.com',  'c@x.com',  0, 3, '', '', '', ''),
+		   ('m4', 't4', '', '', '', '',         '',         '',         0, 4, '', '', '', '')`,
+		`CREATE VIRTUAL TABLE messages_fts USING fts5(
+			subject, from_addr, to_addrs, body_text,
+			content='messages',
+			content_rowid='id'
+		)`,
+		`INSERT INTO messages_fts(rowid, subject, from_addr, to_addrs, body_text)
+		 SELECT id, COALESCE(subject, ''), COALESCE(from_addr, ''), COALESCE(to_addrs, ''), COALESCE(body_text, '')
+		 FROM messages`,
+	}
+	for _, stmt := range seed {
+		if _, err := seedDB.Exec(stmt); err != nil {
+			t.Fatalf("seed: %v\nstmt: %s", err, stmt)
+		}
+	}
+	seedDB.Close()
+
+	sd, err := Open(dbPath, testKeyring(t))
+	if err != nil {
+		t.Fatalf("store open: %v", err)
+	}
+	t.Cleanup(func() { sd.Close() })
+	if err := sd.Init(); err != nil {
+		t.Fatalf("init/migrate: %v", err)
+	}
+
+	var version int
+	if err := sd.db.QueryRow("SELECT version FROM schema_version WHERE rowid = 1").Scan(&version); err != nil {
+		t.Fatalf("read version: %v", err)
+	}
+	if version != 12 {
+		t.Fatalf("version = %d, want 12", version)
+	}
+
+	rows, err := sd.db.Query(`SELECT message_id, from_addr, from_addr_ct,
+		to_addrs, to_addrs_ct, cc_addrs, cc_addrs_ct
+		FROM messages ORDER BY message_id`)
+	if err != nil {
+		t.Fatalf("query: %v", err)
+	}
+	defer rows.Close()
+	type row struct {
+		id                                       string
+		from, to, cc                             string
+		fromCT, toCT, ccCT                       []byte
+	}
+	var got []row
+	for rows.Next() {
+		var r row
+		if err := rows.Scan(&r.id, &r.from, &r.fromCT, &r.to, &r.toCT, &r.cc, &r.ccCT); err != nil {
+			t.Fatalf("scan: %v", err)
+		}
+		got = append(got, r)
+	}
+	if len(got) != 4 {
+		t.Fatalf("rows = %d, want 4", len(got))
+	}
+	checks := []struct {
+		idx                                 int
+		wantFromCT, wantToCT, wantCCCT bool
+	}{
+		{0, true, true, false},
+		{1, false, false, true},
+		{2, true, true, true},
+		{3, false, false, false},
+	}
+	for _, c := range checks {
+		r := got[c.idx]
+		if (len(r.fromCT) > 0) != c.wantFromCT {
+			t.Errorf("%s from_addr_ct populated=%v, want %v", r.id, len(r.fromCT) > 0, c.wantFromCT)
+		}
+		if (len(r.toCT) > 0) != c.wantToCT {
+			t.Errorf("%s to_addrs_ct populated=%v, want %v", r.id, len(r.toCT) > 0, c.wantToCT)
+		}
+		if (len(r.ccCT) > 0) != c.wantCCCT {
+			t.Errorf("%s cc_addrs_ct populated=%v, want %v", r.id, len(r.ccCT) > 0, c.wantCCCT)
+		}
+	}
+
+	// Round-trip via the production read path.
+	for _, want := range got {
+		msg, err := sd.GetByMessageID(want.id)
+		if err != nil {
+			t.Fatalf("get %s: %v", want.id, err)
+		}
+		if msg == nil {
+			t.Fatalf("get %s: nil", want.id)
+		}
+		if msg.FromAddr != want.from || msg.ToAddrs != want.to || msg.CCAddrs != want.cc {
+			t.Errorf("%s addrs mismatch: got (%q/%q/%q), want (%q/%q/%q)",
+				want.id, msg.FromAddr, msg.ToAddrs, msg.CCAddrs,
+				want.from, want.to, want.cc)
 		}
 	}
 }

--- a/cli/internal/store/store_test.go
+++ b/cli/internal/store/store_test.go
@@ -42,8 +42,8 @@ func TestOpenAndInit(t *testing.T) {
 	if err != nil {
 		t.Fatalf("read version: %v", err)
 	}
-	if version != 13 {
-		t.Errorf("version = %d, want 13", version)
+	if version != 15 {
+		t.Errorf("version = %d, want 15", version)
 	}
 }
 
@@ -168,8 +168,8 @@ func TestMigrateV9_PopulatesMailboxesAndAccounts(t *testing.T) {
 	if err := db.QueryRow("SELECT version FROM schema_version WHERE rowid = 1").Scan(&version); err != nil {
 		t.Fatalf("read version: %v", err)
 	}
-	if version != 13 {
-		t.Fatalf("version = %d, want 13", version)
+	if version != 15 {
+		t.Fatalf("version = %d, want 15", version)
 	}
 
 	// mailboxes must contain exactly INBOX and Drafts (case-collapsed).
@@ -349,8 +349,8 @@ func TestMigrateV10_BackfillsSubjectCt(t *testing.T) {
 	if err := sd.db.QueryRow("SELECT version FROM schema_version WHERE rowid = 1").Scan(&version); err != nil {
 		t.Fatalf("read version: %v", err)
 	}
-	if version != 13 {
-		t.Fatalf("version = %d, want 13", version)
+	if version != 15 {
+		t.Fatalf("version = %d, want 15", version)
 	}
 
 	// Raw check: subject_ct must be NULL for empty subject, non-NULL for the
@@ -483,8 +483,8 @@ func TestMigrateV11_BackfillsBodyCt(t *testing.T) {
 	if err := sd.db.QueryRow("SELECT version FROM schema_version WHERE rowid = 1").Scan(&version); err != nil {
 		t.Fatalf("read version: %v", err)
 	}
-	if version != 13 {
-		t.Fatalf("version = %d, want 13", version)
+	if version != 15 {
+		t.Fatalf("version = %d, want 15", version)
 	}
 
 	// Raw check: body_text_ct populated only where body_text non-empty.
@@ -624,8 +624,8 @@ func TestMigrateV12_BackfillsAddrsCt(t *testing.T) {
 	if err := sd.db.QueryRow("SELECT version FROM schema_version WHERE rowid = 1").Scan(&version); err != nil {
 		t.Fatalf("read version: %v", err)
 	}
-	if version != 13 {
-		t.Fatalf("version = %d, want 13", version)
+	if version != 15 {
+		t.Fatalf("version = %d, want 15", version)
 	}
 
 	rows, err := sd.db.Query(`SELECT message_id, from_addr, from_addr_ct,

--- a/cli/internal/store/store_test.go
+++ b/cli/internal/store/store_test.go
@@ -42,8 +42,8 @@ func TestOpenAndInit(t *testing.T) {
 	if err != nil {
 		t.Fatalf("read version: %v", err)
 	}
-	if version != 15 {
-		t.Errorf("version = %d, want 15", version)
+	if version != 16 {
+		t.Errorf("version = %d, want 16", version)
 	}
 }
 
@@ -168,8 +168,8 @@ func TestMigrateV9_PopulatesMailboxesAndAccounts(t *testing.T) {
 	if err := db.QueryRow("SELECT version FROM schema_version WHERE rowid = 1").Scan(&version); err != nil {
 		t.Fatalf("read version: %v", err)
 	}
-	if version != 15 {
-		t.Fatalf("version = %d, want 15", version)
+	if version != 16 {
+		t.Fatalf("version = %d, want 16", version)
 	}
 
 	// mailboxes must contain exactly INBOX and Drafts (case-collapsed).
@@ -349,8 +349,8 @@ func TestMigrateV10_BackfillsSubjectCt(t *testing.T) {
 	if err := sd.db.QueryRow("SELECT version FROM schema_version WHERE rowid = 1").Scan(&version); err != nil {
 		t.Fatalf("read version: %v", err)
 	}
-	if version != 15 {
-		t.Fatalf("version = %d, want 15", version)
+	if version != 16 {
+		t.Fatalf("version = %d, want 16", version)
 	}
 
 	// Raw check: subject_ct must be NULL for empty subject, non-NULL for the
@@ -483,8 +483,8 @@ func TestMigrateV11_BackfillsBodyCt(t *testing.T) {
 	if err := sd.db.QueryRow("SELECT version FROM schema_version WHERE rowid = 1").Scan(&version); err != nil {
 		t.Fatalf("read version: %v", err)
 	}
-	if version != 15 {
-		t.Fatalf("version = %d, want 15", version)
+	if version != 16 {
+		t.Fatalf("version = %d, want 16", version)
 	}
 
 	// Raw check: body_text_ct populated only where body_text non-empty.
@@ -624,8 +624,8 @@ func TestMigrateV12_BackfillsAddrsCt(t *testing.T) {
 	if err := sd.db.QueryRow("SELECT version FROM schema_version WHERE rowid = 1").Scan(&version); err != nil {
 		t.Fatalf("read version: %v", err)
 	}
-	if version != 15 {
-		t.Fatalf("version = %d, want 15", version)
+	if version != 16 {
+		t.Fatalf("version = %d, want 16", version)
 	}
 
 	rows, err := sd.db.Query(`SELECT message_id, from_addr, from_addr_ct,
@@ -687,6 +687,54 @@ func TestMigrateV12_BackfillsAddrsCt(t *testing.T) {
 				want.id, msg.FromAddr, msg.ToAddrs, msg.CCAddrs,
 				want.from, want.to, want.cc)
 		}
+	}
+}
+
+// TestBlindFTS_InsertAndMatch verifies the step-7 (a+b) round-trip:
+// a message inserted via the store API populates messages_blind_fts,
+// and a token computed independently with the same FTSToken sub-key
+// matches the right rowid via SQLite's FTS5 MATCH operator.
+func TestBlindFTS_InsertAndMatch(t *testing.T) {
+	db := newTestDB(t)
+	kr := testKeyring(t)
+
+	msg := &Message{
+		MessageID: "blindtest@example",
+		Subject:   "Hello Blindtoken World",
+		FromAddr:  "alice@example.com",
+		ToAddrs:   "bob@example.com",
+		BodyText:  "the quick brown fox",
+		CreatedAt: 1,
+		Account:   "acct1",
+	}
+	if err := db.InsertMessage(msg); err != nil {
+		t.Fatalf("insert: %v", err)
+	}
+
+	tok := dbcrypto.TokenizeFTS(kr.FTSToken, "blindtoken")
+	if tok == "" {
+		t.Fatal("tokenizer returned empty for non-empty input")
+	}
+	var rowid int64
+	err := db.db.QueryRow(
+		`SELECT rowid FROM messages_blind_fts WHERE subject_tok MATCH ? LIMIT 1`,
+		tok,
+	).Scan(&rowid)
+	if err != nil {
+		t.Fatalf("blind fts match: %v", err)
+	}
+	if rowid != msg.ID {
+		t.Errorf("rowid = %d, want %d", rowid, msg.ID)
+	}
+
+	notInSubject := dbcrypto.TokenizeFTS(kr.FTSToken, "kraftfahrzeughaftpflichtversicherung")
+	var dummy int64
+	err = db.db.QueryRow(
+		`SELECT rowid FROM messages_blind_fts WHERE subject_tok MATCH ? LIMIT 1`,
+		notInSubject,
+	).Scan(&dummy)
+	if err == nil {
+		t.Errorf("blind fts matched a word not in any subject (rowid=%d)", dummy)
 	}
 }
 


### PR DESCRIPTION
## Summary

Stacked on top of #236. Brings \`contacts.db\` under at-rest encryption using the Contact sub-key (LabelContact) — the last column-group from the ADR-0001 §3 registry.

contacts.db is a separate persistence layer with its own Open/Init/schema lifecycle, no \`schema_version\` table. Migration uses PRAGMA table_info as the idempotency check; if a future migration needs ordering we introduce schema_version then.

## What changes

- \`contacts.Open\` now requires a non-nil *dbcrypto.Keyring (hard-error otherwise), mirrors store.Open from step 5. All seven call-sites updated.
- \`contacts.DB.Init()\` runs the upgrade: ALTER TABLE contacts ADD COLUMN email_ct + name_ct BLOB, then backfillContactCt under one tx.
- \`Add\` / \`AddBatch\` encrypt email + name on every write; ON CONFLICT UPSERT keeps ct in sync with plaintext.
- Plaintext email + name columns stay: UNIQUE + LIKE-prefix indexes that random-nonce ciphertext cannot serve. Step 7 introduces deterministic blind-tokens.
- Drive-by fix in serve.go: \`cdb.Init()\` now called after contacts.Open. Previously serve skipped Init relying on contacts subcommands having pre-init'd the schema — broken on fresh installs once encrypt-on-write went live.

## Live migration

Prod contacts.db (2658 rows, 880 KB):
- 2658 emails encrypted, 2268 names encrypted (rest NULL/empty per design)
- Backfill ~3 s
- contacts.db grew to 2.0 MB

## Test plan

- [x] \`bazel test //cli/...\` — all 19 targets pass
- [x] dbcrypto_test keyring grows to 7 sub-keys, 21-pair distinctness matrix auto-generates
- [x] contacts_test passes with new Open signature + injected test keyring
- [x] Real-DB validation: 2658/2658 emails + 2268 names encrypted on user's prod contacts.db

## Merge order

1. Merge encryption PR to main first
2. This PR auto-rebases (or \`gh pr edit --base main\` if needed), then mergeable