### PR TITLE
ADR-0001 step 7 (a+b) — blind-token FTS5 infrastructure

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -25,7 +25,7 @@ go_sdk.download(version = "1.25.10")
 
 go_deps = use_extension("@gazelle//:extensions.bzl", "go_deps")
 go_deps.from_file(go_mod = "//cli:go.mod")
-use_repo(go_deps, "com_github_apple_pkl_go", "com_github_emersion_go_imap", "com_github_emersion_go_sasl", "com_github_fatih_color", "com_github_google_uuid", "com_github_gorilla_mux", "com_github_microcosm_cc_bluemonday", "com_github_spf13_cobra", "in_yaml_go_yaml_v3", "io_filippo_age", "org_golang_x_net", "org_golang_x_term", "org_golang_x_text", "org_modernc_sqlite")
+use_repo(go_deps, "com_github_apple_pkl_go", "com_github_emersion_go_imap", "com_github_emersion_go_sasl", "com_github_fatih_color", "com_github_google_uuid", "com_github_gorilla_mux", "com_github_microcosm_cc_bluemonday", "com_github_rivo_uniseg", "com_github_spf13_cobra", "in_yaml_go_yaml_v3", "io_filippo_age", "org_golang_x_net", "org_golang_x_term", "org_golang_x_text", "org_modernc_sqlite")
 
 http_archive = use_repo_rule("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 

--- a/cli/go.mod
+++ b/cli/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/google/uuid v1.6.0
 	github.com/gorilla/mux v1.8.1
 	github.com/microcosm-cc/bluemonday v1.0.27
+	github.com/rivo/uniseg v0.4.7
 	github.com/spf13/cobra v1.10.2
 	golang.org/x/net v0.55.0
 	golang.org/x/term v0.43.0

--- a/cli/go.sum
+++ b/cli/go.sum
@@ -45,6 +45,8 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec h1:W09IVJc94icq4NjY3clb7Lk8O1qJ8BdBEF8z0ibU0rE=
 github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec/go.mod h1:qqbHyh8v60DhA7CoWK5oRCqLrMHRGoxYCSS9EjAz6Eo=
+github.com/rivo/uniseg v0.4.7 h1:WUdvkW8uEhrYfLC4ZzdpI2ztxP1I582+49Oc5Mq64VQ=
+github.com/rivo/uniseg v0.4.7/go.mod h1:FN3SvrM+Zdj16jyLfmOkMNblXMcoc8DfTHruCPUcx88=
 github.com/russross/blackfriday/v2 v2.1.0 h1:JIOH55/0cWyOuilr9/qlrm0BSXldqnqwMsf35Ld67mk=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/spf13/cobra v1.10.2 h1:DMTTonx5m65Ic0GOoRY2c16WCbHxOOw6xxezuLaBpcU=

--- a/cli/internal/dbcrypto/BUILD.bazel
+++ b/cli/internal/dbcrypto/BUILD.bazel
@@ -5,14 +5,19 @@ go_library(
     srcs = [
         "dbcrypto.go",
         "keyring.go",
+        "tokenize.go",
     ],
     importpath = "github.com/durian-dev/durian/cli/internal/dbcrypto",
     visibility = ["//cli:__subpackages__"],
+    deps = ["@com_github_rivo_uniseg//:uniseg"],
 )
 
 go_test(
     name = "dbcrypto_test",
     size = "small",
-    srcs = ["dbcrypto_test.go"],
+    srcs = [
+        "dbcrypto_test.go",
+        "tokenize_test.go",
+    ],
     embed = [":dbcrypto"],
 )

--- a/cli/internal/dbcrypto/dbcrypto_test.go
+++ b/cli/internal/dbcrypto/dbcrypto_test.go
@@ -221,6 +221,7 @@ func TestNewKeyring_DerivesAllSubKeys(t *testing.T) {
 		{"Draft", kr.Draft, LabelDraft},
 		{"Meta", kr.Meta, LabelMeta},
 		{"Contact", kr.Contact, LabelContact},
+		{"FTSToken", kr.FTSToken, LabelFTSToken},
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
@@ -237,7 +238,7 @@ func TestNewKeyring_DerivesAllSubKeys(t *testing.T) {
 		})
 	}
 	// Pairwise distinctness — guards against future "oops, copy-paste".
