### PR TITLE
ADR-0001 step 7f — drop messages.mailbox/account/flags plaintext shadows

### DIFF
--- a/cli/cmd/durian/contacts.go
+++ b/cli/cmd/durian/contacts.go
@@ -93,7 +93,7 @@ func runContactsInit(cmd *cobra.Command, args []string) error {
 	dbPath := getDBPath()
 	slog.Debug("Initializing contacts database", "path", dbPath)
 
-	db, err := contacts.Open(dbPath, bootstrapKeyring())
+	db, err := contacts.Open(dbPath)
 	if err != nil {
 		return fmt.Errorf("open database: %w", err)
 	}
@@ -122,7 +122,7 @@ func runContactsImport(cmd *cobra.Command, args []string) error {
 	slog.Debug("Importing contacts", "path", dbPath)
 
 	// Open/create database
-	db, err := contacts.Open(dbPath, bootstrapKeyring())
+	db, err := contacts.Open(dbPath)
 	if err != nil {
 		return fmt.Errorf("open database: %w", err)
 	}
@@ -183,7 +183,7 @@ func runContactsImport(cmd *cobra.Command, args []string) error {
 func runContactsList(cmd *cobra.Command, args []string) error {
 	dbPath := getDBPath()
 
-	db, err := contacts.Open(dbPath, bootstrapKeyring())
+	db, err := contacts.Open(dbPath)
 	if err != nil {
 		return fmt.Errorf("open database: %w", err)
 	}
@@ -230,7 +230,7 @@ func runContactsSearch(cmd *cobra.Command, args []string) error {
 	query := args[0]
 	dbPath := getDBPath()
 
-	db, err := contacts.Open(dbPath, bootstrapKeyring())
+	db, err := contacts.Open(dbPath)
 	if err != nil {
 		return fmt.Errorf("open database: %w", err)
 	}
@@ -268,7 +268,7 @@ func runContactsAdd(cmd *cobra.Command, args []string) error {
 
 	dbPath := getDBPath()
 
-	db, err := contacts.Open(dbPath, bootstrapKeyring())
+	db, err := contacts.Open(dbPath)
 	if err != nil {
 		return fmt.Errorf("open database: %w", err)
 	}
@@ -307,7 +307,7 @@ func runContactsDelete(cmd *cobra.Command, args []string) error {
 	email := args[0]
 	dbPath := getDBPath()
 
-	db, err := contacts.Open(dbPath, bootstrapKeyring())
+	db, err := contacts.Open(dbPath)
 	if err != nil {
 		return fmt.Errorf("open database: %w", err)
 	}

--- a/cli/cmd/durian/serve.go
+++ b/cli/cmd/durian/serve.go
@@ -73,14 +73,14 @@ func runServe(cmd *cobra.Command, args []string) {
 	if contactsDBPath == "" {
 		contactsDBPath = contacts.DefaultDBPath()
 	}
-	if cdb, err := contacts.Open(contactsDBPath, keyring); err != nil {
+	if cdb, err := contacts.Open(contactsDBPath); err != nil {
 		slog.Warn("Could not open contacts database", "module", "SERVE", "path", contactsDBPath, "err", err)
 	} else if err := cdb.Init(); err != nil {
 		// Init runs the CREATE TABLE IF NOT EXISTS and any pending
-		// migrations (ADR-0001 step 6 contact encryption). Previously
-		// serve skipped Init and relied on the import subcommand to
-		// have set up the schema; with encrypt-on-write live we must
-		// guarantee the migration runs on startup.
+		// migrations (currently: ADR-0001 step 7g drops the dead
+		// email_ct / name_ct columns). serve must run Init on startup
+		// rather than deferring to subcommands, otherwise pending
+		// schema migrations never apply on a server-only deployment.
 		slog.Warn("Could not init contacts database", "module", "SERVE", "path", contactsDBPath, "err", err)
 		cdb.Close()
 	} else {

--- a/cli/cmd/testseeder/main.go
+++ b/cli/cmd/testseeder/main.go
@@ -119,7 +119,7 @@ func seedEmailDB(path string) error {
 }
 
 func seedContactsDB(path string) error {
-	db, err := contacts.Open(path, testKeyring())
+	db, err := contacts.Open(path)
 	if err != nil {
 		return fmt.Errorf("open: %w", err)
 	}

--- a/cli/internal/contacts/db.go
+++ b/cli/internal/contacts/db.go
@@ -10,8 +10,6 @@ import (
 
 	"github.com/google/uuid"
 
-	"github.com/durian-dev/durian/cli/internal/dbcrypto"
-
 	_ "modernc.org/sqlite"
 )
 
@@ -27,20 +25,17 @@ func DefaultDBPath() string {
 
 // DB represents a contacts database connection
 type DB struct {
-	db      *sql.DB
-	keyring *dbcrypto.Keyring
+	db *sql.DB
 }
 
 // Open opens or creates a contacts database at the given path.
 //
-// kr must be a non-nil Keyring derived from the OS-keychain master key.
-// ADR-0001 step 6 requires the Contact sub-key for the email/name
-// encrypt-on-write path and the one-shot backfill in Init().
-func Open(dbPath string, kr *dbcrypto.Keyring) (*DB, error) {
-	if kr == nil {
-		return nil, fmt.Errorf("contacts: Open requires a non-nil keyring (see ADR-0001)")
-	}
-
+// ADR-0001 step 7g (β-revision): contact email + name stay plaintext on
+// disk. They are on the wire any time a mail is sent or received, so the
+// asymmetric protection of encrypting only the local mirror is not worth
+// losing UNIQUE(email) enforcement and prefix-LIKE search. The contacts
+// store therefore takes no keyring; see ADR §3 "Stays plaintext".
+func Open(dbPath string) (*DB, error) {
 	// Expand ~ if present
 	if strings.HasPrefix(dbPath, "~/") {
 		home, err := os.UserHomeDir()
@@ -71,7 +66,7 @@ func Open(dbPath string, kr *dbcrypto.Keyring) (*DB, error) {
 		return nil, fmt.Errorf("set journal mode: %w", err)
 	}
 
-	return &DB{db: db, keyring: kr}, nil
+	return &DB{db: db}, nil
 }
 
 // Close closes the database connection
@@ -80,9 +75,8 @@ func (d *DB) Close() error {
 }
 
 // Init creates the contacts table and indexes if they don't exist, and
-// runs any pending one-shot migrations (ADR-0001 step 6 encryption is
-// detected via PRAGMA table_info since contacts.db has no schema_version
-// — first migration ever and likely the only one until step 7).
+// runs any pending one-shot migrations. contacts.db has no
+// schema_version table — migrations are detected via PRAGMA table_info.
 func (d *DB) Init() error {
 	schema := `
 	CREATE TABLE IF NOT EXISTS contacts (
@@ -104,26 +98,23 @@ func (d *DB) Init() error {
 		return fmt.Errorf("create schema: %w", err)
 	}
 
-	// ADR-0001 step 6: add email_ct + name_ct BLOB columns for at-rest
-	// encryption of contact PII. Idempotent via PRAGMA table_info — once
-	// both columns exist the backfill becomes a no-op (zero rows match
-	// WHERE *_ct IS NULL). Plaintext email/name columns stay until
-	// step 7 introduces deterministic lookup tokens — the UNIQUE
-	// constraint on email and the indexed LIKE prefix on both columns
-	// cannot be served from random-nonce ciphertext.
+	// ADR-0001 step 7g (β-revision): drop the email_ct + name_ct BLOB
+	// columns that step 6 added. They were written but never read — the
+	// UNIQUE(email) constraint and the indexed LIKE prefix search both
+	// need plaintext, and the β-revision argument (address PII is already
+	// on the wire) removed any motivation to keep the ciphertext mirror.
+	// Idempotent via PRAGMA table_info — once dropped, the column
+	// disappears and the loop becomes a no-op on subsequent opens.
 	for _, col := range []string{"email_ct", "name_ct"} {
 		has, err := hasColumn(d.db, "contacts", col)
 		if err != nil {
 			return fmt.Errorf("inspect %s: %w", col, err)
 		}
-		if !has {
-			if _, err := d.db.Exec("ALTER TABLE contacts ADD COLUMN " + col + " BLOB"); err != nil {
-				return fmt.Errorf("add %s: %w", col, err)
+		if has {
+			if _, err := d.db.Exec("ALTER TABLE contacts DROP COLUMN " + col); err != nil {
+				return fmt.Errorf("drop %s: %w", col, err)
 			}
 		}
-	}
-	if err := d.backfillContactCt(); err != nil {
-		return fmt.Errorf("backfill contacts ct: %w", err)
 	}
 
 	return nil
@@ -153,95 +144,6 @@ func hasColumn(db *sql.DB, table, column string) (bool, error) {
 	return false, rows.Err()
 }
 
-// encryptContact seals plain with the contact sub-key. Empty plaintext
-// maps to nil so the ct column stays NULL — same convention as the
-// store package's encrypt* helpers.
-func (d *DB) encryptContact(plain string) ([]byte, error) {
-	if plain == "" {
-		return nil, nil
-	}
-	return dbcrypto.Encrypt(d.keyring.Contact, []byte(plain))
-}
-
-// decryptContact returns plaintext for a contact_key column, preferring
-// the ct when present and falling back to plaintext only when ct IS NULL.
-// Decrypt failures on non-nil ct are hard errors. Not yet called by
-// production reads — step 7 will wire the lookup paths once the
-// plaintext columns die.
-func (d *DB) decryptContact(plain string, ct []byte) (string, error) {
-	if len(ct) == 0 {
-		return plain, nil
-	}
-	out, err := dbcrypto.Decrypt(d.keyring.Contact, ct)
-	if err != nil {
-		return "", fmt.Errorf("decrypt contact: %w", err)
-	}
-	return string(out), nil
-}
-
-// backfillContactCt encrypts every existing contacts.email + contacts.name
-// into the new BLOB columns. Single transaction so a mid-loop failure
-// rolls back cleanly. Contact volumes are typically in the low thousands
-// even for heavy users; loading the batch in RAM is fine.
-func (d *DB) backfillContactCt() error {
-	if d.keyring == nil || d.keyring.Contact == nil {
-		return fmt.Errorf("no keyring available for contact backfill")
-	}
-	tx, err := d.db.Begin()
-	if err != nil {
-		return fmt.Errorf("begin tx: %w", err)
-	}
-	defer tx.Rollback() //nolint:errcheck
-
-	rows, err := tx.Query(`SELECT id, email, name FROM contacts
-		WHERE (email IS NOT NULL AND email <> '' AND email_ct IS NULL)
-		   OR (name  IS NOT NULL AND name  <> '' AND name_ct  IS NULL)`)
-	if err != nil {
-		return fmt.Errorf("select rows: %w", err)
-	}
-	type pending struct {
-		id          string
-		email, name string
-	}
-	var batch []pending
-	for rows.Next() {
-		var p pending
-		var name sql.NullString
-		if err := rows.Scan(&p.id, &p.email, &name); err != nil {
-			rows.Close()
-			return fmt.Errorf("scan: %w", err)
-		}
-		if name.Valid {
-			p.name = name.String
-		}
-		batch = append(batch, p)
-	}
-	rows.Close()
-	if err := rows.Err(); err != nil {
-		return fmt.Errorf("iterate rows: %w", err)
-	}
-
-	stmt, err := tx.Prepare("UPDATE contacts SET email_ct = ?, name_ct = ? WHERE id = ?")
-	if err != nil {
-		return fmt.Errorf("prepare update: %w", err)
-	}
-	defer stmt.Close()
-	for _, p := range batch {
-		emailCT, err := d.encryptContact(p.email)
-		if err != nil {
-			return fmt.Errorf("encrypt email id=%s: %w", p.id, err)
-		}
-		nameCT, err := d.encryptContact(p.name)
-		if err != nil {
-			return fmt.Errorf("encrypt name id=%s: %w", p.id, err)
-		}
-		if _, err := stmt.Exec(emailCT, nameCT, p.id); err != nil {
-			return fmt.Errorf("update id=%s: %w", p.id, err)
-		}
-	}
-	return tx.Commit()
-}
-
 // Add adds a new contact to the database
 // If the email already exists, it updates the name if provided
 func (d *DB) Add(email, name, source string) error {
@@ -252,23 +154,13 @@ func (d *DB) Add(email, name, source string) error {
 	id := uuid.New().String()
 	now := time.Now()
 	lowered := strings.ToLower(email)
-	emailCT, err := d.encryptContact(lowered)
-	if err != nil {
-		return fmt.Errorf("encrypt email: %w", err)
-	}
-	nameCT, err := d.encryptContact(name)
-	if err != nil {
-		return fmt.Errorf("encrypt name: %w", err)
-	}
 
-	_, err = d.db.Exec(`
-		INSERT INTO contacts (id, email, email_ct, name, name_ct, source, created_at, usage_count)
-		VALUES (?, ?, ?, ?, ?, ?, ?, 0)
+	_, err := d.db.Exec(`
+		INSERT INTO contacts (id, email, name, source, created_at, usage_count)
+		VALUES (?, ?, ?, ?, ?, 0)
 		ON CONFLICT(email) DO UPDATE SET
-			name = COALESCE(NULLIF(excluded.name, ''), contacts.name),
-			name_ct = CASE WHEN NULLIF(excluded.name, '') IS NOT NULL
-			               THEN excluded.name_ct ELSE contacts.name_ct END
-	`, id, lowered, emailCT, name, nameCT, source, now)
+			name = COALESCE(NULLIF(excluded.name, ''), contacts.name)
+	`, id, lowered, name, source, now)
 
 	if err != nil {
 		return fmt.Errorf("add contact: %w", err)
@@ -286,12 +178,10 @@ func (d *DB) AddBatch(contacts []Contact) (added, updated int, err error) {
 	defer tx.Rollback()
 
 	stmt, err := tx.Prepare(`
-		INSERT INTO contacts (id, email, email_ct, name, name_ct, source, created_at, usage_count)
-		VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+		INSERT INTO contacts (id, email, name, source, created_at, usage_count)
+		VALUES (?, ?, ?, ?, ?, ?)
 		ON CONFLICT(email) DO UPDATE SET
 			name = COALESCE(NULLIF(excluded.name, ''), contacts.name),
-			name_ct = CASE WHEN NULLIF(excluded.name, '') IS NOT NULL
-			               THEN excluded.name_ct ELSE contacts.name_ct END,
 			usage_count = excluded.usage_count
 	`)
 	if err != nil {
@@ -304,15 +194,7 @@ func (d *DB) AddBatch(contacts []Contact) (added, updated int, err error) {
 			continue
 		}
 		lowered := strings.ToLower(c.Email)
-		emailCT, err := d.encryptContact(lowered)
-		if err != nil {
-			return added, updated, fmt.Errorf("encrypt contact %s email: %w", c.Email, err)
-		}
-		nameCT, err := d.encryptContact(c.Name)
-		if err != nil {
-			return added, updated, fmt.Errorf("encrypt contact %s name: %w", c.Email, err)
-		}
-		result, err := stmt.Exec(c.ID, lowered, emailCT, c.Name, nameCT, c.Source, c.CreatedAt, c.UsageCount)
+		result, err := stmt.Exec(c.ID, lowered, c.Name, c.Source, c.CreatedAt, c.UsageCount)
 		if err != nil {
 			return added, updated, fmt.Errorf("insert contact %s: %w", c.Email, err)
 		}

--- a/cli/internal/contacts/db_test.go
+++ b/cli/internal/contacts/db_test.go
@@ -1,22 +1,15 @@
 package contacts
 
 import (
-	"bytes"
 	"path/filepath"
 	"testing"
 	"time"
-
-	"github.com/durian-dev/durian/cli/internal/dbcrypto"
 )
 
 func newTestDB(t *testing.T) *DB {
 	t.Helper()
 	dir := t.TempDir()
-	kr, err := dbcrypto.NewKeyring(bytes.Repeat([]byte{0x42}, dbcrypto.MasterKeyLen))
-	if err != nil {
-		t.Fatalf("test keyring: %v", err)
-	}
-	db, err := Open(filepath.Join(dir, "contacts.db"), kr)
+	db, err := Open(filepath.Join(dir, "contacts.db"))
 	if err != nil {
 		t.Fatalf("open: %v", err)
 	}

--- a/cli/internal/handler/http_test.go
+++ b/cli/internal/handler/http_test.go
@@ -1,7 +1,6 @@
 package handler
 
 import (
-	"bytes"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -14,7 +13,6 @@ import (
 	"github.com/gorilla/mux"
 
 	"github.com/durian-dev/durian/cli/internal/contacts"
-	"github.com/durian-dev/durian/cli/internal/dbcrypto"
 )
 
 // newTestRouter sets up a mux.Router with all routes, mirroring serve.go.
@@ -42,11 +40,7 @@ func newTestRouter(h *Handler, hub *EventHub) *mux.Router {
 func newTestContactsDB(t *testing.T) *contacts.DB {
 	t.Helper()
 	dir := t.TempDir()
-	kr, err := dbcrypto.NewKeyring(bytes.Repeat([]byte{0x42}, dbcrypto.MasterKeyLen))
-	if err != nil {
-		t.Fatalf("test keyring: %v", err)
-	}
-	db, err := contacts.Open(filepath.Join(dir, "contacts.db"), kr)
+	db, err := contacts.Open(filepath.Join(dir, "contacts.db"))
 	if err != nil {
 		t.Fatalf("open contacts: %v", err)
 	}

--- a/cli/internal/store/headers.go
+++ b/cli/internal/store/headers.go
@@ -51,12 +51,25 @@ func (d *DB) HasHeaders(messageDBID int64) (bool, error) {
 }
 
 // GetMessageDBID returns the internal DB ID for a message by its RFC822 Message-ID
-// and account. Returns 0 if not found.
+// and account. Returns 0 if not found. Step 7f: account is resolved to
+// its accounts.id; an empty account string matches rows where
+// account_id IS NULL (the empty-Account upsert path).
 func (d *DB) GetMessageDBID(messageID, account string) (int64, error) {
 	var id int64
-	err := d.db.QueryRow(
-		"SELECT id FROM messages WHERE message_id = ? AND account = ?",
-		messageID, account).Scan(&id)
+	var err error
+	if account == "" {
+		err = d.db.QueryRow(
+			"SELECT id FROM messages WHERE message_id = ? AND account_id IS NULL",
+			messageID).Scan(&id)
+	} else {
+		var accountID int64
+		if err = d.db.QueryRow("SELECT id FROM accounts WHERE name = ?", account).Scan(&accountID); err != nil {
+			return 0, nil
+		}
+		err = d.db.QueryRow(
+			"SELECT id FROM messages WHERE message_id = ? AND account_id = ?",
+			messageID, accountID).Scan(&id)
+	}
 	if err != nil {
 		return 0, nil
 	}
@@ -65,11 +78,14 @@ func (d *DB) GetMessageDBID(messageID, account string) (int64, error) {
 
 // AllMessages returns all messages with fields needed for rule matching.
 // from_addr/to_addrs/cc_addrs are plaintext (ADR-0001 §3 revision);
-// subject/body_text are ct-only after step 7e.
+// subject/body_text are ct-only after step 7e. Step 7f: account name
+// comes from the accounts LEFT JOIN + meta_key decrypt.
 func (d *DB) AllMessages() ([]*Message, error) {
-	rows, err := d.db.Query(`SELECT id, message_id, subject_ct,
-		from_addr, to_addrs, cc_addrs,
-		body_text_ct, account FROM messages`)
+	rows, err := d.db.Query(`SELECT m.id, m.message_id, m.subject_ct,
+		m.from_addr, m.to_addrs, m.cc_addrs,
+		m.body_text_ct, ac.name_ct
+		FROM messages m
+		LEFT JOIN accounts ac ON ac.id = m.account_id`)
 	if err != nil {
 		return nil, fmt.Errorf("query messages: %w", err)
 	}
@@ -78,10 +94,10 @@ func (d *DB) AllMessages() ([]*Message, error) {
 	var msgs []*Message
 	for rows.Next() {
 		m := &Message{}
-		var subjectCT, bodyTextCT []byte
+		var subjectCT, bodyTextCT, accountCT []byte
 		if err := rows.Scan(&m.ID, &m.MessageID, &subjectCT,
 			&m.FromAddr, &m.ToAddrs, &m.CCAddrs,
-			&bodyTextCT, &m.Account); err != nil {
+			&bodyTextCT, &accountCT); err != nil {
 			return nil, fmt.Errorf("scan message: %w", err)
 		}
 		if m.Subject, err = d.decryptSubject("", subjectCT); err != nil {
@@ -89,6 +105,9 @@ func (d *DB) AllMessages() ([]*Message, error) {
 		}
 		if m.BodyText, err = d.decryptBody("", bodyTextCT); err != nil {
 			return nil, err
+		}
+		if m.Account, err = d.decryptMeta("", accountCT); err != nil {
+			return nil, fmt.Errorf("decrypt account name: %w", err)
 		}
 		msgs = append(msgs, m)
 	}

--- a/cli/internal/store/messages.go
+++ b/cli/internal/store/messages.go
@@ -3,7 +3,19 @@ package store
 import (
 	"database/sql"
 	"fmt"
+	"strings"
 )
+
+// nullableID maps a zero id to sql.NULL so the resulting column stays NULL
+// instead of pointing at the non-existent row 0. Empty mailbox/account
+// names are legal (e.g. early-sync edge cases) and must not introduce a
+// dangling FK reference.
+func nullableID(id int64) any {
+	if id == 0 {
+		return nil
+	}
+	return id
+}
 
 // InsertMessage inserts or upserts a single message, resolving its thread ID.
 func (d *DB) InsertMessage(msg *Message) error {
@@ -66,32 +78,54 @@ func (d *DB) insertMessageTx(tx *sql.Tx, msg *Message) error {
 	if err != nil {
 		return fmt.Errorf("encrypt body_html: %w", err)
 	}
-	// ADR-0001 step 6: non-boolean flag parts go to flags_other under
-	// the meta sub-key. Booleans (is_seen/is_flagged/is_deleted) are
-	// derived elsewhere in this insert path's downstream tag flow.
+	// ADR-0001 step 7f: split msg.Flags into the three boolean columns
+	// + flags_other (everything else, encrypted under meta_key). Inverse
+	// of flagsFromParts on the read path.
+	parts := strings.Fields(msg.Flags)
+	var isSeen, isFlagged, isDeleted int
+	for _, p := range parts {
+		switch p {
+		case `\Seen`:
+			isSeen = 1
+		case `\Flagged`:
+			isFlagged = 1
+		case `\Deleted`:
+			isDeleted = 1
+		}
+	}
 	flagsOtherCT, err := d.encryptMeta(flagsOtherForEncryption(msg.Flags))
 	if err != nil {
 		return fmt.Errorf("encrypt flags_other: %w", err)
+	}
+
+	// ADR-0001 step 7f: resolve mailbox + account names to their FK ids,
+	// inserting new rows (with encrypted name_ct) on first sight. The
+	// plaintext shadow columns messages.mailbox / messages.account /
+	// messages.flags are gone in v19; this insert no longer touches them.
+	mailboxID, err := d.getOrCreateMailbox(tx, msg.Mailbox)
+	if err != nil {
+		return fmt.Errorf("resolve mailbox: %w", err)
+	}
+	accountID, err := d.getOrCreateAccount(tx, msg.Account)
+	if err != nil {
+		return fmt.Errorf("resolve account: %w", err)
 	}
 
 	// ADR-0001 step 7d / §3 revision: from_addr/to_addrs/cc_addrs stay
 	// plaintext (substring-search UX, addresses already public on the
 	// wire). No *_ct columns written for the addrs columns — v17
 	// migration drops them.
-
-	// ADR-0001 step 7e: subject / body_text / body_html plaintext
-	// columns are gone. Only the *_ct columns are written. flags TEXT
-	// still alive for tag-system + mailbox/account stay TEXT (step 7f
-	// handles those).
 	err = tx.QueryRow(`
 		INSERT INTO messages (
 			message_id, thread_id, in_reply_to, refs, subject_ct,
 			from_addr, to_addrs, cc_addrs,
 			date, created_at,
 			body_text_ct, body_html_ct,
-			mailbox, flags, flags_other, uid, size, fetched_body, account
-		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-		ON CONFLICT(message_id, account) DO UPDATE SET
+			mailbox_id, account_id,
+			is_seen, is_flagged, is_deleted, flags_other,
+			uid, size, fetched_body
+		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+		ON CONFLICT(message_id, IFNULL(account_id, 0)) DO UPDATE SET
 			subject_ct = excluded.subject_ct,
 			from_addr = excluded.from_addr,
 			to_addrs = excluded.to_addrs,
@@ -101,16 +135,21 @@ func (d *DB) insertMessageTx(tx *sql.Tx, msg *Message) error {
 			body_html_ct = CASE WHEN excluded.fetched_body = 1 AND messages.fetched_body = 0
 			                 THEN excluded.body_html_ct ELSE messages.body_html_ct END,
 			fetched_body = MAX(messages.fetched_body, excluded.fetched_body),
-			flags = excluded.flags,
+			is_seen = excluded.is_seen,
+			is_flagged = excluded.is_flagged,
+			is_deleted = excluded.is_deleted,
 			flags_other = excluded.flags_other,
 			uid = CASE WHEN excluded.uid > 0 THEN excluded.uid ELSE messages.uid END,
-			mailbox = CASE WHEN excluded.mailbox != '' THEN excluded.mailbox ELSE messages.mailbox END
+			mailbox_id = CASE WHEN excluded.mailbox_id IS NOT NULL
+			                 THEN excluded.mailbox_id ELSE messages.mailbox_id END
 		RETURNING id`,
 		msg.MessageID, threadID, msg.InReplyTo, msg.Refs, subjectCT,
 		msg.FromAddr, msg.ToAddrs, msg.CCAddrs,
 		msg.Date, msg.CreatedAt,
 		bodyTextCT, bodyHTMLCT,
-		msg.Mailbox, msg.Flags, flagsOtherCT, msg.UID, msg.Size, fetchedBody, msg.Account,
+		nullableID(mailboxID), nullableID(accountID),
+		isSeen, isFlagged, isDeleted, flagsOtherCT,
+		msg.UID, msg.Size, fetchedBody,
 	).Scan(&msg.ID)
 	if err != nil {
 		return fmt.Errorf("upsert message: %w", err)
@@ -197,61 +236,63 @@ func (d *DB) UpdateBody(messageID, bodyText, bodyHTML string) error {
 
 // UpdateMailbox sets the mailbox and UID for a message identified by message_id and account.
 func (d *DB) UpdateMailbox(messageID, account, mailbox string, uid uint32) error {
-	_, err := d.db.Exec(
-		"UPDATE messages SET mailbox = ?, uid = ? WHERE message_id = ? AND account = ?",
-		mailbox, uid, messageID, account)
+	tx, err := d.db.Begin()
 	if err != nil {
+		return fmt.Errorf("begin tx: %w", err)
+	}
+	defer tx.Rollback() //nolint:errcheck
+	mailboxID, err := d.getOrCreateMailbox(tx, mailbox)
+	if err != nil {
+		return err
+	}
+	accountID, err := d.getOrCreateAccount(tx, account)
+	if err != nil {
+		return err
+	}
+	if _, err := tx.Exec(
+		"UPDATE messages SET mailbox_id = ?, uid = ? WHERE message_id = ? AND account_id = ?",
+		nullableID(mailboxID), uid, messageID, nullableID(accountID)); err != nil {
 		return fmt.Errorf("update mailbox: %w", err)
 	}
-	return nil
+	return tx.Commit()
 }
 
 // BackfillUID sets the UID and mailbox for a message that has uid=0.
 // Used to populate UIDs for messages that were synced without UID info.
 func (d *DB) BackfillUID(messageID, account string, uid uint32, mailbox string) error {
-	_, err := d.db.Exec(`
-		UPDATE messages SET uid = ?, mailbox = ?
-		WHERE message_id = ? AND account = ? AND uid = 0`,
-		uid, mailbox, messageID, account)
+	tx, err := d.db.Begin()
 	if err != nil {
+		return fmt.Errorf("begin tx: %w", err)
+	}
+	defer tx.Rollback() //nolint:errcheck
+	mailboxID, err := d.getOrCreateMailbox(tx, mailbox)
+	if err != nil {
+		return err
+	}
+	accountID, err := d.getOrCreateAccount(tx, account)
+	if err != nil {
+		return err
+	}
+	if _, err := tx.Exec(`
+		UPDATE messages SET uid = ?, mailbox_id = ?
+		WHERE message_id = ? AND account_id = ? AND uid = 0`,
+		uid, nullableID(mailboxID), messageID, nullableID(accountID)); err != nil {
 		return fmt.Errorf("backfill uid: %w", err)
 	}
-	return nil
+	return tx.Commit()
 }
 
 // GetByMessageID retrieves a message by its Message-ID header value.
 func (d *DB) GetByMessageID(messageID string) (*Message, error) {
-	msg := &Message{}
-	var fetchedBody int
-	var subjectCT, bodyTextCT, bodyHTMLCT []byte
-	err := d.db.QueryRow(`
-		SELECT id, message_id, thread_id, in_reply_to, refs, subject_ct,
-		       from_addr, to_addrs, cc_addrs, date, created_at,
-		       body_text_ct, body_html_ct,
-		       mailbox, flags, uid, size, fetched_body, account
-		FROM messages WHERE message_id = ? LIMIT 1`, messageID,
-	).Scan(
-		&msg.ID, &msg.MessageID, &msg.ThreadID, &msg.InReplyTo, &msg.Refs, &subjectCT,
-		&msg.FromAddr, &msg.ToAddrs, &msg.CCAddrs, &msg.Date, &msg.CreatedAt,
-		&bodyTextCT, &bodyHTMLCT,
-		&msg.Mailbox, &msg.Flags, &msg.UID, &msg.Size, &fetchedBody, &msg.Account,
-	)
+	row := d.db.QueryRow(`SELECT `+messageSelectColumns+`
+		`+messageSelectFrom+`
+		WHERE m.message_id = ? LIMIT 1`, messageID)
+	msg, err := d.scanMessageRow(row.Scan)
 	if err == sql.ErrNoRows {
 		return nil, nil
 	}
 	if err != nil {
 		return nil, fmt.Errorf("get by message_id: %w", err)
-	}
-	msg.FetchedBody = fetchedBody == 1
-	if msg.Subject, err = d.decryptSubject("", subjectCT); err != nil {
-		return nil, err
-	}
-	// from_addr/to_addrs/cc_addrs stay plaintext (ADR-0001 §3 revision).
-	if msg.BodyText, err = d.decryptBody("", bodyTextCT); err != nil {
-		return nil, err
-	}
-	if msg.BodyHTML, err = d.decryptBody("", bodyHTMLCT); err != nil {
-		return nil, err
 	}
 	return msg, nil
 }
@@ -259,13 +300,10 @@ func (d *DB) GetByMessageID(messageID string) (*Message, error) {
 // GetByThread retrieves all messages in a thread, ordered by date ascending.
 // When a message exists in multiple accounts, only the first row is kept.
 func (d *DB) GetByThread(threadID string) ([]*Message, error) {
-	rows, err := d.db.Query(`
-		SELECT id, message_id, thread_id, in_reply_to, refs, subject_ct,
-		       from_addr, to_addrs, cc_addrs, date, created_at,
-		       body_text_ct, body_html_ct,
-		       mailbox, flags, uid, size, fetched_body, account
-		FROM messages WHERE thread_id = ?
-		ORDER BY date ASC`, threadID)
+	rows, err := d.db.Query(`SELECT `+messageSelectColumns+`
+		`+messageSelectFrom+`
+		WHERE m.thread_id = ?
+		ORDER BY m.date ASC`, threadID)
 	if err != nil {
 		return nil, fmt.Errorf("get by thread: %w", err)
 	}
@@ -293,13 +331,10 @@ func (d *DB) GetByThread(threadID string) ([]*Message, error) {
 // GetAllByThread retrieves all messages in a thread without deduplication.
 // Returns all rows including multi-account duplicates. Used for tag sync.
 func (d *DB) GetAllByThread(threadID string) ([]*Message, error) {
-	rows, err := d.db.Query(`
-		SELECT id, message_id, thread_id, in_reply_to, refs, subject_ct,
-		       from_addr, to_addrs, cc_addrs, date, created_at,
-		       body_text_ct, body_html_ct,
-		       mailbox, flags, uid, size, fetched_body, account
-		FROM messages WHERE thread_id = ?
-		ORDER BY date ASC`, threadID)
+	rows, err := d.db.Query(`SELECT `+messageSelectColumns+`
+		`+messageSelectFrom+`
+		WHERE m.thread_id = ?
+		ORDER BY m.date ASC`, threadID)
 	if err != nil {
 		return nil, fmt.Errorf("get all by thread: %w", err)
 	}
@@ -318,11 +353,21 @@ func (d *DB) MessageExists(messageID string) (bool, error) {
 }
 
 // MessageExistsForAccount checks if a message exists for a specific account.
+// The account name is resolved to its accounts.id; an unknown account
+// returns false without inserting a row (read-only path).
 func (d *DB) MessageExistsForAccount(messageID, account string) (bool, error) {
+	var accountID int64
+	err := d.db.QueryRow("SELECT id FROM accounts WHERE name = ?", account).Scan(&accountID)
+	if err == sql.ErrNoRows {
+		return false, nil
+	}
+	if err != nil {
+		return false, fmt.Errorf("lookup account id: %w", err)
+	}
 	var count int
-	err := d.db.QueryRow(
-		"SELECT COUNT(*) FROM messages WHERE message_id = ? AND account = ?",
-		messageID, account).Scan(&count)
+	err = d.db.QueryRow(
+		"SELECT COUNT(*) FROM messages WHERE message_id = ? AND account_id = ?",
+		messageID, accountID).Scan(&count)
 	if err != nil {
 		return false, fmt.Errorf("check message exists for account: %w", err)
 	}
@@ -364,9 +409,17 @@ func (d *DB) DeleteByMessageID(messageID string) error {
 
 // DeleteByMessageIDAndAccount deletes a message by its Message-ID and account.
 func (d *DB) DeleteByMessageIDAndAccount(messageID, account string) error {
+	var accountID int64
+	err := d.db.QueryRow("SELECT id FROM accounts WHERE name = ?", account).Scan(&accountID)
+	if err == sql.ErrNoRows {
+		return fmt.Errorf("message not found: %s (account %s)", messageID, account)
+	}
+	if err != nil {
+		return fmt.Errorf("lookup account id: %w", err)
+	}
 	result, err := d.db.Exec(
-		"DELETE FROM messages WHERE message_id = ? AND account = ?",
-		messageID, account)
+		"DELETE FROM messages WHERE message_id = ? AND account_id = ?",
+		messageID, accountID)
 	if err != nil {
 		return fmt.Errorf("delete message: %w", err)
 	}
@@ -414,34 +467,75 @@ func (d *DB) GetRecipientAddresses() ([]string, error) {
 	return result, rows.Err()
 }
 
-// scanMessages scans rows into a slice of Message pointers. Caller's
-// SELECT must list subject_ct, body_text_ct, body_html_ct (no plaintext
-// counterparts — dropped in step 7e). from_addr/to_addrs/cc_addrs stay
-// plaintext (ADR-0001 §3 revision).
+// messageSelectColumns is the canonical SELECT list for scanMessages /
+// the singular row-scan in GetByMessageID. Step 7f dropped the plaintext
+// mailbox / account / flags columns; mailbox name and account name now
+// come from LEFT JOINs against mailboxes / accounts (decrypted from
+// name_ct) and the flags string is reconstructed from is_*  + the
+// decrypted flags_other BLOB.
+const messageSelectColumns = `m.id, m.message_id, m.thread_id, m.in_reply_to, m.refs, m.subject_ct,
+		m.from_addr, m.to_addrs, m.cc_addrs, m.date, m.created_at,
+		m.body_text_ct, m.body_html_ct,
+		mb.name_ct, ac.name_ct,
+		m.is_seen, m.is_flagged, m.is_deleted, m.flags_other,
+		m.uid, m.size, m.fetched_body`
+
+const messageSelectFrom = `FROM messages m
+		LEFT JOIN mailboxes mb ON mb.id = m.mailbox_id
+		LEFT JOIN accounts  ac ON ac.id = m.account_id`
+
+// scanMessageRow scans one row produced by a SELECT over
+// messageSelectColumns + messageSelectFrom into a *Message. Shared
+// implementation for both the singular GetByMessageID path and the
+// row-by-row loop in scanMessages.
+func (d *DB) scanMessageRow(scan func(...any) error) (*Message, error) {
+	msg := &Message{}
+	var fetchedBody int
+	var subjectCT, bodyTextCT, bodyHTMLCT, flagsOtherCT, mailboxNameCT, accountNameCT []byte
+	var isSeen, isFlagged, isDeleted int
+	if err := scan(
+		&msg.ID, &msg.MessageID, &msg.ThreadID, &msg.InReplyTo, &msg.Refs, &subjectCT,
+		&msg.FromAddr, &msg.ToAddrs, &msg.CCAddrs, &msg.Date, &msg.CreatedAt,
+		&bodyTextCT, &bodyHTMLCT,
+		&mailboxNameCT, &accountNameCT,
+		&isSeen, &isFlagged, &isDeleted, &flagsOtherCT,
+		&msg.UID, &msg.Size, &fetchedBody,
+	); err != nil {
+		return nil, err
+	}
+	msg.FetchedBody = fetchedBody == 1
+	var err error
+	if msg.Subject, err = d.decryptSubject("", subjectCT); err != nil {
+		return nil, err
+	}
+	if msg.BodyText, err = d.decryptBody("", bodyTextCT); err != nil {
+		return nil, err
+	}
+	if msg.BodyHTML, err = d.decryptBody("", bodyHTMLCT); err != nil {
+		return nil, err
+	}
+	if msg.Mailbox, err = d.decryptMeta("", mailboxNameCT); err != nil {
+		return nil, fmt.Errorf("decrypt mailbox name: %w", err)
+	}
+	if msg.Account, err = d.decryptMeta("", accountNameCT); err != nil {
+		return nil, fmt.Errorf("decrypt account name: %w", err)
+	}
+	otherPlain, err := d.decryptMeta("", flagsOtherCT)
+	if err != nil {
+		return nil, fmt.Errorf("decrypt flags_other: %w", err)
+	}
+	msg.Flags = flagsFromParts(isSeen == 1, isFlagged == 1, isDeleted == 1, otherPlain)
+	return msg, nil
+}
+
+// scanMessages scans rows produced by SELECT messageSelectColumns +
+// messageSelectFrom into a slice of Message pointers.
 func (d *DB) scanMessages(rows *sql.Rows) ([]*Message, error) {
 	var msgs []*Message
 	for rows.Next() {
-		msg := &Message{}
-		var fetchedBody int
-		var subjectCT, bodyTextCT, bodyHTMLCT []byte
-		err := rows.Scan(
-			&msg.ID, &msg.MessageID, &msg.ThreadID, &msg.InReplyTo, &msg.Refs, &subjectCT,
-			&msg.FromAddr, &msg.ToAddrs, &msg.CCAddrs, &msg.Date, &msg.CreatedAt,
-			&bodyTextCT, &bodyHTMLCT,
-			&msg.Mailbox, &msg.Flags, &msg.UID, &msg.Size, &fetchedBody, &msg.Account,
-		)
+		msg, err := d.scanMessageRow(rows.Scan)
 		if err != nil {
 			return nil, fmt.Errorf("scan message: %w", err)
-		}
-		msg.FetchedBody = fetchedBody == 1
-		if msg.Subject, err = d.decryptSubject("", subjectCT); err != nil {
-			return nil, err
-		}
-		if msg.BodyText, err = d.decryptBody("", bodyTextCT); err != nil {
-			return nil, err
-		}
-		if msg.BodyHTML, err = d.decryptBody("", bodyHTMLCT); err != nil {
-			return nil, err
 		}
 		msgs = append(msgs, msg)
 	}

--- a/cli/internal/store/search.go
+++ b/cli/internal/store/search.go
@@ -1,6 +1,7 @@
 package store
 
 import (
+	"database/sql"
 	"fmt"
 	"strconv"
 	"strings"
@@ -117,6 +118,26 @@ func (d *DB) Search(query string, limit int) ([]SearchResult, error) {
 	return results, nil
 }
 
+// resolveAccountIDs maps account names to their accounts.id values for
+// use in WHERE m.account_id IN (...) clauses. Unknown names drop out
+// silently — caller treats an empty result as "no matching rows". Used
+// throughout search.go after step 7f removed the plaintext messages.account.
+func (d *DB) resolveAccountIDs(names []string) ([]int64, error) {
+	out := make([]int64, 0, len(names))
+	for _, name := range names {
+		var id int64
+		err := d.db.QueryRow("SELECT id FROM accounts WHERE name = ?", name).Scan(&id)
+		if err == sql.ErrNoRows {
+			continue
+		}
+		if err != nil {
+			return nil, fmt.Errorf("lookup account id: %w", err)
+		}
+		out = append(out, id)
+	}
+	return out, nil
+}
+
 // getThreadTagsBatch returns distinct tags for multiple threads in a single query.
 // Returns map[threadID][]tags. When accounts are provided, only tags from those
 // accounts are included.
@@ -137,12 +158,19 @@ func (d *DB) getThreadTagsBatch(threadIDs []string, accounts ...string) (map[str
 		WHERE m.thread_id IN (` + strings.Join(placeholders, ",") + `)`
 
 	if len(accounts) > 0 {
-		acctPH := make([]string, len(accounts))
-		for i, a := range accounts {
-			acctPH[i] = "?"
-			params = append(params, a)
+		ids, err := d.resolveAccountIDs(accounts)
+		if err != nil {
+			return nil, err
 		}
-		q += " AND m.account IN (" + strings.Join(acctPH, ",") + ")"
+		if len(ids) == 0 {
+			return make(map[string][]string), nil
+		}
+		acctPH := make([]string, len(ids))
+		for i, id := range ids {
+			acctPH[i] = "?"
+			params = append(params, id)
+		}
+		q += " AND m.account_id IN (" + strings.Join(acctPH, ",") + ")"
 	}
 	q += " ORDER BY m.thread_id, t.tag"
 
@@ -171,12 +199,19 @@ func (d *DB) getThreadTags(threadID string, accounts ...string) ([]string, error
 		WHERE m.thread_id = ?`
 	params := []interface{}{threadID}
 	if len(accounts) > 0 {
-		placeholders := make([]string, len(accounts))
-		for i, a := range accounts {
-			placeholders[i] = "?"
-			params = append(params, a)
+		ids, err := d.resolveAccountIDs(accounts)
+		if err != nil {
+			return nil, err
 		}
-		q += " AND m.account IN (" + strings.Join(placeholders, ",") + ")"
+		if len(ids) == 0 {
+			return nil, nil
+		}
+		placeholders := make([]string, len(ids))
+		for i, id := range ids {
+			placeholders[i] = "?"
+			params = append(params, id)
+		}
+		q += " AND m.account_id IN (" + strings.Join(placeholders, ",") + ")"
 	}
 	q += " ORDER BY t.tag"
 	rows, err := d.db.Query(q, params...)
@@ -528,7 +563,14 @@ func (d *DB) fieldToSQL(f *fieldExpr) (string, []interface{}, error) {
 	case "path":
 		account := extractAccountFromPath(f.value)
 		if account != "" {
-			return "m.account = ?", []interface{}{account}, nil
+			ids, err := d.resolveAccountIDs([]string{account})
+			if err != nil {
+				return "", nil, err
+			}
+			if len(ids) == 0 {
+				return "1=0", nil, nil
+			}
+			return "m.account_id = ?", []interface{}{ids[0]}, nil
 		}
 		return "1=1", nil, nil
 

--- a/cli/internal/store/store.go
+++ b/cli/internal/store/store.go
@@ -116,31 +116,16 @@ func (d *DB) Init() error {
 
 		`CREATE INDEX IF NOT EXISTS idx_messages_thread_id ON messages(thread_id)`,
 		`CREATE INDEX IF NOT EXISTS idx_messages_date ON messages(date)`,
-		`CREATE INDEX IF NOT EXISTS idx_messages_mailbox ON messages(mailbox)`,
 		`CREATE INDEX IF NOT EXISTS idx_messages_from_addr ON messages(from_addr)`,
 
-		`CREATE VIRTUAL TABLE IF NOT EXISTS messages_fts USING fts5(
-			subject, from_addr, to_addrs, body_text,
-			content='messages',
-			content_rowid='id'
-		)`,
-
-		`CREATE TRIGGER IF NOT EXISTS messages_ai AFTER INSERT ON messages BEGIN
-			INSERT INTO messages_fts(rowid, subject, from_addr, to_addrs, body_text)
-			VALUES (new.id, new.subject, new.from_addr, new.to_addrs, new.body_text);
-		END`,
-
-		`CREATE TRIGGER IF NOT EXISTS messages_ad AFTER DELETE ON messages BEGIN
-			INSERT INTO messages_fts(messages_fts, rowid, subject, from_addr, to_addrs, body_text)
-			VALUES ('delete', old.id, old.subject, old.from_addr, old.to_addrs, old.body_text);
-		END`,
-
-		`CREATE TRIGGER IF NOT EXISTS messages_au AFTER UPDATE ON messages BEGIN
-			INSERT INTO messages_fts(messages_fts, rowid, subject, from_addr, to_addrs, body_text)
-			VALUES ('delete', old.id, old.subject, old.from_addr, old.to_addrs, old.body_text);
-			INSERT INTO messages_fts(rowid, subject, from_addr, to_addrs, body_text)
-			VALUES (new.id, new.subject, new.from_addr, new.to_addrs, new.body_text);
-		END`,
+		// idx_messages_mailbox / idx_messages_account, the old messages_fts
+		// table, and the messages_ai / messages_ad / messages_au triggers
+		// were removed from the fresh-install schema by ADR-0001 step 7f.
+		// On an old DB they still exist at this point and get cleaned up
+		// by the v17→v18 (FTS drop) and v18→v19 (column rebuild) migrations
+		// below. Listing them here would only re-create them under
+		// CREATE IF NOT EXISTS, then break the next Init() when their
+		// referenced columns are gone.
 
 		`CREATE TABLE IF NOT EXISTS tags (
 			id INTEGER PRIMARY KEY AUTOINCREMENT,
@@ -217,27 +202,15 @@ func (d *DB) Init() error {
 		return err
 	}
 
-	// Indexes and triggers that may have been dropped by migrations.
+	// Indexes that may have been dropped by migrations. Step 7f removed
+	// idx_messages_account + idx_messages_mailbox along with the columns
+	// they covered; the messages_ai / messages_ad / messages_au triggers
+	// died with the rebuilt table (step 7e had already patched them to
+	// SELECT-1 no-ops, and messages_fts itself is gone).
 	postMigration := []string{
-		`CREATE INDEX IF NOT EXISTS idx_messages_account ON messages(account)`,
 		`CREATE INDEX IF NOT EXISTS idx_messages_thread_id ON messages(thread_id)`,
 		`CREATE INDEX IF NOT EXISTS idx_messages_date ON messages(date)`,
-		`CREATE INDEX IF NOT EXISTS idx_messages_mailbox ON messages(mailbox)`,
 		`CREATE INDEX IF NOT EXISTS idx_messages_from_addr ON messages(from_addr)`,
-		`CREATE TRIGGER IF NOT EXISTS messages_ai AFTER INSERT ON messages BEGIN
-			INSERT INTO messages_fts(rowid, subject, from_addr, to_addrs, body_text)
-			VALUES (new.id, new.subject, new.from_addr, new.to_addrs, new.body_text);
-		END`,
-		`CREATE TRIGGER IF NOT EXISTS messages_ad AFTER DELETE ON messages BEGIN
-			INSERT INTO messages_fts(messages_fts, rowid, subject, from_addr, to_addrs, body_text)
-			VALUES ('delete', old.id, old.subject, old.from_addr, old.to_addrs, old.body_text);
-		END`,
-		`CREATE TRIGGER IF NOT EXISTS messages_au AFTER UPDATE ON messages BEGIN
-			INSERT INTO messages_fts(messages_fts, rowid, subject, from_addr, to_addrs, body_text)
-			VALUES ('delete', old.id, old.subject, old.from_addr, old.to_addrs, old.body_text);
-			INSERT INTO messages_fts(rowid, subject, from_addr, to_addrs, body_text)
-			VALUES (new.id, new.subject, new.from_addr, new.to_addrs, new.body_text);
-		END`,
 	}
 	for _, stmt := range postMigration {
 		if _, err := d.db.Exec(stmt); err != nil {
@@ -796,6 +769,288 @@ func (d *DB) migrate() error {
 		}
 	}
 
+	if version < 19 {
+		// ADR-0001 step 7f: drop the messages.mailbox / messages.account /
+		// messages.flags plaintext shadow columns. The structured
+		// replacements (mailbox_id FK, account_id FK, is_seen / is_flagged
+		// / is_deleted booleans, encrypted flags_other BLOB) have been
+		// alive since step 1 / step 6 but the INSERT path has been writing
+		// only the plaintext shadows — so before dropping anything we
+		// re-run the step-1 backfill for any row that the steady-state
+		// insert path left with NULL FK ids or zero booleans.
+		if err := d.backfillMessageMetaShadows(); err != nil {
+			return fmt.Errorf("migrate v18→v19 backfill: %w", err)
+		}
+
+		// DROP COLUMN cannot remove a column that participates in a UNIQUE
+		// constraint, and account is half of UNIQUE(message_id, account).
+		// SQLite's recommended escape hatch (https://www.sqlite.org/lang_altertable.html
+		// 12-step procedure) is a full table-rebuild: CREATE table with
+		// the desired schema, INSERT SELECT, DROP old, RENAME. FK refs
+		// from tags / attachments / message_headers / messages_blind_fts
+		// to messages.id survive the rebuild because we leave foreign_keys
+		// OFF for the duration and the FK lookups are by table name (which
+		// the final RENAME preserves).
+		if err := d.rebuildMessagesForStep7f(); err != nil {
+			return fmt.Errorf("migrate v18→v19 rebuild: %w", err)
+		}
+
+		if _, err := d.db.Exec("UPDATE schema_version SET version = 19 WHERE rowid = 1"); err != nil {
+			return fmt.Errorf("migrate v18→v19 bump: %w", err)
+		}
+	}
+
+	return nil
+}
+
+// backfillMessageMetaShadows populates mailbox_id / account_id / is_seen /
+// is_flagged / is_deleted / flags_other for any row that the post-step-1
+// INSERT path left with NULL FKs or zero booleans. Idempotent — rows
+// already populated are filtered out of every UPDATE's WHERE clause.
+// Runs inside the v18→v19 migration just before the table-rebuild that
+// drops the source columns.
+func (d *DB) backfillMessageMetaShadows() error {
+	// Populate mailboxes/accounts from any plaintext shadow value that's
+	// not yet represented. INBOX gets the same case normalization as the
+	// step-1 backfill so 'inbox' / 'Inbox' / 'INBOX' merge.
+	pre := []string{
+		`INSERT OR IGNORE INTO mailboxes (name)
+		 SELECT DISTINCT
+		   CASE WHEN UPPER(mailbox) = 'INBOX' THEN 'INBOX' ELSE mailbox END
+		 FROM messages
+		 WHERE mailbox IS NOT NULL AND mailbox <> '' AND mailbox_id IS NULL`,
+		`INSERT OR IGNORE INTO accounts (name)
+		 SELECT DISTINCT account FROM messages
+		 WHERE account IS NOT NULL AND account <> '' AND account_id IS NULL`,
+		`UPDATE messages
+		 SET mailbox_id = (
+		   SELECT id FROM mailboxes
+		   WHERE name = CASE WHEN UPPER(messages.mailbox) = 'INBOX'
+		                     THEN 'INBOX' ELSE messages.mailbox END
+		 )
+		 WHERE mailbox IS NOT NULL AND mailbox <> '' AND mailbox_id IS NULL`,
+		`UPDATE messages
+		 SET account_id = (SELECT id FROM accounts WHERE name = messages.account)
+		 WHERE account IS NOT NULL AND account <> '' AND account_id IS NULL`,
+		// Re-derive activity booleans for any row where they're still at
+		// the default 0 but flags TEXT actually carries one of the system
+		// flags (catches rows synced post-step-1 with the old insert path).
+		`UPDATE messages SET
+		   is_seen    = CASE WHEN INSTR(IFNULL(flags, ''), '\Seen')    > 0 THEN 1 ELSE is_seen END,
+		   is_flagged = CASE WHEN INSTR(IFNULL(flags, ''), '\Flagged') > 0 THEN 1 ELSE is_flagged END,
+		   is_deleted = CASE WHEN INSTR(IFNULL(flags, ''), '\Deleted') > 0 THEN 1 ELSE is_deleted END
+		 WHERE flags IS NOT NULL AND flags <> ''`,
+	}
+	for _, stmt := range pre {
+		if _, err := d.db.Exec(stmt); err != nil {
+			return fmt.Errorf("pre-rebuild backfill: %w", err)
+		}
+	}
+
+	// Mailboxes/accounts rows freshly created above need their name_ct
+	// populated too — the v14→v15 backfill ran before they existed.
+	// Encrypt-on-read isn't an option; the SELECT path JOINs name_ct.
+	if err := d.encryptMissingMetaNames(); err != nil {
+		return fmt.Errorf("encrypt new meta names: %w", err)
+	}
+
+	// flags_other_ct backfill for any row with non-empty plaintext flags
+	// but a NULL flags_other (rows synced after step 1 but before step 6
+	// landed encrypt-on-write).
+	if err := d.backfillFlagsOtherFromShadow(); err != nil {
+		return fmt.Errorf("flags_other backfill: %w", err)
+	}
+	return nil
+}
+
+// encryptMissingMetaNames writes name_ct for any mailboxes / accounts
+// row that has plaintext name but no encrypted name_ct yet. Covers the
+// freshly-created rows from backfillMessageMetaShadows. Idempotent.
+func (d *DB) encryptMissingMetaNames() error {
+	if d.keyring == nil || d.keyring.Meta == nil {
+		return fmt.Errorf("no keyring for meta name encrypt")
+	}
+	tx, err := d.db.Begin()
+	if err != nil {
+		return fmt.Errorf("begin tx: %w", err)
+	}
+	defer tx.Rollback() //nolint:errcheck
+	for _, table := range []string{"mailboxes", "accounts"} {
+		rows, err := tx.Query(`SELECT id, name FROM ` + table + `
+			WHERE name IS NOT NULL AND name <> '' AND name_ct IS NULL`)
+		if err != nil {
+			return fmt.Errorf("select %s: %w", table, err)
+		}
+		type pending struct {
+			id   int64
+			name string
+		}
+		var batch []pending
+		for rows.Next() {
+			var p pending
+			if err := rows.Scan(&p.id, &p.name); err != nil {
+				rows.Close()
+				return fmt.Errorf("scan %s: %w", table, err)
+			}
+			batch = append(batch, p)
+		}
+		rows.Close()
+		stmt, err := tx.Prepare("UPDATE " + table + " SET name_ct = ? WHERE id = ?")
+		if err != nil {
+			return fmt.Errorf("prepare %s update: %w", table, err)
+		}
+		for _, p := range batch {
+			ct, err := d.encryptMeta(p.name)
+			if err != nil {
+				stmt.Close()
+				return fmt.Errorf("encrypt %s name id=%d: %w", table, p.id, err)
+			}
+			if _, err := stmt.Exec(ct, p.id); err != nil {
+				stmt.Close()
+				return fmt.Errorf("update %s id=%d: %w", table, p.id, err)
+			}
+		}
+		stmt.Close()
+	}
+	return tx.Commit()
+}
+
+// backfillFlagsOtherFromShadow encrypts any messages row's plaintext
+// flags TEXT (minus the boolean-covered system flags) into flags_other
+// when the latter is still NULL. Idempotent. Mirrors backfillMetaCt
+// but only targets rows still showing the pre-step-6 NULL.
+func (d *DB) backfillFlagsOtherFromShadow() error {
+	if d.keyring == nil || d.keyring.Meta == nil {
+		return fmt.Errorf("no keyring for flags_other backfill")
+	}
+	tx, err := d.db.Begin()
+	if err != nil {
+		return fmt.Errorf("begin tx: %w", err)
+	}
+	defer tx.Rollback() //nolint:errcheck
+	rows, err := tx.Query(`SELECT id, flags FROM messages
+		WHERE flags IS NOT NULL AND flags <> '' AND flags_other IS NULL`)
+	if err != nil {
+		return fmt.Errorf("select: %w", err)
+	}
+	type pending struct {
+		id    int64
+		flags string
+	}
+	var batch []pending
+	for rows.Next() {
+		var p pending
+		if err := rows.Scan(&p.id, &p.flags); err != nil {
+			rows.Close()
+			return fmt.Errorf("scan: %w", err)
+		}
+		batch = append(batch, p)
+	}
+	rows.Close()
+	stmt, err := tx.Prepare("UPDATE messages SET flags_other = ? WHERE id = ?")
+	if err != nil {
+		return fmt.Errorf("prepare: %w", err)
+	}
+	defer stmt.Close()
+	for _, p := range batch {
+		ct, err := d.encryptMeta(flagsOtherForEncryption(p.flags))
+		if err != nil {
+			return fmt.Errorf("encrypt id=%d: %w", p.id, err)
+		}
+		if _, err := stmt.Exec(ct, p.id); err != nil {
+			return fmt.Errorf("update id=%d: %w", p.id, err)
+		}
+	}
+	return tx.Commit()
+}
+
+// rebuildMessagesForStep7f rebuilds the messages table to drop the
+// plaintext mailbox / account / flags columns and replace the
+// UNIQUE(message_id, account) constraint with UNIQUE(message_id,
+// account_id). SQLite's 12-step ALTER procedure.
+func (d *DB) rebuildMessagesForStep7f() error {
+	stmts := []string{
+		`PRAGMA foreign_keys = OFF`,
+		// The new table mirrors the current messages schema minus the
+		// three doomed columns. Column order chosen to keep CREATE TABLE
+		// readable rather than to match the in-place order — INSERT
+		// SELECT names columns explicitly so order is irrelevant.
+		`CREATE TABLE messages_new (
+			id INTEGER PRIMARY KEY AUTOINCREMENT,
+			message_id TEXT NOT NULL,
+			thread_id TEXT NOT NULL,
+			in_reply_to TEXT,
+			refs TEXT,
+			from_addr TEXT,
+			to_addrs TEXT,
+			cc_addrs TEXT,
+			date INTEGER,
+			created_at INTEGER NOT NULL,
+			uid INTEGER DEFAULT 0,
+			size INTEGER DEFAULT 0,
+			fetched_body INTEGER DEFAULT 0,
+			mailbox_id INTEGER REFERENCES mailboxes(id),
+			account_id INTEGER REFERENCES accounts(id),
+			is_seen INTEGER NOT NULL DEFAULT 0,
+			is_flagged INTEGER NOT NULL DEFAULT 0,
+			is_deleted INTEGER NOT NULL DEFAULT 0,
+			subject_ct BLOB,
+			body_text_ct BLOB,
+			body_html_ct BLOB,
+			flags_other BLOB
+		)`,
+		`INSERT INTO messages_new (
+			id, message_id, thread_id, in_reply_to, refs,
+			from_addr, to_addrs, cc_addrs,
+			date, created_at, uid, size, fetched_body,
+			mailbox_id, account_id, is_seen, is_flagged, is_deleted,
+			subject_ct, body_text_ct, body_html_ct, flags_other
+		) SELECT
+			id, message_id, thread_id, in_reply_to, refs,
+			from_addr, to_addrs, cc_addrs,
+			date, created_at, uid, size, fetched_body,
+			mailbox_id, account_id, is_seen, is_flagged, is_deleted,
+			subject_ct, body_text_ct, body_html_ct, flags_other
+		FROM messages`,
+		// modernc.org/sqlite step 7e quirk: DROP TRIGGER fired inside
+		// migrate() silently no-ops. The patched-to-no-op triggers
+		// (messages_ai / messages_ad / messages_au + messages_blind_fts_ad)
+		// disappear with the table drop, which works fine, but we have
+		// to re-create the blind-FTS trigger against the renamed table
+		// below since DROP TABLE takes its triggers with it.
+		`DROP TABLE messages`,
+		`ALTER TABLE messages_new RENAME TO messages`,
+		// Recreate the indexes that survived step 7e (idx_messages_mailbox
+		// + idx_messages_account died with the columns they covered).
+		`CREATE INDEX IF NOT EXISTS idx_messages_thread_id ON messages(thread_id)`,
+		`CREATE INDEX IF NOT EXISTS idx_messages_date ON messages(date)`,
+		`CREATE INDEX IF NOT EXISTS idx_messages_from_addr ON messages(from_addr)`,
+		`CREATE INDEX IF NOT EXISTS idx_messages_mailbox_id ON messages(mailbox_id)`,
+		`CREATE INDEX IF NOT EXISTS idx_messages_account_id ON messages(account_id)`,
+		// Replacement for the old UNIQUE(message_id, account) inline
+		// constraint. account_id can legitimately be NULL (empty Account
+		// on the Message struct → NULL FK), and SQLite treats NULLs as
+		// distinct under a plain UNIQUE — which would silently allow
+		// duplicate (message_id, NULL) rows and break the ON CONFLICT
+		// upsert path. Wrapping in IFNULL collapses NULL to the sentinel 0.
+		`CREATE UNIQUE INDEX IF NOT EXISTS idx_messages_msgid_acctid_uniq
+			ON messages(message_id, IFNULL(account_id, 0))`,
+		// Re-attach the blind-FTS delete trigger so messages_blind_fts
+		// stays in sync. INSERT/UPDATE maintenance still happens Go-side.
+		`CREATE TRIGGER IF NOT EXISTS messages_blind_fts_ad AFTER DELETE ON messages BEGIN
+			DELETE FROM messages_blind_fts WHERE rowid = old.id;
+		END`,
+		`PRAGMA foreign_keys = ON`,
+		`PRAGMA foreign_key_check`,
+	}
+	for _, s := range stmts {
+		if _, err := d.db.Exec(s); err != nil {
+			return fmt.Errorf("rebuild step %q: %w", s[:min(60, len(s))], err)
+		}
+	}
+	if _, err := d.db.Exec("VACUUM"); err != nil {
+		return fmt.Errorf("rebuild vacuum: %w", err)
+	}
 	return nil
 }
 
@@ -1133,6 +1388,94 @@ func flagsOtherForEncryption(flags string) string {
 		}
 	}
 	return strings.Join(out, " ")
+}
+
+// flagsFromParts reconstructs the space-separated IMAP flags string from
+// the three boolean columns plus the decrypted flags_other plaintext.
+// Inverse of flagsOtherForEncryption + the is_*-derivation in
+// insertMessageTx — together they must round-trip such that
+// flagsOtherForEncryption(flagsFromParts(s,f,d, other)) == other for
+// every other that contains no \Seen/\Flagged/\Deleted token (which is
+// guaranteed by flagsOtherForEncryption itself).
+//
+// Callers: scanMessages, GetByMessageID, GetByThread, GetAllByThread.
+// They feed the result into Message.Flags which IMAP/SMTP/tagsync code
+// re-tokenizes with strings.Fields — so the function only needs to
+// produce a *valid* space-separated flag list; the canonical IMAP order
+// is not enforceable here anyway (the original UID FETCH order is lost
+// the moment the booleans were extracted).
+func flagsFromParts(isSeen, isFlagged, isDeleted bool, other string) string {
+	if !isSeen && !isFlagged && !isDeleted {
+		return other
+	}
+	parts := make([]string, 0, 4)
+	if isSeen {
+		parts = append(parts, `\Seen`)
+	}
+	if isFlagged {
+		parts = append(parts, `\Flagged`)
+	}
+	if isDeleted {
+		parts = append(parts, `\Deleted`)
+	}
+	if other != "" {
+		parts = append(parts, other)
+	}
+	return strings.Join(parts, " ")
+}
+
+// getOrCreateMailbox returns the mailboxes.id for name, inserting the
+// row (with encrypted name_ct under meta_key) if it does not yet exist.
+// INBOX is case-normalized to "INBOX" to match the v8→v9 backfill so
+// 'inbox' / 'Inbox' / 'INBOX' continue to resolve to the same id.
+//
+// Runs inside the caller's transaction so failures roll back along with
+// the message insert that triggered the lookup. Returns 0 + nil for an
+// empty name — caller decides whether to store NULL.
+func (d *DB) getOrCreateMailbox(tx *sql.Tx, name string) (int64, error) {
+	if name == "" {
+		return 0, nil
+	}
+	if strings.EqualFold(name, "INBOX") {
+		name = "INBOX"
+	}
+	nameCT, err := d.encryptMeta(name)
+	if err != nil {
+		return 0, fmt.Errorf("encrypt mailbox name: %w", err)
+	}
+	if _, err := tx.Exec(
+		"INSERT OR IGNORE INTO mailboxes (name, name_ct) VALUES (?, ?)",
+		name, nameCT); err != nil {
+		return 0, fmt.Errorf("insert mailbox: %w", err)
+	}
+	var id int64
+	if err := tx.QueryRow("SELECT id FROM mailboxes WHERE name = ?", name).Scan(&id); err != nil {
+		return 0, fmt.Errorf("lookup mailbox id: %w", err)
+	}
+	return id, nil
+}
+
+// getOrCreateAccount mirrors getOrCreateMailbox for the accounts table.
+// Account names are not case-normalized — they are full email addresses
+// that callers already canonicalize at sync-config load.
+func (d *DB) getOrCreateAccount(tx *sql.Tx, name string) (int64, error) {
+	if name == "" {
+		return 0, nil
+	}
+	nameCT, err := d.encryptMeta(name)
+	if err != nil {
+		return 0, fmt.Errorf("encrypt account name: %w", err)
+	}
+	if _, err := tx.Exec(
+		"INSERT OR IGNORE INTO accounts (name, name_ct) VALUES (?, ?)",
+		name, nameCT); err != nil {
+		return 0, fmt.Errorf("insert account: %w", err)
+	}
+	var id int64
+	if err := tx.QueryRow("SELECT id FROM accounts WHERE name = ?", name).Scan(&id); err != nil {
+		return 0, fmt.Errorf("lookup account id: %w", err)
+	}
+	return id, nil
 }
 
 // backfillMetaCt encrypts existing mailbox names, account names, and the

--- a/cli/internal/store/store_test.go
+++ b/cli/internal/store/store_test.go
@@ -42,8 +42,8 @@ func TestOpenAndInit(t *testing.T) {
 	if err != nil {
 		t.Fatalf("read version: %v", err)
 	}
-	if version != 18 {
-		t.Errorf("version = %d, want 18", version)
+	if version != 19 {
+		t.Errorf("version = %d, want 19", version)
 	}
 }
 
@@ -168,8 +168,8 @@ func TestMigrateV9_PopulatesMailboxesAndAccounts(t *testing.T) {
 	if err := db.QueryRow("SELECT version FROM schema_version WHERE rowid = 1").Scan(&version); err != nil {
 		t.Fatalf("read version: %v", err)
 	}
-	if version != 18 {
-		t.Fatalf("version = %d, want 18", version)
+	if version != 19 {
+		t.Fatalf("version = %d, want 19", version)
 	}
 
 	// mailboxes must contain exactly INBOX and Drafts (case-collapsed).

--- a/cli/internal/store/tags.go
+++ b/cli/internal/store/tags.go
@@ -144,14 +144,31 @@ func (d *DB) ListTags(accounts ...string) ([]string, error) {
 	var rows *sql.Rows
 	var err error
 	if len(accounts) > 0 {
-		placeholders := make([]string, len(accounts))
-		params := make([]interface{}, len(accounts))
-		for i, a := range accounts {
+		// Resolve account names → ids. Unknown names contribute nothing
+		// to the IN-list; if all names are unknown we short-circuit empty.
+		ids := make([]int64, 0, len(accounts))
+		for _, name := range accounts {
+			var id int64
+			err := d.db.QueryRow("SELECT id FROM accounts WHERE name = ?", name).Scan(&id)
+			if err == sql.ErrNoRows {
+				continue
+			}
+			if err != nil {
+				return nil, fmt.Errorf("lookup account id: %w", err)
+			}
+			ids = append(ids, id)
+		}
+		if len(ids) == 0 {
+			return nil, nil
+		}
+		placeholders := make([]string, len(ids))
+		params := make([]interface{}, len(ids))
+		for i, id := range ids {
 			placeholders[i] = "?"
-			params[i] = a
+			params[i] = id
 		}
 		rows, err = d.db.Query(
-			"SELECT DISTINCT t.tag FROM tags t JOIN messages m ON m.id = t.message_id WHERE m.account IN ("+
+			"SELECT DISTINCT t.tag FROM tags t JOIN messages m ON m.id = t.message_id WHERE m.account_id IN ("+
 				strings.Join(placeholders, ",")+") ORDER BY t.tag", params...)
 	} else {
 		rows, err = d.db.Query("SELECT DISTINCT tag FROM tags ORDER BY tag")
@@ -215,10 +232,15 @@ func (d *DB) ModifyTagsByMessageIDAndAccount(messageID, account string, addTags,
 	}
 	defer tx.Rollback()
 
+	var accountID int64
+	err = tx.QueryRow("SELECT id FROM accounts WHERE name = ?", account).Scan(&accountID)
+	if err != nil {
+		return nil // unknown account → no-op (mirrors pre-7f behavior)
+	}
 	var dbID int64
 	err = tx.QueryRow(
-		"SELECT id FROM messages WHERE message_id = ? AND account = ?",
-		messageID, account).Scan(&dbID)
+		"SELECT id FROM messages WHERE message_id = ? AND account_id = ?",
+		messageID, accountID).Scan(&dbID)
 	if err != nil {
 		return nil // message/account pair not in store — no-op
 	}
@@ -333,11 +355,15 @@ func (d *DB) SetMeta(key string, value int64) {
 }
 
 // ExportAllTags returns all (message_id, account, tag) tuples in the database.
-// Used for initial push to the tag sync server.
+// Used for initial push to the tag sync server. Account is resolved via
+// JOIN on accounts.id; the name comes from the encrypted name_ct BLOB
+// (decrypted under meta_key).
 func (d *DB) ExportAllTags() ([]struct{ MessageID, Account, Tag string }, error) {
 	rows, err := d.db.Query(`
-		SELECT m.message_id, m.account, t.tag
-		FROM tags t JOIN messages m ON m.id = t.message_id
+		SELECT m.message_id, ac.name_ct, t.tag
+		FROM tags t
+		JOIN messages m ON m.id = t.message_id
+		LEFT JOIN accounts ac ON ac.id = m.account_id
 		ORDER BY m.message_id`)
 	if err != nil {
 		return nil, fmt.Errorf("export tags: %w", err)
@@ -347,8 +373,12 @@ func (d *DB) ExportAllTags() ([]struct{ MessageID, Account, Tag string }, error)
 	var result []struct{ MessageID, Account, Tag string }
 	for rows.Next() {
 		var r struct{ MessageID, Account, Tag string }
-		if err := rows.Scan(&r.MessageID, &r.Account, &r.Tag); err != nil {
+		var accountCT []byte
+		if err := rows.Scan(&r.MessageID, &accountCT, &r.Tag); err != nil {
 			return nil, fmt.Errorf("scan: %w", err)
+		}
+		if r.Account, err = d.decryptMeta("", accountCT); err != nil {
+			return nil, fmt.Errorf("decrypt account name: %w", err)
 		}
 		result = append(result, r)
 	}
@@ -358,17 +388,37 @@ func (d *DB) ExportAllTags() ([]struct{ MessageID, Account, Tag string }, error)
 // GetAllMessagesWithTags returns a map of message_id → tags for all messages
 // in a given mailbox. When account is non-empty, results are scoped to that account.
 // Used for IMAP flag synchronization.
+//
+// Step 7f: mailbox + account are resolved to their FK ids; unknown names
+// return an empty map without an error (no rows can match).
 func (d *DB) GetAllMessagesWithTags(mailbox string, account ...string) (map[string][]string, error) {
+	if strings.EqualFold(mailbox, "INBOX") {
+		mailbox = "INBOX"
+	}
+	var mailboxID int64
+	if err := d.db.QueryRow("SELECT id FROM mailboxes WHERE name = ?", mailbox).Scan(&mailboxID); err != nil {
+		if err == sql.ErrNoRows {
+			return map[string][]string{}, nil
+		}
+		return nil, fmt.Errorf("lookup mailbox id: %w", err)
+	}
 	q := `
 		SELECT m.message_id, t.tag
 		FROM messages m
 		JOIN tags t ON t.message_id = m.id
-		WHERE m.mailbox = ?`
-	params := []interface{}{mailbox}
+		WHERE m.mailbox_id = ?`
+	params := []interface{}{mailboxID}
 
 	if len(account) > 0 && account[0] != "" {
-		q += " AND m.account = ?"
-		params = append(params, account[0])
+		var accountID int64
+		if err := d.db.QueryRow("SELECT id FROM accounts WHERE name = ?", account[0]).Scan(&accountID); err != nil {
+			if err == sql.ErrNoRows {
+				return map[string][]string{}, nil
+			}
+			return nil, fmt.Errorf("lookup account id: %w", err)
+		}
+		q += " AND m.account_id = ?"
+		params = append(params, accountID)
 	}
 	q += " ORDER BY m.message_id"
 

--- a/cli/internal/store/tags_test.go
+++ b/cli/internal/store/tags_test.go
@@ -294,17 +294,16 @@ func TestModifyTagsByMessageIDAndAccount(t *testing.T) {
 		t.Fatalf("modify personal tags: %v", err)
 	}
 
-	// Verify work row has "sent" but not "inbox"
-	var workID int64
-	db.db.QueryRow("SELECT id FROM messages WHERE message_id = ? AND account = ?", "acct-tag@x", "work").Scan(&workID)
+	// Verify work row has "sent" but not "inbox". Step 7f removed
+	// messages.account; lookup is now via the accounts FK.
+	workID := messageDBIDForAccount(t, db, "acct-tag@x", "work")
 	workTags, _ := db.GetMessageTags(workID)
 	if len(workTags) != 1 || workTags[0] != "sent" {
 		t.Errorf("work tags = %v, want [sent]", workTags)
 	}
 
 	// Verify personal row has "inbox" but not "sent"
-	var persID int64
-	db.db.QueryRow("SELECT id FROM messages WHERE message_id = ? AND account = ?", "acct-tag@x", "personal").Scan(&persID)
+	persID := messageDBIDForAccount(t, db, "acct-tag@x", "personal")
 	persTags, _ := db.GetMessageTags(persID)
 	if len(persTags) != 1 || persTags[0] != "inbox" {
 		t.Errorf("personal tags = %v, want [inbox]", persTags)
@@ -319,6 +318,19 @@ func TestModifyTagsByMessageIDAndAccount_NotFound(t *testing.T) {
 	if err != nil {
 		t.Fatalf("expected no-op, got error: %v", err)
 	}
+}
+
+// messageDBIDForAccount looks up messages.id for a (message_id, account)
+// pair. Step 7f removed messages.account; lookups go via the accounts FK.
+func messageDBIDForAccount(t *testing.T, db *DB, msgID, account string) int64 {
+	t.Helper()
+	var id int64
+	if err := db.db.QueryRow(`SELECT m.id FROM messages m
+		JOIN accounts ac ON ac.id = m.account_id
+		WHERE m.message_id = ? AND ac.name = ?`, msgID, account).Scan(&id); err != nil {
+		t.Fatalf("lookup message id (%s, %s): %v", msgID, account, err)
+	}
+	return id
 }
 
 func insertTestMessageForAccount(t *testing.T, db *DB, msgID, account string) int64 {

--- a/docs/content/docs/developers/design/0001-mail-content-encryption-at-rest.md
+++ b/docs/content/docs/developers/design/0001-mail-content-encryption-at-rest.md
@@ -108,14 +108,19 @@ no new direct dependency added).
 | `headers_key`      | `"durian/v1/headers"`    | encrypts `message_headers.value`       |
 | `addrs_key`        | `"durian/v1/addrs"`      | **(retired, see §3)** previously encrypted `from_addr`, `to_addrs`, `cc_addrs` |
 | `draft_key`        | `"durian/v1/draft"`      | encrypts `local_drafts.draft_json`, `outbox.draft_json` |
-| `contact_key`      | `"durian/v1/contact"`    | encrypts `contacts.email`, `contacts.name` |
+| `contact_key`      | `"durian/v1/contact"`    | **(retired, see §3)** previously encrypted `contacts.email`, `contacts.name` |
 | `fts_token_key`    | `"durian/v1/fts-token"`  | HMAC key for blind FTS5 tokens (§4)    |
 | `meta_key`         | `"durian/v1/meta"`       | encrypts `mailbox` name, custom `flags`, `account` string |
 
-`addrs_key` is derived for backward-compatibility (the v11→v12 migration
-populated `from_addr_ct` / `to_addrs_ct` / `cc_addrs_ct` columns under
-this key) but no current read or write path consumes it — see §3 for
-why the addresses ended up staying plaintext.
+`addrs_key` and `contact_key` are still derived for forward-compatibility
+(the v11→v12 migration populated `from_addr_ct` / `to_addrs_ct` /
+`cc_addrs_ct` columns under `addrs_key`; the step-6 contacts migration
+populated `email_ct` / `name_ct` under `contact_key`) but no current
+read or write path consumes either — see §3 for why message addresses
+and contact rows both ended up staying plaintext. Removing the derivation
+is a no-op cleanup that would force a sub-key index renumber on every
+existing install; deferred until a future migration touches the keyring
+shape for unrelated reasons.
 
 Keychain layout (new):
 
@@ -208,8 +213,21 @@ Columns that **stay plaintext** with a documented information leak:
 `message_headers.value` → `BLOB`. Header `name` stays plaintext (already a
 small enumerable set per RFC 5322).
 
-`contacts.email` and `contacts.name` → `BLOB`. `id` stays plaintext (UUID),
-`source`, `last_used`, `usage_count`, `created_at` stay plaintext.
+`contacts.email` and `contacts.name` **stay plaintext TEXT** — moved
+from the encrypted set during implementation (step 7g). Same β-revision
+reasoning as `from_addr` / `to_addrs` / `cc_addrs` above: every contact
+row in the directory was either harvested from an incoming `From:` /
+`To:` / `Cc:` header or typed into a `compose` field that immediately
+becomes a wire address. Encrypting the local mirror while the same
+addresses shout on every wire hop is asymmetric protection. The cost
+side is concrete: `UNIQUE(email)` upsert and the `email LIKE 'ali%'` /
+`name LIKE 'ali%'` autocomplete that the compose-recipient picker
+relies on both need plaintext indexes — neither survives random-nonce
+AES-GCM, and a deterministic-token replacement (Naveed et al, CCS 2015)
+would leak a contact-frequency histogram that re-identifies the user's
+top correspondents from the ciphertext alone. `id` stays plaintext
+(UUID), `source`, `last_used`, `usage_count`, `created_at` stay
+plaintext as before.
 
 `outbox.draft_json`, `local_drafts.draft_json` → `BLOB`.
 
@@ -392,6 +410,14 @@ Does **not** defend against:
   ADR may add an opt-in encrypt-from-to flag for users whose threat
   model puts the local DB as the genuinely-only-place these addresses
   live (air-gapped archive, etc.).
+- Information leakage from `contacts.email` / `contacts.name` (see
+  §3): the directory is the projected union of every `From:` / `To:` /
+  `Cc:` the user has ever seen plus the addresses typed into compose.
+  An attacker with `contacts.db` recovers the user's full address book
+  and (via `usage_count` + `last_used`, also plaintext) a ranking of
+  who they correspond with most. Mitigation: none, deliberately. Same
+  on-the-wire-anyway argument as messages-side addresses; same
+  cost/benefit failure for the implementable encrypted alternatives.
 
 ### Threat-actor personas
 
@@ -679,6 +705,14 @@ Resolved (kept here for traceability):
   stay plaintext TEXT" + §6 threat-model bullet). Substring search
   served by `LIKE` on the plaintext column; no FTS5 address tokens
   exist in V1.
+- ~~Contact encryption.~~ → `contacts.email` and `contacts.name`
+  moved to plaintext in step 7g (see §3 + §6 threat-model bullet).
+  Same β-revision reasoning as the message-side addresses: contact
+  rows are projections of wire addresses, so encrypting only the
+  local mirror is asymmetric protection that costs `UNIQUE(email)`
+  upsert and prefix-LIKE autocomplete. The dead `email_ct` /
+  `name_ct` columns were dropped; `contact_key` is retired but
+  still derived (see §2 sub-key table).
 - ~~Mailbox / flags / account plaintext leak.~~ → encrypted, with integer
   surrogate columns for indexing (§3). Resolved in response to early-review
   feedback.

--- a/docs/content/docs/developers/design/0001-mail-content-encryption-at-rest.md
+++ b/docs/content/docs/developers/design/0001-mail-content-encryption-at-rest.md
@@ -517,8 +517,12 @@ statement. Mitigations, all part of the implementation PR:
   `slog.String("subject", ...)` defeats the whole scheme. CI gate + redact
   wrapper documented in the *Logging audit* section above.
 - Three new tables (`mailboxes`, `accounts`) and a new BLOB columns layout
-  mean every query that previously joined on `messages.mailbox` /
-  `messages.account` gets a JOIN rewrite.
+  meant every query that previously joined on `messages.mailbox` /
+  `messages.account` got a JOIN rewrite (executed in step 7f when the
+  plaintext shadow columns were finally dropped). Same churn for the
+  `messages.flags` TEXT column, now reconstructed from
+  `is_seen` / `is_flagged` / `is_deleted` + the encrypted `flags_other`
+  BLOB on every read.
 
 **Neutral:**
 


### PR DESCRIPTION
## Summary

Drop the three plaintext shadow columns that step 1 added alongside their structured replacements. Step 1 backfilled `mailbox_id` / `account_id` FKs once, but the steady-state INSERT path kept writing only the plaintext side — 196 rows out of 20867 silently accumulated NULL FKs in prod over three months. Step 7f closes that gap before dropping the columns.

- `insertMessageTx` resolves mailbox + account names via new `getOrCreateMailbox` / `getOrCreateAccount` helpers (INSERT OR IGNORE + SELECT, encrypts `name_ct` under meta_key on first sight), derives `is_seen` / `is_flagged` / `is_deleted` from `msg.Flags`, and stops writing the plaintext columns. ON CONFLICT target shifts to \`(message_id, IFNULL(account_id, 0))\`.
- New \`scanMessageRow\` helper used by \`GetByMessageID\` / \`GetByThread\` / \`GetAllByThread\` / \`scanMessages\` — single SELECT list LEFT JOINs \`mailboxes\` / \`accounts\` and reconstructs \`Message.Flags\` via \`flagsFromParts(isSeen, isFlagged, isDeleted, decryptedFlagsOther)\` (inverse of the existing \`flagsOtherForEncryption\`).
- 12 mutation/lookup sites in \`messages.go\` / \`headers.go\` / \`tags.go\` / \`search.go\` rewired to resolve account names → ids through a shared \`resolveAccountIDs\` helper.

Migration v18 → v19:
- \`backfillMessageMetaShadows\` re-runs the step-1 INSERT OR IGNORE for any row left with NULL FKs, encrypts the fresh \`mailboxes\`/\`accounts\` rows with the meta sub-key, then backfills any NULL \`flags_other\` from the plaintext \`flags\` shadow.
- \`rebuildMessagesForStep7f\` performs SQLite's 12-step ALTER (CREATE \`messages_new\`, INSERT SELECT, DROP, RENAME, recreate indexes + blind-FTS delete trigger, \`PRAGMA foreign_key_check\`) — required because SQLite's plain \`UNIQUE(message_id, account)\` couldn't be dropped in place, and the replacement \`UNIQUE INDEX … (message_id, IFNULL(account_id, 0))\` collapses NULLs to a sentinel so empty-Account upserts continue to deduplicate.
- VACUUM at the end.

ADR §5 Cons bullet for the JOIN-rewrite churn moved to past tense and extended with the flags-reconstruction note.

Stacked on top of #238 (step 7g).

## Test plan

- [x] All 18 CLI unit tests pass; encryption grep-gate clean.
- [x] Live dryrun + live install on prod \`email.db\` (20867 messages, schema v18 → v19): 196 → 0 NULL FKs, file shrank 2.4 MB, \`search\` / \`show\` / \`tag list\` / \`path:gmail\` all work.