### PR TITLE
ADR-0001 step 7g — β-revision for contacts.email/name

### DIFF
--- a/cli/cmd/durian/contacts.go
+++ b/cli/cmd/durian/contacts.go
@@ -93,7 +93,7 @@ func runContactsInit(cmd *cobra.Command, args []string) error {
 	dbPath := getDBPath()
 	slog.Debug("Initializing contacts database", "path", dbPath)
 
-	db, err := contacts.Open(dbPath, bootstrapKeyring())
+	db, err := contacts.Open(dbPath)
 	if err != nil {
 		return fmt.Errorf("open database: %w", err)
 	}
@@ -122,7 +122,7 @@ func runContactsImport(cmd *cobra.Command, args []string) error {
 	slog.Debug("Importing contacts", "path", dbPath)
 
 	// Open/create database
-	db, err := contacts.Open(dbPath, bootstrapKeyring())
+	db, err := contacts.Open(dbPath)
 	if err != nil {
 		return fmt.Errorf("open database: %w", err)
 	}
@@ -183,7 +183,7 @@ func runContactsImport(cmd *cobra.Command, args []string) error {
 func runContactsList(cmd *cobra.Command, args []string) error {
 	dbPath := getDBPath()
 
-	db, err := contacts.Open(dbPath, bootstrapKeyring())
+	db, err := contacts.Open(dbPath)
 	if err != nil {
 		return fmt.Errorf("open database: %w", err)
 	}
@@ -230,7 +230,7 @@ func runContactsSearch(cmd *cobra.Command, args []string) error {
 	query := args[0]
 	dbPath := getDBPath()
 
-	db, err := contacts.Open(dbPath, bootstrapKeyring())
+	db, err := contacts.Open(dbPath)
 	if err != nil {
 		return fmt.Errorf("open database: %w", err)
 	}
@@ -268,7 +268,7 @@ func runContactsAdd(cmd *cobra.Command, args []string) error {
 
 	dbPath := getDBPath()
 
-	db, err := contacts.Open(dbPath, bootstrapKeyring())
+	db, err := contacts.Open(dbPath)
 	if err != nil {
 		return fmt.Errorf("open database: %w", err)
 	}
@@ -307,7 +307,7 @@ func runContactsDelete(cmd *cobra.Command, args []string) error {
 	email := args[0]
 	dbPath := getDBPath()
 
-	db, err := contacts.Open(dbPath, bootstrapKeyring())
+	db, err := contacts.Open(dbPath)
 	if err != nil {
 		return fmt.Errorf("open database: %w", err)
 	}

--- a/cli/cmd/durian/serve.go
+++ b/cli/cmd/durian/serve.go
@@ -73,14 +73,14 @@ func runServe(cmd *cobra.Command, args []string) {
 	if contactsDBPath == "" {
 		contactsDBPath = contacts.DefaultDBPath()
 	}
-	if cdb, err := contacts.Open(contactsDBPath, keyring); err != nil {
+	if cdb, err := contacts.Open(contactsDBPath); err != nil {
 		slog.Warn("Could not open contacts database", "module", "SERVE", "path", contactsDBPath, "err", err)
 	} else if err := cdb.Init(); err != nil {
 		// Init runs the CREATE TABLE IF NOT EXISTS and any pending
-		// migrations (ADR-0001 step 6 contact encryption). Previously
-		// serve skipped Init and relied on the import subcommand to
-		// have set up the schema; with encrypt-on-write live we must
-		// guarantee the migration runs on startup.
+		// migrations (currently: ADR-0001 step 7g drops the dead
+		// email_ct / name_ct columns). serve must run Init on startup
+		// rather than deferring to subcommands, otherwise pending
+		// schema migrations never apply on a server-only deployment.
 		slog.Warn("Could not init contacts database", "module", "SERVE", "path", contactsDBPath, "err", err)
 		cdb.Close()
 	} else {

--- a/cli/cmd/testseeder/main.go
+++ b/cli/cmd/testseeder/main.go
@@ -119,7 +119,7 @@ func seedEmailDB(path string) error {
 }
 
 func seedContactsDB(path string) error {
-	db, err := contacts.Open(path, testKeyring())
+	db, err := contacts.Open(path)
 	if err != nil {
 		return fmt.Errorf("open: %w", err)
 	}

--- a/cli/internal/contacts/db.go
+++ b/cli/internal/contacts/db.go
@@ -10,8 +10,6 @@ import (
 
 	"github.com/google/uuid"
 
-	"github.com/durian-dev/durian/cli/internal/dbcrypto"
-
 	_ "modernc.org/sqlite"
 )
 
@@ -27,20 +25,17 @@ func DefaultDBPath() string {
 
 // DB represents a contacts database connection
 type DB struct {
-	db      *sql.DB
-	keyring *dbcrypto.Keyring
+	db *sql.DB
 }
 
 // Open opens or creates a contacts database at the given path.
 //
-// kr must be a non-nil Keyring derived from the OS-keychain master key.
-// ADR-0001 step 6 requires the Contact sub-key for the email/name
-// encrypt-on-write path and the one-shot backfill in Init().
-func Open(dbPath string, kr *dbcrypto.Keyring) (*DB, error) {
-	if kr == nil {
-		return nil, fmt.Errorf("contacts: Open requires a non-nil keyring (see ADR-0001)")
-	}
-
+// ADR-0001 step 7g (β-revision): contact email + name stay plaintext on
+// disk. They are on the wire any time a mail is sent or received, so the
+// asymmetric protection of encrypting only the local mirror is not worth
+// losing UNIQUE(email) enforcement and prefix-LIKE search. The contacts
+// store therefore takes no keyring; see ADR §3 "Stays plaintext".
+func Open(dbPath string) (*DB, error) {
 	// Expand ~ if present
 	if strings.HasPrefix(dbPath, "~/") {
 		home, err := os.UserHomeDir()
@@ -71,7 +66,7 @@ func Open(dbPath string, kr *dbcrypto.Keyring) (*DB, error) {
 		return nil, fmt.Errorf("set journal mode: %w", err)
 	}
 
-	return &DB{db: db, keyring: kr}, nil
+	return &DB{db: db}, nil
 }
 
 // Close closes the database connection
@@ -80,9 +75,8 @@ func (d *DB) Close() error {
 }
 
 // Init creates the contacts table and indexes if they don't exist, and
-// runs any pending one-shot migrations (ADR-0001 step 6 encryption is
-// detected via PRAGMA table_info since contacts.db has no schema_version
-// — first migration ever and likely the only one until step 7).
+// runs any pending one-shot migrations. contacts.db has no
+// schema_version table — migrations are detected via PRAGMA table_info.
 func (d *DB) Init() error {
 	schema := `
 	CREATE TABLE IF NOT EXISTS contacts (
@@ -104,26 +98,23 @@ func (d *DB) Init() error {
 		return fmt.Errorf("create schema: %w", err)
 	}
 
-	// ADR-0001 step 6: add email_ct + name_ct BLOB columns for at-rest
-	// encryption of contact PII. Idempotent via PRAGMA table_info — once
-	// both columns exist the backfill becomes a no-op (zero rows match
-	// WHERE *_ct IS NULL). Plaintext email/name columns stay until
-	// step 7 introduces deterministic lookup tokens — the UNIQUE
-	// constraint on email and the indexed LIKE prefix on both columns
-	// cannot be served from random-nonce ciphertext.
+	// ADR-0001 step 7g (β-revision): drop the email_ct + name_ct BLOB
+	// columns that step 6 added. They were written but never read — the
+	// UNIQUE(email) constraint and the indexed LIKE prefix search both
+	// need plaintext, and the β-revision argument (address PII is already
+	// on the wire) removed any motivation to keep the ciphertext mirror.
+	// Idempotent via PRAGMA table_info — once dropped, the column
+	// disappears and the loop becomes a no-op on subsequent opens.
 	for _, col := range []string{"email_ct", "name_ct"} {
 		has, err := hasColumn(d.db, "contacts", col)
 		if err != nil {
 			return fmt.Errorf("inspect %s: %w", col, err)
 		}
-		if !has {
-			if _, err := d.db.Exec("ALTER TABLE contacts ADD COLUMN " + col + " BLOB"); err != nil {
-				return fmt.Errorf("add %s: %w", col, err)
+		if has {
+			if _, err := d.db.Exec("ALTER TABLE contacts DROP COLUMN " + col); err != nil {
+				return fmt.Errorf("drop %s: %w", col, err)
 			}
 		}
-	}
-	if err := d.backfillContactCt(); err != nil {
-		return fmt.Errorf("backfill contacts ct: %w", err)
 	}
 
 	return nil
@@ -153,95 +144,6 @@ func hasColumn(db *sql.DB, table, column string) (bool, error) {
 	return false, rows.Err()
 }
 
-// encryptContact seals plain with the contact sub-key. Empty plaintext
-// maps to nil so the ct column stays NULL — same convention as the
-// store package's encrypt* helpers.
-func (d *DB) encryptContact(plain string) ([]byte, error) {
-	if plain == "" {
-		return nil, nil
-	}
-	return dbcrypto.Encrypt(d.keyring.Contact, []byte(plain))
-}
-
-// decryptContact returns plaintext for a contact_key column, preferring
-// the ct when present and falling back to plaintext only when ct IS NULL.
-// Decrypt failures on non-nil ct are hard errors. Not yet called by
-// production reads — step 7 will wire the lookup paths once the
-// plaintext columns die.
-func (d *DB) decryptContact(plain string, ct []byte) (string, error) {
-	if len(ct) == 0 {
-		return plain, nil
-	}
-	out, err := dbcrypto.Decrypt(d.keyring.Contact, ct)
-	if err != nil {
-		return "", fmt.Errorf("decrypt contact: %w", err)
-	}
-	return string(out), nil
-}
-
-// backfillContactCt encrypts every existing contacts.email + contacts.name
-// into the new BLOB columns. Single transaction so a mid-loop failure
-// rolls back cleanly. Contact volumes are typically in the low thousands
-// even for heavy users; loading the batch in RAM is fine.
-func (d *DB) backfillContactCt() error {
-	if d.keyring == nil || d.keyring.Contact == nil {
-		return fmt.Errorf("no keyring available for contact backfill")
-	}
-	tx, err := d.db.Begin()
-	if err != nil {
-		return fmt.Errorf("begin tx: %w", err)
-	}
-	defer tx.Rollback() //nolint:errcheck
-
-	rows, err := tx.Query(`SELECT id, email, name FROM contacts
-		WHERE (email IS NOT NULL AND email <> '' AND email_ct IS NULL)
-		   OR (name  IS NOT NULL AND name  <> '' AND name_ct  IS NULL)`)
-	if err != nil {
-		return fmt.Errorf("select rows: %w", err)
-	}
-	type pending struct {
-		id          string
-		email, name string
-	}
-	var batch []pending
-	for rows.Next() {
-		var p pending
-		var name sql.NullString
-		if err := rows.Scan(&p.id, &p.email, &name); err != nil {
-			rows.Close()
-			return fmt.Errorf("scan: %w", err)
-		}
-		if name.Valid {
-			p.name = name.String
-		}
-		batch = append(batch, p)
-	}
-	rows.Close()
-	if err := rows.Err(); err != nil {
-		return fmt.Errorf("iterate rows: %w", err)
-	}
-
-	stmt, err := tx.Prepare("UPDATE contacts SET email_ct = ?, name_ct = ? WHERE id = ?")
-	if err != nil {
-		return fmt.Errorf("prepare update: %w", err)
-	}
-	defer stmt.Close()
-	for _, p := range batch {
-		emailCT, err := d.encryptContact(p.email)
-		if err != nil {
-			return fmt.Errorf("encrypt email id=%s: %w", p.id, err)
-		}
-		nameCT, err := d.encryptContact(p.name)
-		if err != nil {
-			return fmt.Errorf("encrypt name id=%s: %w", p.id, err)
-		}
-		if _, err := stmt.Exec(emailCT, nameCT, p.id); err != nil {
-			return fmt.Errorf("update id=%s: %w", p.id, err)
-		}
-	}
-	return tx.Commit()
-}
-
 // Add adds a new contact to the database
 // If the email already exists, it updates the name if provided
 func (d *DB) Add(email, name, source string) error {
@@ -252,23 +154,13 @@ func (d *DB) Add(email, name, source string) error {
 	id := uuid.New().String()
 	now := time.Now()
 	lowered := strings.ToLower(email)
-	emailCT, err := d.encryptContact(lowered)
-	if err != nil {
-		return fmt.Errorf("encrypt email: %w", err)
-	}
-	nameCT, err := d.encryptContact(name)
-	if err != nil {
-		return fmt.Errorf("encrypt name: %w", err)
-	}
 
-	_, err = d.db.Exec(`
-		INSERT INTO contacts (id, email, email_ct, name, name_ct, source, created_at, usage_count)
-		VALUES (?, ?, ?, ?, ?, ?, ?, 0)
+	_, err := d.db.Exec(`
+		INSERT INTO contacts (id, email, name, source, created_at, usage_count)
+		VALUES (?, ?, ?, ?, ?, 0)
 		ON CONFLICT(email) DO UPDATE SET
-			name = COALESCE(NULLIF(excluded.name, ''), contacts.name),
-			name_ct = CASE WHEN NULLIF(excluded.name, '') IS NOT NULL
-			               THEN excluded.name_ct ELSE contacts.name_ct END
-	`, id, lowered, emailCT, name, nameCT, source, now)
+			name = COALESCE(NULLIF(excluded.name, ''), contacts.name)
+	`, id, lowered, name, source, now)
 
 	if err != nil {
 		return fmt.Errorf("add contact: %w", err)
@@ -286,12 +178,10 @@ func (d *DB) AddBatch(contacts []Contact) (added, updated int, err error) {
 	defer tx.Rollback()
 
 	stmt, err := tx.Prepare(`
-		INSERT INTO contacts (id, email, email_ct, name, name_ct, source, created_at, usage_count)
-		VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+		INSERT INTO contacts (id, email, name, source, created_at, usage_count)
+		VALUES (?, ?, ?, ?, ?, ?)
 		ON CONFLICT(email) DO UPDATE SET
 			name = COALESCE(NULLIF(excluded.name, ''), contacts.name),
-			name_ct = CASE WHEN NULLIF(excluded.name, '') IS NOT NULL
-			               THEN excluded.name_ct ELSE contacts.name_ct END,
 			usage_count = excluded.usage_count
 	`)
 	if err != nil {
@@ -304,15 +194,7 @@ func (d *DB) AddBatch(contacts []Contact) (added, updated int, err error) {
 			continue
 		}
 		lowered := strings.ToLower(c.Email)
-		emailCT, err := d.encryptContact(lowered)
-		if err != nil {
-			return added, updated, fmt.Errorf("encrypt contact %s email: %w", c.Email, err)
-		}
-		nameCT, err := d.encryptContact(c.Name)
-		if err != nil {
-			return added, updated, fmt.Errorf("encrypt contact %s name: %w", c.Email, err)
-		}
-		result, err := stmt.Exec(c.ID, lowered, emailCT, c.Name, nameCT, c.Source, c.CreatedAt, c.UsageCount)
+		result, err := stmt.Exec(c.ID, lowered, c.Name, c.Source, c.CreatedAt, c.UsageCount)
 		if err != nil {
 			return added, updated, fmt.Errorf("insert contact %s: %w", c.Email, err)
 		}

--- a/cli/internal/contacts/db_test.go
+++ b/cli/internal/contacts/db_test.go
@@ -1,22 +1,15 @@
 package contacts
 
 import (
-	"bytes"
 	"path/filepath"
 	"testing"
 	"time"
-
-	"github.com/durian-dev/durian/cli/internal/dbcrypto"
 )
 
 func newTestDB(t *testing.T) *DB {
 	t.Helper()
 	dir := t.TempDir()
-	kr, err := dbcrypto.NewKeyring(bytes.Repeat([]byte{0x42}, dbcrypto.MasterKeyLen))
-	if err != nil {
-		t.Fatalf("test keyring: %v", err)
-	}
-	db, err := Open(filepath.Join(dir, "contacts.db"), kr)
+	db, err := Open(filepath.Join(dir, "contacts.db"))
 	if err != nil {
 		t.Fatalf("open: %v", err)
 	}

--- a/cli/internal/handler/http_test.go
+++ b/cli/internal/handler/http_test.go
@@ -1,7 +1,6 @@
 package handler
 
 import (
-	"bytes"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -14,7 +13,6 @@ import (
 	"github.com/gorilla/mux"
 
 	"github.com/durian-dev/durian/cli/internal/contacts"
-	"github.com/durian-dev/durian/cli/internal/dbcrypto"
 )
 
 // newTestRouter sets up a mux.Router with all routes, mirroring serve.go.
@@ -42,11 +40,7 @@ func newTestRouter(h *Handler, hub *EventHub) *mux.Router {
 func newTestContactsDB(t *testing.T) *contacts.DB {
 	t.Helper()
 	dir := t.TempDir()
-	kr, err := dbcrypto.NewKeyring(bytes.Repeat([]byte{0x42}, dbcrypto.MasterKeyLen))
-	if err != nil {
-		t.Fatalf("test keyring: %v", err)
-	}
-	db, err := contacts.Open(filepath.Join(dir, "contacts.db"), kr)
+	db, err := contacts.Open(filepath.Join(dir, "contacts.db"))
 	if err != nil {
 		t.Fatalf("open contacts: %v", err)
 	}

--- a/docs/content/docs/developers/design/0001-mail-content-encryption-at-rest.md
+++ b/docs/content/docs/developers/design/0001-mail-content-encryption-at-rest.md
@@ -108,14 +108,19 @@ no new direct dependency added).
 | `headers_key`      | `"durian/v1/headers"`    | encrypts `message_headers.value`       |
 | `addrs_key`        | `"durian/v1/addrs"`      | **(retired, see §3)** previously encrypted `from_addr`, `to_addrs`, `cc_addrs` |
 | `draft_key`        | `"durian/v1/draft"`      | encrypts `local_drafts.draft_json`, `outbox.draft_json` |
-| `contact_key`      | `"durian/v1/contact"`    | encrypts `contacts.email`, `contacts.name` |
+| `contact_key`      | `"durian/v1/contact"`    | **(retired, see §3)** previously encrypted `contacts.email`, `contacts.name` |
 | `fts_token_key`    | `"durian/v1/fts-token"`  | HMAC key for blind FTS5 tokens (§4)    |
 | `meta_key`         | `"durian/v1/meta"`       | encrypts `mailbox` name, custom `flags`, `account` string |
 
-`addrs_key` is derived for backward-compatibility (the v11→v12 migration
-populated `from_addr_ct` / `to_addrs_ct` / `cc_addrs_ct` columns under
-this key) but no current read or write path consumes it — see §3 for
-why the addresses ended up staying plaintext.
+`addrs_key` and `contact_key` are still derived for forward-compatibility
+(the v11→v12 migration populated `from_addr_ct` / `to_addrs_ct` /
+`cc_addrs_ct` columns under `addrs_key`; the step-6 contacts migration
+populated `email_ct` / `name_ct` under `contact_key`) but no current
+read or write path consumes either — see §3 for why message addresses
+and contact rows both ended up staying plaintext. Removing the derivation
+is a no-op cleanup that would force a sub-key index renumber on every
+existing install; deferred until a future migration touches the keyring
+shape for unrelated reasons.
 
 Keychain layout (new):
 
@@ -208,8 +213,21 @@ Columns that **stay plaintext** with a documented information leak:
 `message_headers.value` → `BLOB`. Header `name` stays plaintext (already a
 small enumerable set per RFC 5322).
 
-`contacts.email` and `contacts.name` → `BLOB`. `id` stays plaintext (UUID),
-`source`, `last_used`, `usage_count`, `created_at` stay plaintext.
+`contacts.email` and `contacts.name` **stay plaintext TEXT** — moved
+from the encrypted set during implementation (step 7g). Same β-revision
+reasoning as `from_addr` / `to_addrs` / `cc_addrs` above: every contact
+row in the directory was either harvested from an incoming `From:` /
+`To:` / `Cc:` header or typed into a `compose` field that immediately
+becomes a wire address. Encrypting the local mirror while the same
+addresses shout on every wire hop is asymmetric protection. The cost
+side is concrete: `UNIQUE(email)` upsert and the `email LIKE 'ali%'` /
+`name LIKE 'ali%'` autocomplete that the compose-recipient picker
+relies on both need plaintext indexes — neither survives random-nonce
+AES-GCM, and a deterministic-token replacement (Naveed et al, CCS 2015)
+would leak a contact-frequency histogram that re-identifies the user's
+top correspondents from the ciphertext alone. `id` stays plaintext
+(UUID), `source`, `last_used`, `usage_count`, `created_at` stay
+plaintext as before.
 
 `outbox.draft_json`, `local_drafts.draft_json` → `BLOB`.
 
@@ -392,6 +410,14 @@ Does **not** defend against:
   ADR may add an opt-in encrypt-from-to flag for users whose threat
   model puts the local DB as the genuinely-only-place these addresses
   live (air-gapped archive, etc.).
+- Information leakage from `contacts.email` / `contacts.name` (see
+  §3): the directory is the projected union of every `From:` / `To:` /
+  `Cc:` the user has ever seen plus the addresses typed into compose.
+  An attacker with `contacts.db` recovers the user's full address book
+  and (via `usage_count` + `last_used`, also plaintext) a ranking of
+  who they correspond with most. Mitigation: none, deliberately. Same
+  on-the-wire-anyway argument as messages-side addresses; same
+  cost/benefit failure for the implementable encrypted alternatives.
 
 ### Threat-actor personas
 
@@ -679,6 +705,14 @@ Resolved (kept here for traceability):
   stay plaintext TEXT" + §6 threat-model bullet). Substring search
   served by `LIKE` on the plaintext column; no FTS5 address tokens
   exist in V1.
+- ~~Contact encryption.~~ → `contacts.email` and `contacts.name`
+  moved to plaintext in step 7g (see §3 + §6 threat-model bullet).
+  Same β-revision reasoning as the message-side addresses: contact
+  rows are projections of wire addresses, so encrypting only the
+  local mirror is asymmetric protection that costs `UNIQUE(email)`
+  upsert and prefix-LIKE autocomplete. The dead `email_ct` /
+  `name_ct` columns were dropped; `contact_key` is retired but
+  still derived (see §2 sub-key table).
 - ~~Mailbox / flags / account plaintext leak.~~ → encrypted, with integer
   surrogate columns for indexing (§3). Resolved in response to early-review
   feedback.


### PR DESCRIPTION
## Summary

Apply the β-revision (move plaintext-on-disk addresses out of the encrypted set) to the contacts directory. The mirror columns added in step 6 (`contacts.email_ct` + `contacts.name_ct`) were written but never read — `UNIQUE(email)` upsert and the compose-recipient autocomplete (`LIKE 'ali%'`) both need plaintext indexes, and the β argument from step 7d applies symmetrically: every contact row is a projection of a wire address, so encrypting only the local mirror is asymmetric protection.

- Drop `contacts.email_ct` + `contacts.name_ct` columns via idempotent migration.
- Strip `encryptContact` / `decryptContact` / `backfillContactCt` helpers + ct writes from `Add()` / `AddBatch()`.
- `contacts.Open()` no longer takes `*Keyring`; updated 10 caller sites. `Keyring.Contact` stays derived (mirrors `Addrs` after step 7d).
- ADR §2 marks `contact_key` retired; §3 moves `contacts.email/name` to the plaintext-stays section with full β justification; §6 gains a contacts-plaintext threat-model bullet; Open Questions records the resolution.

Stacked on top of `adr-0001-step-7e-drop-plaintexts`.

## Test plan

- [x] All 18 CLI unit tests pass.
- [x] Encryption grep-gate clean.
- [x] Live dryrun on prod \`contacts.db\` snapshot (2658 rows): \`email_ct\` + \`name_ct\` dropped, all reads (\`list\` / \`search\` / \`add\`) work, re-init is no-op.