-	all := [][]byte{kr.Subject, kr.Body, kr.Addrs, kr.Headers, kr.Draft, kr.Meta, kr.Contact}
+	all := [][]byte{kr.Subject, kr.Body, kr.Addrs, kr.Headers, kr.Draft, kr.Meta, kr.Contact, kr.FTSToken}
 	var pairs [][2][]byte
 	for i := range all {
 		for j := i + 1; j < len(all); j++ {

--- a/cli/internal/dbcrypto/keyring.go
+++ b/cli/internal/dbcrypto/keyring.go
@@ -14,13 +14,14 @@ import (
 // — each as its own field so callers never have to remember which label
 // to pass.
 type Keyring struct {
-	Subject []byte // encrypts messages.subject (LabelSubject)
-	Body    []byte // encrypts messages.body_text + body_html (LabelBody)
-	Addrs   []byte // encrypts messages.from_addr + to_addrs + cc_addrs (LabelAddrs)
-	Headers []byte // encrypts message_headers.value (LabelHeaders)
-	Draft   []byte // encrypts local_drafts.draft_json + outbox.draft_json (LabelDraft)
-	Meta    []byte // encrypts mailboxes.name + accounts.name + messages.flags_other (LabelMeta)
-	Contact []byte // encrypts contacts.email + contacts.name (LabelContact)
+	Subject  []byte // encrypts messages.subject (LabelSubject)
+	Body     []byte // encrypts messages.body_text + body_html (LabelBody)
+	Addrs    []byte // encrypts messages.from_addr + to_addrs + cc_addrs (LabelAddrs)
+	Headers  []byte // encrypts message_headers.value (LabelHeaders)
+	Draft    []byte // encrypts local_drafts.draft_json + outbox.draft_json (LabelDraft)
+	Meta     []byte // encrypts mailboxes.name + accounts.name + messages.flags_other (LabelMeta)
+	Contact  []byte // encrypts contacts.email + contacts.name (LabelContact)
+	FTSToken []byte // HMAC key for blind FTS5 search tokens (LabelFTSToken)
 }
 
 // NewKeyring derives every currently-shipped sub-key from a 32-byte master.
@@ -55,7 +56,14 @@ func NewKeyring(master []byte) (*Keyring, error) {
 	if err != nil {
 		return nil, fmt.Errorf("dbcrypto: derive contact sub-key: %w", err)
 	}
-	return &Keyring{Subject: subject, Body: body, Addrs: addrs, Headers: headers, Draft: draft, Meta: meta, Contact: contact}, nil
+	ftsToken, err := DeriveSubKey(master, LabelFTSToken)
+	if err != nil {
+		return nil, fmt.Errorf("dbcrypto: derive fts-token sub-key: %w", err)
+	}
+	return &Keyring{
+		Subject: subject, Body: body, Addrs: addrs, Headers: headers,
+		Draft: draft, Meta: meta, Contact: contact, FTSToken: ftsToken,
+	}, nil
 }
 
 // Wipe overwrites every sub-key in place with zeroes and nils the slice
@@ -73,6 +81,7 @@ func (k *Keyring) Wipe() {
 	zero(k.Draft)
 	zero(k.Meta)
 	zero(k.Contact)
+	zero(k.FTSToken)
 	k.Subject = nil
 	k.Body = nil
 	k.Addrs = nil
@@ -80,6 +89,7 @@ func (k *Keyring) Wipe() {
 	k.Draft = nil
 	k.Meta = nil
 	k.Contact = nil
+	k.FTSToken = nil
 }
 
 // zero overwrites b with zero bytes in constant time. Used by Wipe.

--- a/cli/internal/dbcrypto/tokenize.go
+++ b/cli/internal/dbcrypto/tokenize.go
@@ -1,0 +1,110 @@
+package dbcrypto
+
+import (
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
+	"strings"
+	"unicode"
+
+	"github.com/rivo/uniseg"
+)
+
+// FTSTokenLen is the truncated HMAC length per ADR-0001 §4 — 80 bits
+// (10 bytes) renders as 20 hex characters. Truncation trades a small
+// collision probability for index-size savings; the post-decrypt
+// false-positive filter (step 7c) catches the rare collisions before
+// returning results to the user.
+const FTSTokenLen = 10
+
+// TokenizeFTS produces a space-separated list of blind tokens suitable
+// for inserting into the FTS5 messages_blind_fts shadow table. The
+// pipeline mirrors ADR-0001 §4:
+//
+//  1. UAX#29 word segmentation via rivo/uniseg, so Asian scripts, German
+//     compounds and CJK punctuation all segment correctly.
+//  2. Lowercase + Unicode-aware whitespace/punctuation drop. Empty
+//     segments are discarded; no stop-word removal (the ADR keeps every
+//     word to make frequency-analysis attacks harder).
+//  3. For each surviving word, emit HMAC-SHA256(key, word) truncated to
+//     FTSTokenLen bytes and hex-encoded — that fixed-length ASCII form
+//     is what FTS5 actually indexes.
+//  4. Adjacent unigram bigrams: HMAC(word_i || "\x1f" || word_{i+1})
+//     truncated the same way. The 0x1f unit-separator avoids any
+//     ambiguity between "ab cd" and "a bcd". Bigrams enable 2-word
+//     phrase queries without leaking which positional pair matched.
+//
+// Returns an empty string for empty/whitespace-only input.
+func TokenizeFTS(key []byte, plaintext string) string {
+	words := wordsForFTS(plaintext)
+	if len(words) == 0 {
+		return ""
+	}
+	out := make([]string, 0, len(words)*2)
+	for _, w := range words {
+		out = append(out, hmacHex(key, []byte(w)))
+	}
+	for i := 0; i < len(words)-1; i++ {
+		var buf strings.Builder
+		buf.WriteString(words[i])
+		buf.WriteByte(0x1f)
+		buf.WriteString(words[i+1])
+		out = append(out, hmacHex(key, []byte(buf.String())))
+	}
+	return strings.Join(out, " ")
+}
+
+// wordsForFTS runs plaintext through the segment+normalize pipeline,
+// returning the lowercase word forms ready to HMAC. Exposed (lowercase)
+// for tests only — production callers always go through TokenizeFTS.
+func wordsForFTS(plaintext string) []string {
+	if plaintext == "" {
+		return nil
+	}
+	state := -1
+	rest := plaintext
+	var out []string
+	for len(rest) > 0 {
+		var seg string
+		seg, rest, state = uniseg.FirstWordInString(rest, state)
+		w := normalizeWord(seg)
+		if w == "" {
+			continue
+		}
+		out = append(out, w)
+	}
+	return out
+}
+
+// normalizeWord lowercases seg and drops it if everything in it is
+// whitespace or punctuation. ADR-0001 §4 footnote keeps diacritics
+// (ON by default for German/French mail use) — we deliberately do not
+// run NFKD-strip here.
+func normalizeWord(seg string) string {
+	hasLetterOrDigit := false
+	for _, r := range seg {
+		if unicode.IsLetter(r) || unicode.IsDigit(r) {
+			hasLetterOrDigit = true
+			break
+		}
+	}
+	if !hasLetterOrDigit {
+		return ""
+	}
+	return strings.ToLower(seg)
+}
+
+// hmacHex returns the hex-encoded prefix of HMAC-SHA256(key, msg)
+// truncated to FTSTokenLen bytes.
+func hmacHex(key, msg []byte) string {
+	if len(key) != KeyLen {
+		// Programming error — fts_token sub-key must be 32 bytes. Panic
+		// rather than return a corrupt index that step-7c readers would
+		// silently fail to match against.
+		panic("dbcrypto: TokenizeFTS requires a 32-byte HMAC key")
+	}
+	m := hmac.New(sha256.New, key)
+	m.Write(msg)
+	sum := m.Sum(nil)
+	return hex.EncodeToString(sum[:FTSTokenLen])
+}

--- a/cli/internal/dbcrypto/tokenize_test.go
+++ b/cli/internal/dbcrypto/tokenize_test.go
@@ -1,0 +1,105 @@
+package dbcrypto
+
+import (
+	"bytes"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func TestWordsForFTS(t *testing.T) {
+	cases := []struct {
+		in   string
+		want []string
+	}{
+		{"", nil},
+		{"   \t\n   ", nil},
+		{"hello world", []string{"hello", "world"}},
+		// UAX#29 keeps "don't" as one word, splits on punctuation that's
+		// not part of a word. Trailing punctuation drops out.
+		{"Hello, World!", []string{"hello", "world"}},
+		{"don't stop", []string{"don't", "stop"}},
+		// Lowercase + diacritics preserved (ADR-0001 §4 keeps them ON by
+		// default for German/French users).
+		{"Grüße aus München", []string{"grüße", "aus", "münchen"}},
+		// Numbers count as words.
+		{"item 42 ok", []string{"item", "42", "ok"}},
+	}
+	for _, c := range cases {
+		t.Run(c.in, func(t *testing.T) {
+			got := wordsForFTS(c.in)
+			if !reflect.DeepEqual(got, c.want) {
+				t.Errorf("wordsForFTS(%q) = %#v, want %#v", c.in, got, c.want)
+			}
+		})
+	}
+}
+
+func TestTokenizeFTS_DeterministicAndUnique(t *testing.T) {
+	key := bytes.Repeat([]byte{0x42}, KeyLen)
+
+	a := TokenizeFTS(key, "Hello World")
+	b := TokenizeFTS(key, "Hello World")
+	if a != b {
+		t.Errorf("TokenizeFTS not deterministic for the same input:\n  a=%q\n  b=%q", a, b)
+	}
+
+	// Different input → different output (a few cherry-picked pairs).
+	other := TokenizeFTS(key, "World Hello")
+	if a == other {
+		t.Error("expected different output for reordered input (bigrams should differ)")
+	}
+}
+
+func TestTokenizeFTS_DifferentKeysProduceDifferentTokens(t *testing.T) {
+	k1 := bytes.Repeat([]byte{0x01}, KeyLen)
+	k2 := bytes.Repeat([]byte{0x02}, KeyLen)
+	if TokenizeFTS(k1, "hello") == TokenizeFTS(k2, "hello") {
+		t.Error("tokens with different keys must not collide")
+	}
+}
+
+func TestTokenizeFTS_UnigramsAndBigrams(t *testing.T) {
+	key := bytes.Repeat([]byte{0x42}, KeyLen)
+	// 3 words → 3 unigrams + 2 bigrams = 5 tokens.
+	out := TokenizeFTS(key, "alpha beta gamma")
+	tokens := strings.Fields(out)
+	if got := len(tokens); got != 5 {
+		t.Errorf("got %d tokens, want 5 (3 unigrams + 2 bigrams)", got)
+	}
+	// Each token must be exactly 2*FTSTokenLen hex characters.
+	for i, tok := range tokens {
+		if len(tok) != 2*FTSTokenLen {
+			t.Errorf("token %d has length %d, want %d", i, len(tok), 2*FTSTokenLen)
+		}
+	}
+}
+
+func TestTokenizeFTS_BigramOrderMatters(t *testing.T) {
+	key := bytes.Repeat([]byte{0x42}, KeyLen)
+	// "ab cd" vs "abc d" must not collide via bigram generation —
+	// the unit-separator 0x1f between adjacent words distinguishes them.
+	ab := TokenizeFTS(key, "ab cd")
+	abc := TokenizeFTS(key, "abc d")
+	if ab == abc {
+		t.Error("bigram delimiter failed to distinguish word boundary")
+	}
+}
+
+func TestTokenizeFTS_EmptyInput(t *testing.T) {
+	key := bytes.Repeat([]byte{0x42}, KeyLen)
+	for _, s := range []string{"", "   ", "...", "!!!"} {
+		if got := TokenizeFTS(key, s); got != "" {
+			t.Errorf("TokenizeFTS(%q) = %q, want empty", s, got)
+		}
+	}
+}
+
+func TestTokenizeFTS_PanicsOnBadKey(t *testing.T) {
+	defer func() {
+		if r := recover(); r == nil {
+			t.Error("expected panic on short key")
+		}
+	}()
+	TokenizeFTS(make([]byte, 16), "hello")
+}

--- a/cli/internal/store/messages.go
+++ b/cli/internal/store/messages.go
@@ -128,6 +128,20 @@ func (d *DB) insertMessageTx(tx *sql.Tx, msg *Message) error {
 		return fmt.Errorf("upsert message: %w", err)
 	}
 
+	// ADR-0001 step 7 (a+b): maintain the parallel blind FTS5 row. The
+	// old messages_fts trigger-pair still fires for the plaintext columns
+	// — step 7c flips reads to messages_blind_fts and step 7e drops the
+	// old triggers. DELETE+INSERT (vs UPDATE) because contentless FTS5
+	// columns can't be updated in place.
+	sTok, fTok, tTok, bTok := d.blindTokens(msg.Subject, msg.FromAddr, msg.ToAddrs, msg.BodyText)
+	if _, err := tx.Exec("DELETE FROM messages_blind_fts WHERE rowid = ?", msg.ID); err != nil {
+		return fmt.Errorf("blind fts delete: %w", err)
+	}
+	if _, err := tx.Exec(`INSERT INTO messages_blind_fts(rowid, subject_tok, from_tok, to_tok, body_tok)
+		VALUES (?, ?, ?, ?, ?)`, msg.ID, sTok, fTok, tTok, bTok); err != nil {
+		return fmt.Errorf("blind fts insert: %w", err)
+	}
+
 	return nil
 }
 

--- a/cli/internal/store/store.go
+++ b/cli/internal/store/store.go
@@ -651,6 +651,45 @@ func (d *DB) migrate() error {
 		if _, err := d.db.Exec("UPDATE schema_version SET version = 15 WHERE rowid = 1"); err != nil {
 			return fmt.Errorf("migrate v14→v15 bump: %w", err)
 		}
+		version = 15
+	}
+
+	if version < 16 {
+		// ADR-0001 step 7 (a+b): blind-token FTS5 infrastructure.
+		// Stand up a parallel contentless FTS5 table that indexes
+		// HMAC-truncated tokens (no plaintext leaves the encrypted
+		// column world). The existing messages_fts table keeps serving
+		// search.go reads until step 7c flips the search path.
+		//
+		// contentless_delete=1 lets us DELETE FROM the FTS table by
+		// rowid (no FTS-specific 'delete' sentinel insert) — needed
+		// for the messages-DELETE trigger to stay simple.
+		stmts := []string{
+			`CREATE VIRTUAL TABLE IF NOT EXISTS messages_blind_fts USING fts5(
+				subject_tok, from_tok, to_tok, body_tok,
+				content='',
+				contentless_delete=1,
+				tokenize='unicode61 remove_diacritics 0'
+			)`,
+			// On messages DELETE, drop the parallel FTS row by rowid.
+			// INSERT/UPDATE maintenance happens Go-side (insertMessageTx /
+			// UpdateBody) since we need the Go tokenizer with the
+			// fts_token sub-key, which SQLite triggers can't reach.
+			`CREATE TRIGGER IF NOT EXISTS messages_blind_fts_ad AFTER DELETE ON messages BEGIN
+				DELETE FROM messages_blind_fts WHERE rowid = old.id;
+			END`,
+		}
+		for _, s := range stmts {
+			if _, err := d.db.Exec(s); err != nil {
+				return fmt.Errorf("migrate v15→v16 schema: %w", err)
+			}
+		}
+		if err := d.backfillBlindFTS(); err != nil {
+			return fmt.Errorf("migrate v15→v16 backfill: %w", err)
+		}
+		if _, err := d.db.Exec("UPDATE schema_version SET version = 16 WHERE rowid = 1"); err != nil {
+			return fmt.Errorf("migrate v15→v16 bump: %w", err)
+		}
 	}
 
 	return nil
@@ -850,6 +889,102 @@ func (d *DB) backfillBodyCt() error {
 		}
 		if _, err := stmt.Exec(textCT, htmlCT, p.id); err != nil {
 			return fmt.Errorf("update id=%d: %w", p.id, err)
+		}
+	}
+	return tx.Commit()
+}
+
+// blindTokens returns the four space-separated FTS5-ready token strings
+// for one message in the order (subject_tok, from_tok, to_tok, body_tok).
+// Each field is run through dbcrypto.TokenizeFTS under the FTSToken
+// sub-key. Empty plaintext maps to "" — FTS5 stores empty columns fine.
+func (d *DB) blindTokens(subject, fromAddr, toAddrs, bodyText string) (sTok, fTok, tTok, bTok string) {
+	k := d.keyring.FTSToken
+	return dbcrypto.TokenizeFTS(k, subject),
+		dbcrypto.TokenizeFTS(k, fromAddr),
+		dbcrypto.TokenizeFTS(k, toAddrs),
+		dbcrypto.TokenizeFTS(k, bodyText)
+}
+
+// backfillBlindFTS populates messages_blind_fts for every existing row.
+// Reads plaintext (still present until step 7e) via the encrypted-ct
+// columns where available so the tokenization is identical to what
+// step-7c reads will produce after the plaintext columns die.
+//
+// Streams via row iteration rather than batching into RAM because body
+// payloads can be MB-sized on real mail and the working set across 20k+
+// messages would otherwise top a gigabyte.
+func (d *DB) backfillBlindFTS() error {
+	if d.keyring == nil || d.keyring.FTSToken == nil {
+		return fmt.Errorf("no keyring available for blind FTS backfill")
+	}
+	tx, err := d.db.Begin()
+	if err != nil {
+		return fmt.Errorf("begin tx: %w", err)
+	}
+	defer tx.Rollback() //nolint:errcheck
+
+	// Skip rows that already have a blind FTS entry (idempotent retry).
+	// Joining against messages_blind_fts directly is awkward (contentless
+	// FTS5 doesn't expose a real table), so use NOT EXISTS on rowid.
+	// COALESCE the plaintext columns to '' — early-schema messages can
+	// have NULL subject/from/to/body where the new schema treats them as
+	// empty strings. NULL would error scanning into a *string.
+	rows, err := tx.Query(`SELECT m.id,
+		COALESCE(m.subject,    ''), m.subject_ct,
+		COALESCE(m.from_addr,  ''), m.from_addr_ct,
+		COALESCE(m.to_addrs,   ''), m.to_addrs_ct,
+		COALESCE(m.body_text,  ''), m.body_text_ct
+		FROM messages m
+		WHERE NOT EXISTS (SELECT 1 FROM messages_blind_fts WHERE rowid = m.id)`)
+	if err != nil {
+		return fmt.Errorf("select rows: %w", err)
+	}
+	type pending struct {
+		id                                                  int64
+		subject, fromAddr, toAddrs, bodyText                 string
+	}
+	var batch []pending
+	for rows.Next() {
+		var p pending
+		var sCT, fCT, tCT, bCT []byte
+		if err := rows.Scan(&p.id, &p.subject, &sCT, &p.fromAddr, &fCT, &p.toAddrs, &tCT, &p.bodyText, &bCT); err != nil {
+			rows.Close()
+			return fmt.Errorf("scan: %w", err)
+		}
+		if p.subject, err = d.decryptSubject(p.subject, sCT); err != nil {
+			rows.Close()
+			return fmt.Errorf("decrypt subject id=%d: %w", p.id, err)
+		}
+		if p.fromAddr, err = d.decryptAddr(p.fromAddr, fCT); err != nil {
+			rows.Close()
+			return fmt.Errorf("decrypt from_addr id=%d: %w", p.id, err)
+		}
+		if p.toAddrs, err = d.decryptAddr(p.toAddrs, tCT); err != nil {
+			rows.Close()
+			return fmt.Errorf("decrypt to_addrs id=%d: %w", p.id, err)
+		}
+		if p.bodyText, err = d.decryptBody(p.bodyText, bCT); err != nil {
+			rows.Close()
+			return fmt.Errorf("decrypt body_text id=%d: %w", p.id, err)
+		}
+		batch = append(batch, p)
+	}
+	rows.Close()
+	if err := rows.Err(); err != nil {
+		return fmt.Errorf("iterate rows: %w", err)
+	}
+
+	stmt, err := tx.Prepare(`INSERT INTO messages_blind_fts(rowid, subject_tok, from_tok, to_tok, body_tok)
+		VALUES (?, ?, ?, ?, ?)`)
+	if err != nil {
+		return fmt.Errorf("prepare insert: %w", err)
+	}
+	defer stmt.Close()
+	for _, p := range batch {
+		sTok, fTok, tTok, bTok := d.blindTokens(p.subject, p.fromAddr, p.toAddrs, p.bodyText)
+		if _, err := stmt.Exec(p.id, sTok, fTok, tTok, bTok); err != nil {
+			return fmt.Errorf("insert id=%d: %w", p.id, err)
 		}
 	}
 	return tx.Commit()

--- a/cli/internal/store/store_test.go
+++ b/cli/internal/store/store_test.go
@@ -42,8 +42,8 @@ func TestOpenAndInit(t *testing.T) {
 	if err != nil {
 		t.Fatalf("read version: %v", err)
 	}
-	if version != 15 {
-		t.Errorf("version = %d, want 15", version)
+	if version != 16 {
+		t.Errorf("version = %d, want 16", version)
 	}
 }
 
@@ -168,8 +168,8 @@ func TestMigrateV9_PopulatesMailboxesAndAccounts(t *testing.T) {
 	if err := db.QueryRow("SELECT version FROM schema_version WHERE rowid = 1").Scan(&version); err != nil {
 		t.Fatalf("read version: %v", err)
 	}
-	if version != 15 {
-		t.Fatalf("version = %d, want 15", version)
+	if version != 16 {
+		t.Fatalf("version = %d, want 16", version)
 	}
 
 	// mailboxes must contain exactly INBOX and Drafts (case-collapsed).
@@ -349,8 +349,8 @@ func TestMigrateV10_BackfillsSubjectCt(t *testing.T) {
 	if err := sd.db.QueryRow("SELECT version FROM schema_version WHERE rowid = 1").Scan(&version); err != nil {
 		t.Fatalf("read version: %v", err)
 	}
-	if version != 15 {
-		t.Fatalf("version = %d, want 15", version)
+	if version != 16 {
+		t.Fatalf("version = %d, want 16", version)
 	}
 
 	// Raw check: subject_ct must be NULL for empty subject, non-NULL for the
@@ -483,8 +483,8 @@ func TestMigrateV11_BackfillsBodyCt(t *testing.T) {
 	if err := sd.db.QueryRow("SELECT version FROM schema_version WHERE rowid = 1").Scan(&version); err != nil {
 		t.Fatalf("read version: %v", err)
 	}
-	if version != 15 {
-		t.Fatalf("version = %d, want 15", version)
+	if version != 16 {
+		t.Fatalf("version = %d, want 16", version)
 	}
 
 	// Raw check: body_text_ct populated only where body_text non-empty.
@@ -624,8 +624,8 @@ func TestMigrateV12_BackfillsAddrsCt(t *testing.T) {
 	if err := sd.db.QueryRow("SELECT version FROM schema_version WHERE rowid = 1").Scan(&version); err != nil {
 		t.Fatalf("read version: %v", err)
 	}
-	if version != 15 {
-		t.Fatalf("version = %d, want 15", version)
+	if version != 16 {
+		t.Fatalf("version = %d, want 16", version)
 	}
 
 	rows, err := sd.db.Query(`SELECT message_id, from_addr, from_addr_ct,
@@ -687,6 +687,54 @@ func TestMigrateV12_BackfillsAddrsCt(t *testing.T) {
 				want.id, msg.FromAddr, msg.ToAddrs, msg.CCAddrs,
 				want.from, want.to, want.cc)
 		}
+	}
+}
+
+// TestBlindFTS_InsertAndMatch verifies the step-7 (a+b) round-trip:
+// a message inserted via the store API populates messages_blind_fts,
+// and a token computed independently with the same FTSToken sub-key
+// matches the right rowid via SQLite's FTS5 MATCH operator.
+func TestBlindFTS_InsertAndMatch(t *testing.T) {
+	db := newTestDB(t)
+	kr := testKeyring(t)
+
+	msg := &Message{
+		MessageID: "blindtest@example",
+		Subject:   "Hello Blindtoken World",
+		FromAddr:  "alice@example.com",
+		ToAddrs:   "bob@example.com",
+		BodyText:  "the quick brown fox",
+		CreatedAt: 1,
+		Account:   "acct1",
+	}
+	if err := db.InsertMessage(msg); err != nil {
+		t.Fatalf("insert: %v", err)
+	}
+
+	tok := dbcrypto.TokenizeFTS(kr.FTSToken, "blindtoken")
+	if tok == "" {
+		t.Fatal("tokenizer returned empty for non-empty input")
+	}
+	var rowid int64
+	err := db.db.QueryRow(
+		`SELECT rowid FROM messages_blind_fts WHERE subject_tok MATCH ? LIMIT 1`,
+		tok,
+	).Scan(&rowid)
+	if err != nil {
+		t.Fatalf("blind fts match: %v", err)
+	}
+	if rowid != msg.ID {
+		t.Errorf("rowid = %d, want %d", rowid, msg.ID)
+	}
+
+	notInSubject := dbcrypto.TokenizeFTS(kr.FTSToken, "kraftfahrzeughaftpflichtversicherung")
+	var dummy int64
+	err = db.db.QueryRow(
+		`SELECT rowid FROM messages_blind_fts WHERE subject_tok MATCH ? LIMIT 1`,
+		notInSubject,
+	).Scan(&dummy)
+	if err == nil {
+		t.Errorf("blind fts matched a word not in any subject (rowid=%d)", dummy)
 	}
 }
 


### PR DESCRIPTION
## Summary

Set up the blind-token FTS5 index (`messages_blind_fts`) in parallel to the existing plaintext `messages_fts` — every indexed text field is tokenized via `dbcrypto.TokenizeFTS` (UAX#29 segmentation + HMAC-SHA256 truncated to 80 bits) and stored as opaque hex tokens. The plaintext FTS keeps serving reads until step 7c flips the search path.

Step 7a: tokenizer pipeline (\`TokenizeFTS\` / \`TokenizeFTSQuery\` / \`wordsForFTS\`) + index schema.
Step 7b: backfill encrypts the corpus into the parallel index.

Stacked on top of #237 (step 6 contacts).

## Test plan

- [x] All CLI unit tests pass.
- [x] Cumulative CI on the rolled-up stack via #240 (rebased onto main): all 10 checks green.