### PR TITLE
ADR-0001 step 7c — flip search to blind-token FTS5

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -25,7 +25,7 @@ go_sdk.download(version = "1.25.10")
 
 go_deps = use_extension("@gazelle//:extensions.bzl", "go_deps")
 go_deps.from_file(go_mod = "//cli:go.mod")
-use_repo(go_deps, "com_github_apple_pkl_go", "com_github_emersion_go_imap", "com_github_emersion_go_sasl", "com_github_fatih_color", "com_github_google_uuid", "com_github_gorilla_mux", "com_github_microcosm_cc_bluemonday", "com_github_spf13_cobra", "in_yaml_go_yaml_v3", "io_filippo_age", "org_golang_x_net", "org_golang_x_term", "org_golang_x_text", "org_modernc_sqlite")
+use_repo(go_deps, "com_github_apple_pkl_go", "com_github_emersion_go_imap", "com_github_emersion_go_sasl", "com_github_fatih_color", "com_github_google_uuid", "com_github_gorilla_mux", "com_github_microcosm_cc_bluemonday", "com_github_rivo_uniseg", "com_github_spf13_cobra", "in_yaml_go_yaml_v3", "io_filippo_age", "org_golang_x_net", "org_golang_x_term", "org_golang_x_text", "org_modernc_sqlite")
 
 http_archive = use_repo_rule("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 

--- a/cli/go.mod
+++ b/cli/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/google/uuid v1.6.0
 	github.com/gorilla/mux v1.8.1
 	github.com/microcosm-cc/bluemonday v1.0.27
+	github.com/rivo/uniseg v0.4.7
 	github.com/spf13/cobra v1.10.2
 	golang.org/x/net v0.55.0
 	golang.org/x/term v0.43.0

--- a/cli/go.sum
+++ b/cli/go.sum
@@ -45,6 +45,8 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec h1:W09IVJc94icq4NjY3clb7Lk8O1qJ8BdBEF8z0ibU0rE=
 github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec/go.mod h1:qqbHyh8v60DhA7CoWK5oRCqLrMHRGoxYCSS9EjAz6Eo=
+github.com/rivo/uniseg v0.4.7 h1:WUdvkW8uEhrYfLC4ZzdpI2ztxP1I582+49Oc5Mq64VQ=
+github.com/rivo/uniseg v0.4.7/go.mod h1:FN3SvrM+Zdj16jyLfmOkMNblXMcoc8DfTHruCPUcx88=
 github.com/russross/blackfriday/v2 v2.1.0 h1:JIOH55/0cWyOuilr9/qlrm0BSXldqnqwMsf35Ld67mk=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/spf13/cobra v1.10.2 h1:DMTTonx5m65Ic0GOoRY2c16WCbHxOOw6xxezuLaBpcU=

--- a/cli/internal/dbcrypto/BUILD.bazel
+++ b/cli/internal/dbcrypto/BUILD.bazel
@@ -5,14 +5,19 @@ go_library(
     srcs = [
         "dbcrypto.go",
         "keyring.go",
+        "tokenize.go",
     ],
     importpath = "github.com/durian-dev/durian/cli/internal/dbcrypto",
     visibility = ["//cli:__subpackages__"],
+    deps = ["@com_github_rivo_uniseg//:uniseg"],
 )
 
 go_test(
     name = "dbcrypto_test",
     size = "small",
-    srcs = ["dbcrypto_test.go"],
+    srcs = [
+        "dbcrypto_test.go",
+        "tokenize_test.go",
+    ],
     embed = [":dbcrypto"],
 )

--- a/cli/internal/dbcrypto/dbcrypto_test.go
+++ b/cli/internal/dbcrypto/dbcrypto_test.go
@@ -221,6 +221,7 @@ func TestNewKeyring_DerivesAllSubKeys(t *testing.T) {
 		{"Draft", kr.Draft, LabelDraft},
 		{"Meta", kr.Meta, LabelMeta},
 		{"Contact", kr.Contact, LabelContact},
+		{"FTSToken", kr.FTSToken, LabelFTSToken},
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
@@ -237,7 +238,7 @@ func TestNewKeyring_DerivesAllSubKeys(t *testing.T) {
 		})
 	}
 	// Pairwise distinctness — guards against future "oops, copy-paste".
-	all := [][]byte{kr.Subject, kr.Body, kr.Addrs, kr.Headers, kr.Draft, kr.Meta, kr.Contact}
+	all := [][]byte{kr.Subject, kr.Body, kr.Addrs, kr.Headers, kr.Draft, kr.Meta, kr.Contact, kr.FTSToken}
 	var pairs [][2][]byte
 	for i := range all {
 		for j := i + 1; j < len(all); j++ {

--- a/cli/internal/dbcrypto/keyring.go
+++ b/cli/internal/dbcrypto/keyring.go
@@ -14,13 +14,14 @@ import (
 // — each as its own field so callers never have to remember which label
 // to pass.
 type Keyring struct {
-	Subject []byte // encrypts messages.subject (LabelSubject)
-	Body    []byte // encrypts messages.body_text + body_html (LabelBody)
-	Addrs   []byte // encrypts messages.from_addr + to_addrs + cc_addrs (LabelAddrs)
-	Headers []byte // encrypts message_headers.value (LabelHeaders)
-	Draft   []byte // encrypts local_drafts.draft_json + outbox.draft_json (LabelDraft)
-	Meta    []byte // encrypts mailboxes.name + accounts.name + messages.flags_other (LabelMeta)
-	Contact []byte // encrypts contacts.email + contacts.name (LabelContact)
+	Subject  []byte // encrypts messages.subject (LabelSubject)
+	Body     []byte // encrypts messages.body_text + body_html (LabelBody)
+	Addrs    []byte // encrypts messages.from_addr + to_addrs + cc_addrs (LabelAddrs)
+	Headers  []byte // encrypts message_headers.value (LabelHeaders)
+	Draft    []byte // encrypts local_drafts.draft_json + outbox.draft_json (LabelDraft)
+	Meta     []byte // encrypts mailboxes.name + accounts.name + messages.flags_other (LabelMeta)
+	Contact  []byte // encrypts contacts.email + contacts.name (LabelContact)
+	FTSToken []byte // HMAC key for blind FTS5 search tokens (LabelFTSToken)
 }
 
 // NewKeyring derives every currently-shipped sub-key from a 32-byte master.
@@ -55,7 +56,14 @@ func NewKeyring(master []byte) (*Keyring, error) {
 	if err != nil {
 		return nil, fmt.Errorf("dbcrypto: derive contact sub-key: %w", err)
 	}
-	return &Keyring{Subject: subject, Body: body, Addrs: addrs, Headers: headers, Draft: draft, Meta: meta, Contact: contact}, nil
+	ftsToken, err := DeriveSubKey(master, LabelFTSToken)
+	if err != nil {
+		return nil, fmt.Errorf("dbcrypto: derive fts-token sub-key: %w", err)
+	}
+	return &Keyring{
+		Subject: subject, Body: body, Addrs: addrs, Headers: headers,
+		Draft: draft, Meta: meta, Contact: contact, FTSToken: ftsToken,
+	}, nil
 }
 
 // Wipe overwrites every sub-key in place with zeroes and nils the slice
@@ -73,6 +81,7 @@ func (k *Keyring) Wipe() {
 	zero(k.Draft)
 	zero(k.Meta)
 	zero(k.Contact)
+	zero(k.FTSToken)
 	k.Subject = nil
 	k.Body = nil
 	k.Addrs = nil
@@ -80,6 +89,7 @@ func (k *Keyring) Wipe() {
 	k.Draft = nil
 	k.Meta = nil
 	k.Contact = nil
+	k.FTSToken = nil
 }
 
 // zero overwrites b with zero bytes in constant time. Used by Wipe.

--- a/cli/internal/dbcrypto/tokenize.go
+++ b/cli/internal/dbcrypto/tokenize.go
@@ -1,0 +1,110 @@
+package dbcrypto
+
+import (
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
+	"strings"
+	"unicode"
+
+	"github.com/rivo/uniseg"
+)
+
+// FTSTokenLen is the truncated HMAC length per ADR-0001 §4 — 80 bits
+// (10 bytes) renders as 20 hex characters. Truncation trades a small
+// collision probability for index-size savings; the post-decrypt
+// false-positive filter (step 7c) catches the rare collisions before
+// returning results to the user.
+const FTSTokenLen = 10
+
+// TokenizeFTS produces a space-separated list of blind tokens suitable
+// for inserting into the FTS5 messages_blind_fts shadow table. The
+// pipeline mirrors ADR-0001 §4:
+//
+//  1. UAX#29 word segmentation via rivo/uniseg, so Asian scripts, German
+//     compounds and CJK punctuation all segment correctly.
+//  2. Lowercase + Unicode-aware whitespace/punctuation drop. Empty
+//     segments are discarded; no stop-word removal (the ADR keeps every
+//     word to make frequency-analysis attacks harder).
+//  3. For each surviving word, emit HMAC-SHA256(key, word) truncated to
+//     FTSTokenLen bytes and hex-encoded — that fixed-length ASCII form
+//     is what FTS5 actually indexes.
+//  4. Adjacent unigram bigrams: HMAC(word_i || "\x1f" || word_{i+1})
+//     truncated the same way. The 0x1f unit-separator avoids any
+//     ambiguity between "ab cd" and "a bcd". Bigrams enable 2-word
+//     phrase queries without leaking which positional pair matched.
+//
+// Returns an empty string for empty/whitespace-only input.
+func TokenizeFTS(key []byte, plaintext string) string {
+	words := wordsForFTS(plaintext)
+	if len(words) == 0 {
+		return ""
+	}
+	out := make([]string, 0, len(words)*2)
+	for _, w := range words {
+		out = append(out, hmacHex(key, []byte(w)))
+	}
+	for i := 0; i < len(words)-1; i++ {
+		var buf strings.Builder
+		buf.WriteString(words[i])
+		buf.WriteByte(0x1f)
+		buf.WriteString(words[i+1])
+		out = append(out, hmacHex(key, []byte(buf.String())))
+	}
+	return strings.Join(out, " ")
+}
+
+// wordsForFTS runs plaintext through the segment+normalize pipeline,
+// returning the lowercase word forms ready to HMAC. Exposed (lowercase)
+// for tests only — production callers always go through TokenizeFTS.
+func wordsForFTS(plaintext string) []string {
+	if plaintext == "" {
+		return nil
+	}
+	state := -1
+	rest := plaintext
+	var out []string
+	for len(rest) > 0 {
+		var seg string
+		seg, rest, state = uniseg.FirstWordInString(rest, state)
+		w := normalizeWord(seg)
+		if w == "" {
+			continue
+		}
+		out = append(out, w)
+	}
+	return out
+}
+
+// normalizeWord lowercases seg and drops it if everything in it is
+// whitespace or punctuation. ADR-0001 §4 footnote keeps diacritics
+// (ON by default for German/French mail use) — we deliberately do not
+// run NFKD-strip here.
+func normalizeWord(seg string) string {
+	hasLetterOrDigit := false
+	for _, r := range seg {
+		if unicode.IsLetter(r) || unicode.IsDigit(r) {
+			hasLetterOrDigit = true
+			break
+		}
+	}
+	if !hasLetterOrDigit {
+		return ""
+	}
+	return strings.ToLower(seg)
+}
+
+// hmacHex returns the hex-encoded prefix of HMAC-SHA256(key, msg)
+// truncated to FTSTokenLen bytes.
+func hmacHex(key, msg []byte) string {
+	if len(key) != KeyLen {
+		// Programming error — fts_token sub-key must be 32 bytes. Panic
+		// rather than return a corrupt index that step-7c readers would
+		// silently fail to match against.
+		panic("dbcrypto: TokenizeFTS requires a 32-byte HMAC key")
+	}
+	m := hmac.New(sha256.New, key)
+	m.Write(msg)
+	sum := m.Sum(nil)
+	return hex.EncodeToString(sum[:FTSTokenLen])
+}

--- a/cli/internal/dbcrypto/tokenize.go
+++ b/cli/internal/dbcrypto/tokenize.go
@@ -54,6 +54,26 @@ func TokenizeFTS(key []byte, plaintext string) string {
 	return strings.Join(out, " ")
 }
 
+// TokenizeFTSQuery returns the same per-word HMAC tokens TokenizeFTS
+// produces but WITHOUT the adjacent-pair bigrams. Use this on the
+// read side for plain word-AND queries — emitting the index-time
+// bigrams as additional query tokens would AND-require the searcher's
+// word pair to also appear consecutively in the source, turning a
+// word-AND query into a phrase-match by accident. Phrase-query
+// support reuses TokenizeFTS (with bigrams) once the parser learns
+// quote-for-phrase syntax.
+func TokenizeFTSQuery(key []byte, plaintext string) string {
+	words := wordsForFTS(plaintext)
+	if len(words) == 0 {
+		return ""
+	}
+	out := make([]string, len(words))
+	for i, w := range words {
+		out[i] = hmacHex(key, []byte(w))
+	}
+	return strings.Join(out, " ")
+}
+
 // wordsForFTS runs plaintext through the segment+normalize pipeline,
 // returning the lowercase word forms ready to HMAC. Exposed (lowercase)
 // for tests only — production callers always go through TokenizeFTS.

--- a/cli/internal/dbcrypto/tokenize_test.go
+++ b/cli/internal/dbcrypto/tokenize_test.go
@@ -1,0 +1,105 @@
+package dbcrypto
+
+import (
+	"bytes"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func TestWordsForFTS(t *testing.T) {
+	cases := []struct {
+		in   string
+		want []string
+	}{
+		{"", nil},
+		{"   \t\n   ", nil},
+		{"hello world", []string{"hello", "world"}},
+		// UAX#29 keeps "don't" as one word, splits on punctuation that's
+		// not part of a word. Trailing punctuation drops out.
+		{"Hello, World!", []string{"hello", "world"}},
+		{"don't stop", []string{"don't", "stop"}},
+		// Lowercase + diacritics preserved (ADR-0001 §4 keeps them ON by
+		// default for German/French users).
+		{"Grüße aus München", []string{"grüße", "aus", "münchen"}},
+		// Numbers count as words.
+		{"item 42 ok", []string{"item", "42", "ok"}},
+	}
+	for _, c := range cases {
+		t.Run(c.in, func(t *testing.T) {
+			got := wordsForFTS(c.in)
+			if !reflect.DeepEqual(got, c.want) {
+				t.Errorf("wordsForFTS(%q) = %#v, want %#v", c.in, got, c.want)
+			}
+		})
+	}
+}
+
+func TestTokenizeFTS_DeterministicAndUnique(t *testing.T) {
+	key := bytes.Repeat([]byte{0x42}, KeyLen)
+
+	a := TokenizeFTS(key, "Hello World")
+	b := TokenizeFTS(key, "Hello World")
+	if a != b {
+		t.Errorf("TokenizeFTS not deterministic for the same input:\n  a=%q\n  b=%q", a, b)
+	}
+
+	// Different input → different output (a few cherry-picked pairs).
+	other := TokenizeFTS(key, "World Hello")
+	if a == other {
+		t.Error("expected different output for reordered input (bigrams should differ)")
+	}
+}
+
+func TestTokenizeFTS_DifferentKeysProduceDifferentTokens(t *testing.T) {
+	k1 := bytes.Repeat([]byte{0x01}, KeyLen)
+	k2 := bytes.Repeat([]byte{0x02}, KeyLen)
+	if TokenizeFTS(k1, "hello") == TokenizeFTS(k2, "hello") {
+		t.Error("tokens with different keys must not collide")
+	}
+}
+
+func TestTokenizeFTS_UnigramsAndBigrams(t *testing.T) {
+	key := bytes.Repeat([]byte{0x42}, KeyLen)
+	// 3 words → 3 unigrams + 2 bigrams = 5 tokens.
+	out := TokenizeFTS(key, "alpha beta gamma")
+	tokens := strings.Fields(out)
+	if got := len(tokens); got != 5 {
+		t.Errorf("got %d tokens, want 5 (3 unigrams + 2 bigrams)", got)
+	}
+	// Each token must be exactly 2*FTSTokenLen hex characters.
+	for i, tok := range tokens {
+		if len(tok) != 2*FTSTokenLen {
+			t.Errorf("token %d has length %d, want %d", i, len(tok), 2*FTSTokenLen)
+		}
+	}
+}
+
+func TestTokenizeFTS_BigramOrderMatters(t *testing.T) {
+	key := bytes.Repeat([]byte{0x42}, KeyLen)
+	// "ab cd" vs "abc d" must not collide via bigram generation —
+	// the unit-separator 0x1f between adjacent words distinguishes them.
+	ab := TokenizeFTS(key, "ab cd")
+	abc := TokenizeFTS(key, "abc d")
+	if ab == abc {
+		t.Error("bigram delimiter failed to distinguish word boundary")
+	}
+}
+
+func TestTokenizeFTS_EmptyInput(t *testing.T) {
+	key := bytes.Repeat([]byte{0x42}, KeyLen)
+	for _, s := range []string{"", "   ", "...", "!!!"} {
+		if got := TokenizeFTS(key, s); got != "" {
+			t.Errorf("TokenizeFTS(%q) = %q, want empty", s, got)
+		}
+	}
+}
+
+func TestTokenizeFTS_PanicsOnBadKey(t *testing.T) {
+	defer func() {
+		if r := recover(); r == nil {
+			t.Error("expected panic on short key")
+		}
+	}()
+	TokenizeFTS(make([]byte, 16), "hello")
+}

--- a/cli/internal/store/headers.go
+++ b/cli/internal/store/headers.go
@@ -65,9 +65,10 @@ func (d *DB) GetMessageDBID(messageID, account string) (int64, error) {
 }
 
 // AllMessages returns all messages with fields needed for rule matching.
+// from_addr/to_addrs/cc_addrs are plaintext (ADR-0001 §3 revision).
 func (d *DB) AllMessages() ([]*Message, error) {
 	rows, err := d.db.Query(`SELECT id, message_id, subject, subject_ct,
-		from_addr, from_addr_ct, to_addrs, to_addrs_ct, cc_addrs, cc_addrs_ct,
+		from_addr, to_addrs, cc_addrs,
 		body_text, body_text_ct, account FROM messages`)
 	if err != nil {
 		return nil, fmt.Errorf("query messages: %w", err)
@@ -77,22 +78,13 @@ func (d *DB) AllMessages() ([]*Message, error) {
 	var msgs []*Message
 	for rows.Next() {
 		m := &Message{}
-		var subjectCT, fromAddrCT, toAddrsCT, ccAddrsCT, bodyTextCT []byte
+		var subjectCT, bodyTextCT []byte
 		if err := rows.Scan(&m.ID, &m.MessageID, &m.Subject, &subjectCT,
-			&m.FromAddr, &fromAddrCT, &m.ToAddrs, &toAddrsCT, &m.CCAddrs, &ccAddrsCT,
+			&m.FromAddr, &m.ToAddrs, &m.CCAddrs,
 			&m.BodyText, &bodyTextCT, &m.Account); err != nil {
 			return nil, fmt.Errorf("scan message: %w", err)
 		}
 		if m.Subject, err = d.decryptSubject(m.Subject, subjectCT); err != nil {
-			return nil, err
-		}
-		if m.FromAddr, err = d.decryptAddr(m.FromAddr, fromAddrCT); err != nil {
-			return nil, err
-		}
-		if m.ToAddrs, err = d.decryptAddr(m.ToAddrs, toAddrsCT); err != nil {
-			return nil, err
-		}
-		if m.CCAddrs, err = d.decryptAddr(m.CCAddrs, ccAddrsCT); err != nil {
 			return nil, err
 		}
 		if m.BodyText, err = d.decryptBody(m.BodyText, bodyTextCT); err != nil {

--- a/cli/internal/store/messages.go
+++ b/cli/internal/store/messages.go
@@ -128,6 +128,20 @@ func (d *DB) insertMessageTx(tx *sql.Tx, msg *Message) error {
 		return fmt.Errorf("upsert message: %w", err)
 	}
 
+	// ADR-0001 step 7 (a+b): maintain the parallel blind FTS5 row. The
+	// old messages_fts trigger-pair still fires for the plaintext columns
+	// — step 7c flips reads to messages_blind_fts and step 7e drops the
+	// old triggers. DELETE+INSERT (vs UPDATE) because contentless FTS5
+	// columns can't be updated in place.
+	sTok, fTok, tTok, bTok := d.blindTokens(msg.Subject, msg.FromAddr, msg.ToAddrs, msg.BodyText)
+	if _, err := tx.Exec("DELETE FROM messages_blind_fts WHERE rowid = ?", msg.ID); err != nil {
+		return fmt.Errorf("blind fts delete: %w", err)
+	}
+	if _, err := tx.Exec(`INSERT INTO messages_blind_fts(rowid, subject_tok, from_tok, to_tok, body_tok)
+		VALUES (?, ?, ?, ?, ?)`, msg.ID, sTok, fTok, tTok, bTok); err != nil {
+		return fmt.Errorf("blind fts insert: %w", err)
+	}
+
 	return nil
 }
 

--- a/cli/internal/store/messages.go
+++ b/cli/internal/store/messages.go
@@ -66,19 +66,6 @@ func (d *DB) insertMessageTx(tx *sql.Tx, msg *Message) error {
 	if err != nil {
 		return fmt.Errorf("encrypt body_html: %w", err)
 	}
-	// ADR-0001 step 6: addrs columns.
-	fromAddrCT, err := d.encryptAddr(msg.FromAddr)
-	if err != nil {
-		return fmt.Errorf("encrypt from_addr: %w", err)
-	}
-	toAddrsCT, err := d.encryptAddr(msg.ToAddrs)
-	if err != nil {
-		return fmt.Errorf("encrypt to_addrs: %w", err)
-	}
-	ccAddrsCT, err := d.encryptAddr(msg.CCAddrs)
-	if err != nil {
-		return fmt.Errorf("encrypt cc_addrs: %w", err)
-	}
 	// ADR-0001 step 6: non-boolean flag parts go to flags_other under
 	// the meta sub-key. Booleans (is_seen/is_flagged/is_deleted) are
 	// derived elsewhere in this insert path's downstream tag flow.
@@ -87,23 +74,25 @@ func (d *DB) insertMessageTx(tx *sql.Tx, msg *Message) error {
 		return fmt.Errorf("encrypt flags_other: %w", err)
 	}
 
+	// ADR-0001 step 7d / §3 revision: from_addr/to_addrs/cc_addrs stay
+	// plaintext (substring-search UX, addresses already public on the
+	// wire). No *_ct columns written for the addrs columns — v17
+	// migration drops them.
+
 	err = tx.QueryRow(`
 		INSERT INTO messages (
 			message_id, thread_id, in_reply_to, refs, subject, subject_ct,
-			from_addr, from_addr_ct, to_addrs, to_addrs_ct, cc_addrs, cc_addrs_ct,
+			from_addr, to_addrs, cc_addrs,
 			date, created_at,
 			body_text, body_text_ct, body_html, body_html_ct,
 			mailbox, flags, flags_other, uid, size, fetched_body, account
-		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 		ON CONFLICT(message_id, account) DO UPDATE SET
 			subject = excluded.subject,
 			subject_ct = excluded.subject_ct,
 			from_addr = excluded.from_addr,
-			from_addr_ct = excluded.from_addr_ct,
 			to_addrs = excluded.to_addrs,
-			to_addrs_ct = excluded.to_addrs_ct,
 			cc_addrs = excluded.cc_addrs,
-			cc_addrs_ct = excluded.cc_addrs_ct,
 			body_text = CASE WHEN excluded.fetched_body = 1 AND messages.fetched_body = 0
 			                 THEN excluded.body_text ELSE messages.body_text END,
 			body_text_ct = CASE WHEN excluded.fetched_body = 1 AND messages.fetched_body = 0
@@ -119,7 +108,7 @@ func (d *DB) insertMessageTx(tx *sql.Tx, msg *Message) error {
 			mailbox = CASE WHEN excluded.mailbox != '' THEN excluded.mailbox ELSE messages.mailbox END
 		RETURNING id`,
 		msg.MessageID, threadID, msg.InReplyTo, msg.Refs, msg.Subject, subjectCT,
-		msg.FromAddr, fromAddrCT, msg.ToAddrs, toAddrsCT, msg.CCAddrs, ccAddrsCT,
+		msg.FromAddr, msg.ToAddrs, msg.CCAddrs,
 		msg.Date, msg.CreatedAt,
 		msg.BodyText, bodyTextCT, msg.BodyHTML, bodyHTMLCT,
 		msg.Mailbox, msg.Flags, flagsOtherCT, msg.UID, msg.Size, fetchedBody, msg.Account,
@@ -157,7 +146,15 @@ func (d *DB) UpdateBody(messageID, bodyText, bodyHTML string) error {
 	if err != nil {
 		return fmt.Errorf("encrypt body_html: %w", err)
 	}
-	result, err := d.db.Exec(`
+	// Wrap in a tx so the messages UPDATE and the blind FTS refresh are
+	// atomic. Without this, a crash between them would leave body_tok
+	// stale (search wouldn't find body content of lazy-fetched mail).
+	tx, err := d.db.Begin()
+	if err != nil {
+		return fmt.Errorf("begin tx: %w", err)
+	}
+	defer tx.Rollback() //nolint:errcheck
+	result, err := tx.Exec(`
 		UPDATE messages SET body_text = ?, body_text_ct = ?,
 		                    body_html = ?, body_html_ct = ?,
 		                    fetched_body = 1
@@ -170,7 +167,26 @@ func (d *DB) UpdateBody(messageID, bodyText, bodyHTML string) error {
 	if rows == 0 {
 		return fmt.Errorf("message not found: %s", messageID)
 	}
-	return nil
+
+	// ADR-0001 step 7d: refresh the blind FTS row so body_tok matches
+	// the newly-fetched body. Need the other three fields too because
+	// contentless FTS5 can't UPDATE column-by-column — DELETE + INSERT
+	// the whole row is the only path.
+	var rowid int64
+	var subject, fromAddr, toAddrs string
+	if err := tx.QueryRow(`SELECT id, COALESCE(subject, ''), COALESCE(from_addr, ''), COALESCE(to_addrs, '')
+		FROM messages WHERE message_id = ? LIMIT 1`, messageID).Scan(&rowid, &subject, &fromAddr, &toAddrs); err != nil {
+		return fmt.Errorf("fetch row for blind FTS refresh: %w", err)
+	}
+	sTok, fTok, tTok, bTok := d.blindTokens(subject, fromAddr, toAddrs, bodyText)
+	if _, err := tx.Exec("DELETE FROM messages_blind_fts WHERE rowid = ?", rowid); err != nil {
+		return fmt.Errorf("blind fts delete: %w", err)
+	}
+	if _, err := tx.Exec(`INSERT INTO messages_blind_fts(rowid, subject_tok, from_tok, to_tok, body_tok)
+		VALUES (?, ?, ?, ?, ?)`, rowid, sTok, fTok, tTok, bTok); err != nil {
+		return fmt.Errorf("blind fts insert: %w", err)
+	}
+	return tx.Commit()
 }
 
 // UpdateMailbox sets the mailbox and UID for a message identified by message_id and account.
@@ -201,18 +217,16 @@ func (d *DB) BackfillUID(messageID, account string, uid uint32, mailbox string) 
 func (d *DB) GetByMessageID(messageID string) (*Message, error) {
 	msg := &Message{}
 	var fetchedBody int
-	var subjectCT, fromAddrCT, toAddrsCT, ccAddrsCT, bodyTextCT, bodyHTMLCT []byte
+	var subjectCT, bodyTextCT, bodyHTMLCT []byte
 	err := d.db.QueryRow(`
 		SELECT id, message_id, thread_id, in_reply_to, refs, subject, subject_ct,
-		       from_addr, from_addr_ct, to_addrs, to_addrs_ct, cc_addrs, cc_addrs_ct,
-		       date, created_at,
+		       from_addr, to_addrs, cc_addrs, date, created_at,
 		       body_text, body_text_ct, body_html, body_html_ct,
 		       mailbox, flags, uid, size, fetched_body, account
 		FROM messages WHERE message_id = ? LIMIT 1`, messageID,
 	).Scan(
 		&msg.ID, &msg.MessageID, &msg.ThreadID, &msg.InReplyTo, &msg.Refs, &msg.Subject, &subjectCT,
-		&msg.FromAddr, &fromAddrCT, &msg.ToAddrs, &toAddrsCT, &msg.CCAddrs, &ccAddrsCT,
-		&msg.Date, &msg.CreatedAt,
+		&msg.FromAddr, &msg.ToAddrs, &msg.CCAddrs, &msg.Date, &msg.CreatedAt,
 		&msg.BodyText, &bodyTextCT, &msg.BodyHTML, &bodyHTMLCT,
 		&msg.Mailbox, &msg.Flags, &msg.UID, &msg.Size, &fetchedBody, &msg.Account,
 	)
@@ -226,15 +240,7 @@ func (d *DB) GetByMessageID(messageID string) (*Message, error) {
 	if msg.Subject, err = d.decryptSubject(msg.Subject, subjectCT); err != nil {
 		return nil, err
 	}
-	if msg.FromAddr, err = d.decryptAddr(msg.FromAddr, fromAddrCT); err != nil {
-		return nil, err
-	}
-	if msg.ToAddrs, err = d.decryptAddr(msg.ToAddrs, toAddrsCT); err != nil {
-		return nil, err
-	}
-	if msg.CCAddrs, err = d.decryptAddr(msg.CCAddrs, ccAddrsCT); err != nil {
-		return nil, err
-	}
+	// from_addr/to_addrs/cc_addrs stay plaintext (ADR-0001 §3 revision).
 	if msg.BodyText, err = d.decryptBody(msg.BodyText, bodyTextCT); err != nil {
 		return nil, err
 	}
@@ -249,8 +255,7 @@ func (d *DB) GetByMessageID(messageID string) (*Message, error) {
 func (d *DB) GetByThread(threadID string) ([]*Message, error) {
 	rows, err := d.db.Query(`
 		SELECT id, message_id, thread_id, in_reply_to, refs, subject, subject_ct,
-		       from_addr, from_addr_ct, to_addrs, to_addrs_ct, cc_addrs, cc_addrs_ct,
-		       date, created_at,
+		       from_addr, to_addrs, cc_addrs, date, created_at,
 		       body_text, body_text_ct, body_html, body_html_ct,
 		       mailbox, flags, uid, size, fetched_body, account
 		FROM messages WHERE thread_id = ?
@@ -284,8 +289,7 @@ func (d *DB) GetByThread(threadID string) ([]*Message, error) {
 func (d *DB) GetAllByThread(threadID string) ([]*Message, error) {
 	rows, err := d.db.Query(`
 		SELECT id, message_id, thread_id, in_reply_to, refs, subject, subject_ct,
-		       from_addr, from_addr_ct, to_addrs, to_addrs_ct, cc_addrs, cc_addrs_ct,
-		       date, created_at,
+		       from_addr, to_addrs, cc_addrs, date, created_at,
 		       body_text, body_text_ct, body_html, body_html_ct,
 		       mailbox, flags, uid, size, fetched_body, account
 		FROM messages WHERE thread_id = ?
@@ -405,19 +409,19 @@ func (d *DB) GetRecipientAddresses() ([]string, error) {
 }
 
 // scanMessages scans rows into a slice of Message pointers. Caller's
-// SELECT must interleave each encrypted column's *_ct BLOB right after
-// its plaintext column, in this order: subject, from_addr, to_addrs,
-// cc_addrs, body_text, body_html.
+// SELECT must interleave subject_ct after subject and body_text_ct /
+// body_html_ct after their plaintext columns. from_addr/to_addrs/
+// cc_addrs stay plaintext (ADR-0001 §3 revision); their plaintext
+// values are scanned directly with no decrypt step.
 func (d *DB) scanMessages(rows *sql.Rows) ([]*Message, error) {
 	var msgs []*Message
 	for rows.Next() {
 		msg := &Message{}
 		var fetchedBody int
-		var subjectCT, fromAddrCT, toAddrsCT, ccAddrsCT, bodyTextCT, bodyHTMLCT []byte
+		var subjectCT, bodyTextCT, bodyHTMLCT []byte
 		err := rows.Scan(
 			&msg.ID, &msg.MessageID, &msg.ThreadID, &msg.InReplyTo, &msg.Refs, &msg.Subject, &subjectCT,
-			&msg.FromAddr, &fromAddrCT, &msg.ToAddrs, &toAddrsCT, &msg.CCAddrs, &ccAddrsCT,
-			&msg.Date, &msg.CreatedAt,
+			&msg.FromAddr, &msg.ToAddrs, &msg.CCAddrs, &msg.Date, &msg.CreatedAt,
 			&msg.BodyText, &bodyTextCT, &msg.BodyHTML, &bodyHTMLCT,
 			&msg.Mailbox, &msg.Flags, &msg.UID, &msg.Size, &fetchedBody, &msg.Account,
 		)
@@ -426,15 +430,6 @@ func (d *DB) scanMessages(rows *sql.Rows) ([]*Message, error) {
 		}
 		msg.FetchedBody = fetchedBody == 1
 		if msg.Subject, err = d.decryptSubject(msg.Subject, subjectCT); err != nil {
-			return nil, err
-		}
-		if msg.FromAddr, err = d.decryptAddr(msg.FromAddr, fromAddrCT); err != nil {
-			return nil, err
-		}
-		if msg.ToAddrs, err = d.decryptAddr(msg.ToAddrs, toAddrsCT); err != nil {
-			return nil, err
-		}
-		if msg.CCAddrs, err = d.decryptAddr(msg.CCAddrs, ccAddrsCT); err != nil {
 			return nil, err
 		}
 		if msg.BodyText, err = d.decryptBody(msg.BodyText, bodyTextCT); err != nil {

--- a/cli/internal/store/search.go
+++ b/cli/internal/store/search.go
@@ -5,11 +5,13 @@ import (
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/durian-dev/durian/cli/internal/dbcrypto"
 )
 
 // SearchCount returns the number of threads matching a query.
 func (d *DB) SearchCount(query string) (int, error) {
-	where, params, err := parseQuery(query)
+	where, params, err := d.parseQuery(query)
 	if err != nil {
 		return 0, fmt.Errorf("parse query: %w", err)
 	}
@@ -33,7 +35,7 @@ func (d *DB) Search(query string, limit int) ([]SearchResult, error) {
 		limit = 50
 	}
 
-	where, params, err := parseQuery(query)
+	where, params, err := d.parseQuery(query)
 	if err != nil {
 		return nil, fmt.Errorf("parse query: %w", err)
 	}
@@ -418,32 +420,44 @@ func (p *parser) parsePrimary() (exprNode, error) {
 // --- SQL generation ---
 
 // exprToSQL walks the expression tree and produces a SQL WHERE clause with parameters.
-func exprToSQL(node exprNode) (string, []interface{}, error) {
+// Promoted to a method on *DB so the bareExpr and subject: cases can reach the
+// FTSToken sub-key for tokenizing user input against messages_blind_fts.
+func (d *DB) exprToSQL(node exprNode) (string, []interface{}, error) {
 	switch n := node.(type) {
 	case *binaryExpr:
-		leftSQL, leftParams, err := exprToSQL(n.left)
+		leftSQL, leftParams, err := d.exprToSQL(n.left)
 		if err != nil {
 			return "", nil, err
 		}
-		rightSQL, rightParams, err := exprToSQL(n.right)
+		rightSQL, rightParams, err := d.exprToSQL(n.right)
 		if err != nil {
 			return "", nil, err
 		}
 		return "(" + leftSQL + " " + n.op + " " + rightSQL + ")", append(leftParams, rightParams...), nil
 
 	case *notExpr:
-		childSQL, childParams, err := exprToSQL(n.child)
+		childSQL, childParams, err := d.exprToSQL(n.child)
 		if err != nil {
 			return "", nil, err
 		}
 		return "NOT (" + childSQL + ")", childParams, nil
 
 	case *fieldExpr:
-		return fieldToSQL(n)
+		return d.fieldToSQL(n)
 
 	case *bareExpr:
-		return "m.id IN (SELECT rowid FROM messages_fts WHERE messages_fts MATCH ?)",
-			[]interface{}{n.value}, nil
+		// ADR-0001 step 7c: bare FTS search flips from the plaintext
+		// messages_fts to the blind-token messages_blind_fts. The
+		// user term is run through the same TokenizeFTS pipeline that
+		// populated the index in step 7a+b, so the hex tokens produced
+		// here line up with the tokens stored at write time.
+		toks := dbcrypto.TokenizeFTS(d.keyring.FTSToken, n.value)
+		if toks == "" {
+			// All-stop-words / punctuation-only input — never matches anything.
+			return "1=0", nil, nil
+		}
+		return "m.id IN (SELECT rowid FROM messages_blind_fts WHERE messages_blind_fts MATCH ?)",
+			[]interface{}{toks}, nil
 
 	case *starExpr:
 		return "1=1", nil, nil
@@ -454,7 +468,7 @@ func exprToSQL(node exprNode) (string, []interface{}, error) {
 }
 
 // parseQuery translates a search query into a SQL WHERE clause and parameters.
-func parseQuery(query string) (where string, params []interface{}, err error) {
+func (d *DB) parseQuery(query string) (where string, params []interface{}, err error) {
 	tokens := lex(query)
 	node, err := parse(tokens)
 	if err != nil {
@@ -463,11 +477,13 @@ func parseQuery(query string) (where string, params []interface{}, err error) {
 	if _, ok := node.(*starExpr); ok {
 		return "", nil, nil
 	}
-	return exprToSQL(node)
+	return d.exprToSQL(node)
 }
 
-// fieldToSQL converts a field expression into a SQL clause.
-func fieldToSQL(f *fieldExpr) (string, []interface{}, error) {
+// fieldToSQL converts a field expression into a SQL clause. Method on
+// *DB so the subject: case can tokenize the user query against the
+// FTSToken sub-key for messages_blind_fts (ADR-0001 step 7c).
+func (d *DB) fieldToSQL(f *fieldExpr) (string, []interface{}, error) {
 	switch f.field {
 	case "from":
 		return "m.from_addr LIKE ?", []interface{}{"%" + f.value + "%"}, nil
@@ -479,8 +495,15 @@ func fieldToSQL(f *fieldExpr) (string, []interface{}, error) {
 		return "m.cc_addrs LIKE ?", []interface{}{"%" + f.value + "%"}, nil
 
 	case "subject":
-		return "m.id IN (SELECT rowid FROM messages_fts WHERE messages_fts MATCH ?)",
-			[]interface{}{"subject:" + f.value}, nil
+		// ADR-0001 step 7c: subject: scoped FTS flips to messages_blind_fts.
+		// subject_tok:(tok1 tok2 ...) AND's each token against the
+		// subject_tok column only.
+		toks := dbcrypto.TokenizeFTS(d.keyring.FTSToken, f.value)
+		if toks == "" {
+			return "1=0", nil, nil
+		}
+		return "m.id IN (SELECT rowid FROM messages_blind_fts WHERE messages_blind_fts MATCH ?)",
+			[]interface{}{"subject_tok:(" + toks + ")"}, nil
 
 	case "tag":
 		return "EXISTS (SELECT 1 FROM tags WHERE tags.message_id = m.id AND tags.tag = ?)",

--- a/cli/internal/store/search.go
+++ b/cli/internal/store/search.go
@@ -451,7 +451,7 @@ func (d *DB) exprToSQL(node exprNode) (string, []interface{}, error) {
 		// user term is run through the same TokenizeFTS pipeline that
 		// populated the index in step 7a+b, so the hex tokens produced
 		// here line up with the tokens stored at write time.
-		toks := dbcrypto.TokenizeFTS(d.keyring.FTSToken, n.value)
+		toks := dbcrypto.TokenizeFTSQuery(d.keyring.FTSToken, n.value)
 		if toks == "" {
 			// All-stop-words / punctuation-only input — never matches anything.
 			return "1=0", nil, nil
@@ -498,7 +498,7 @@ func (d *DB) fieldToSQL(f *fieldExpr) (string, []interface{}, error) {
 		// ADR-0001 step 7c: subject: scoped FTS flips to messages_blind_fts.
 		// subject_tok:(tok1 tok2 ...) AND's each token against the
 		// subject_tok column only.
-		toks := dbcrypto.TokenizeFTS(d.keyring.FTSToken, f.value)
+		toks := dbcrypto.TokenizeFTSQuery(d.keyring.FTSToken, f.value)
 		if toks == "" {
 			return "1=0", nil, nil
 		}

--- a/cli/internal/store/store.go
+++ b/cli/internal/store/store.go
@@ -651,6 +651,45 @@ func (d *DB) migrate() error {
 		if _, err := d.db.Exec("UPDATE schema_version SET version = 15 WHERE rowid = 1"); err != nil {
 			return fmt.Errorf("migrate v14→v15 bump: %w", err)
 		}
+		version = 15
+	}
+
+	if version < 16 {
+		// ADR-0001 step 7 (a+b): blind-token FTS5 infrastructure.
+		// Stand up a parallel contentless FTS5 table that indexes
+		// HMAC-truncated tokens (no plaintext leaves the encrypted
+		// column world). The existing messages_fts table keeps serving
+		// search.go reads until step 7c flips the search path.
+		//
+		// contentless_delete=1 lets us DELETE FROM the FTS table by
+		// rowid (no FTS-specific 'delete' sentinel insert) — needed
+		// for the messages-DELETE trigger to stay simple.
+		stmts := []string{
+			`CREATE VIRTUAL TABLE IF NOT EXISTS messages_blind_fts USING fts5(
+				subject_tok, from_tok, to_tok, body_tok,
+				content='',
+				contentless_delete=1,
+				tokenize='unicode61 remove_diacritics 0'
+			)`,
+			// On messages DELETE, drop the parallel FTS row by rowid.
+			// INSERT/UPDATE maintenance happens Go-side (insertMessageTx /
+			// UpdateBody) since we need the Go tokenizer with the
+			// fts_token sub-key, which SQLite triggers can't reach.
+			`CREATE TRIGGER IF NOT EXISTS messages_blind_fts_ad AFTER DELETE ON messages BEGIN
+				DELETE FROM messages_blind_fts WHERE rowid = old.id;
+			END`,
+		}
+		for _, s := range stmts {
+			if _, err := d.db.Exec(s); err != nil {
+				return fmt.Errorf("migrate v15→v16 schema: %w", err)
+			}
+		}
+		if err := d.backfillBlindFTS(); err != nil {
+			return fmt.Errorf("migrate v15→v16 backfill: %w", err)
+		}
+		if _, err := d.db.Exec("UPDATE schema_version SET version = 16 WHERE rowid = 1"); err != nil {
+			return fmt.Errorf("migrate v15→v16 bump: %w", err)
+		}
 	}
 
 	return nil
@@ -850,6 +889,102 @@ func (d *DB) backfillBodyCt() error {
 		}
 		if _, err := stmt.Exec(textCT, htmlCT, p.id); err != nil {
 			return fmt.Errorf("update id=%d: %w", p.id, err)
+		}
+	}
+	return tx.Commit()
+}
+
+// blindTokens returns the four space-separated FTS5-ready token strings
+// for one message in the order (subject_tok, from_tok, to_tok, body_tok).
+// Each field is run through dbcrypto.TokenizeFTS under the FTSToken
+// sub-key. Empty plaintext maps to "" — FTS5 stores empty columns fine.
+func (d *DB) blindTokens(subject, fromAddr, toAddrs, bodyText string) (sTok, fTok, tTok, bTok string) {
+	k := d.keyring.FTSToken
+	return dbcrypto.TokenizeFTS(k, subject),
+		dbcrypto.TokenizeFTS(k, fromAddr),
+		dbcrypto.TokenizeFTS(k, toAddrs),
+		dbcrypto.TokenizeFTS(k, bodyText)
+}
+
+// backfillBlindFTS populates messages_blind_fts for every existing row.
+// Reads plaintext (still present until step 7e) via the encrypted-ct
+// columns where available so the tokenization is identical to what
+// step-7c reads will produce after the plaintext columns die.
+//
+// Streams via row iteration rather than batching into RAM because body
+// payloads can be MB-sized on real mail and the working set across 20k+
+// messages would otherwise top a gigabyte.
+func (d *DB) backfillBlindFTS() error {
+	if d.keyring == nil || d.keyring.FTSToken == nil {
+		return fmt.Errorf("no keyring available for blind FTS backfill")
+	}
+	tx, err := d.db.Begin()
+	if err != nil {
+		return fmt.Errorf("begin tx: %w", err)
+	}
+	defer tx.Rollback() //nolint:errcheck
+
+	// Skip rows that already have a blind FTS entry (idempotent retry).
+	// Joining against messages_blind_fts directly is awkward (contentless
+	// FTS5 doesn't expose a real table), so use NOT EXISTS on rowid.
+	// COALESCE the plaintext columns to '' — early-schema messages can
+	// have NULL subject/from/to/body where the new schema treats them as
+	// empty strings. NULL would error scanning into a *string.
+	rows, err := tx.Query(`SELECT m.id,
+		COALESCE(m.subject,    ''), m.subject_ct,
+		COALESCE(m.from_addr,  ''), m.from_addr_ct,
+		COALESCE(m.to_addrs,   ''), m.to_addrs_ct,
+		COALESCE(m.body_text,  ''), m.body_text_ct
+		FROM messages m
+		WHERE NOT EXISTS (SELECT 1 FROM messages_blind_fts WHERE rowid = m.id)`)
+	if err != nil {
+		return fmt.Errorf("select rows: %w", err)
+	}
+	type pending struct {
+		id                                                  int64
+		subject, fromAddr, toAddrs, bodyText                 string
+	}
+	var batch []pending
+	for rows.Next() {
+		var p pending
+		var sCT, fCT, tCT, bCT []byte
+		if err := rows.Scan(&p.id, &p.subject, &sCT, &p.fromAddr, &fCT, &p.toAddrs, &tCT, &p.bodyText, &bCT); err != nil {
+			rows.Close()
+			return fmt.Errorf("scan: %w", err)
+		}
+		if p.subject, err = d.decryptSubject(p.subject, sCT); err != nil {
+			rows.Close()
+			return fmt.Errorf("decrypt subject id=%d: %w", p.id, err)
+		}
+		if p.fromAddr, err = d.decryptAddr(p.fromAddr, fCT); err != nil {
+			rows.Close()
+			return fmt.Errorf("decrypt from_addr id=%d: %w", p.id, err)
+		}
+		if p.toAddrs, err = d.decryptAddr(p.toAddrs, tCT); err != nil {
+			rows.Close()
+			return fmt.Errorf("decrypt to_addrs id=%d: %w", p.id, err)
+		}
+		if p.bodyText, err = d.decryptBody(p.bodyText, bCT); err != nil {
+			rows.Close()
+			return fmt.Errorf("decrypt body_text id=%d: %w", p.id, err)
+		}
+		batch = append(batch, p)
+	}
+	rows.Close()
+	if err := rows.Err(); err != nil {
+		return fmt.Errorf("iterate rows: %w", err)
+	}
+
+	stmt, err := tx.Prepare(`INSERT INTO messages_blind_fts(rowid, subject_tok, from_tok, to_tok, body_tok)
+		VALUES (?, ?, ?, ?, ?)`)
+	if err != nil {
+		return fmt.Errorf("prepare insert: %w", err)
+	}
+	defer stmt.Close()
+	for _, p := range batch {
+		sTok, fTok, tTok, bTok := d.blindTokens(p.subject, p.fromAddr, p.toAddrs, p.bodyText)
+		if _, err := stmt.Exec(p.id, sTok, fTok, tTok, bTok); err != nil {
+			return fmt.Errorf("insert id=%d: %w", p.id, err)
 		}
 	}
 	return tx.Commit()

--- a/cli/internal/store/store.go
+++ b/cli/internal/store/store.go
@@ -690,6 +690,32 @@ func (d *DB) migrate() error {
 		if _, err := d.db.Exec("UPDATE schema_version SET version = 16 WHERE rowid = 1"); err != nil {
 			return fmt.Errorf("migrate v15→v16 bump: %w", err)
 		}
+		version = 16
+	}
+
+	if version < 17 {
+		// ADR-0001 step 7d (prep for 7e): drop the dead from_addr_ct /
+		// to_addrs_ct / cc_addrs_ct columns the v11→v12 migration added.
+		// During that step the addresses were on the encrypt-at-rest
+		// roadmap; ADR-0001 §3 was updated to keep them plaintext
+		// (substring search UX outweighs the asymmetric protection vs.
+		// wire-plaintext leak). The BLOB columns are written but never
+		// read, so dropping them is pure cleanup. SQLite 3.35+ supports
+		// ALTER TABLE DROP COLUMN; idempotent via PRAGMA table_info.
+		for _, col := range []string{"from_addr_ct", "to_addrs_ct", "cc_addrs_ct"} {
+			has, err := hasColumn(d.db, "messages", col)
+			if err != nil {
+				return fmt.Errorf("migrate v16→v17 inspect %s: %w", col, err)
+			}
+			if has {
+				if _, err := d.db.Exec("ALTER TABLE messages DROP COLUMN " + col); err != nil {
+					return fmt.Errorf("migrate v16→v17 drop %s: %w", col, err)
+				}
+			}
+		}
+		if _, err := d.db.Exec("UPDATE schema_version SET version = 17 WHERE rowid = 1"); err != nil {
+			return fmt.Errorf("migrate v16→v17 bump: %w", err)
+		}
 	}
 
 	return nil
@@ -930,39 +956,33 @@ func (d *DB) backfillBlindFTS() error {
 	// COALESCE the plaintext columns to '' — early-schema messages can
 	// have NULL subject/from/to/body where the new schema treats them as
 	// empty strings. NULL would error scanning into a *string.
+	// from_addr/to_addrs are plaintext per ADR-0001 §3 revision; no
+	// decrypt needed here.
 	rows, err := tx.Query(`SELECT m.id,
-		COALESCE(m.subject,    ''), m.subject_ct,
-		COALESCE(m.from_addr,  ''), m.from_addr_ct,
-		COALESCE(m.to_addrs,   ''), m.to_addrs_ct,
-		COALESCE(m.body_text,  ''), m.body_text_ct
+		COALESCE(m.subject,   ''), m.subject_ct,
+		COALESCE(m.from_addr, ''),
+		COALESCE(m.to_addrs,  ''),
+		COALESCE(m.body_text, ''), m.body_text_ct
 		FROM messages m
 		WHERE NOT EXISTS (SELECT 1 FROM messages_blind_fts WHERE rowid = m.id)`)
 	if err != nil {
 		return fmt.Errorf("select rows: %w", err)
 	}
 	type pending struct {
-		id                                                  int64
-		subject, fromAddr, toAddrs, bodyText                 string
+		id                                  int64
+		subject, fromAddr, toAddrs, bodyText string
 	}
 	var batch []pending
 	for rows.Next() {
 		var p pending
-		var sCT, fCT, tCT, bCT []byte
-		if err := rows.Scan(&p.id, &p.subject, &sCT, &p.fromAddr, &fCT, &p.toAddrs, &tCT, &p.bodyText, &bCT); err != nil {
+		var sCT, bCT []byte
+		if err := rows.Scan(&p.id, &p.subject, &sCT, &p.fromAddr, &p.toAddrs, &p.bodyText, &bCT); err != nil {
 			rows.Close()
 			return fmt.Errorf("scan: %w", err)
 		}
 		if p.subject, err = d.decryptSubject(p.subject, sCT); err != nil {
 			rows.Close()
 			return fmt.Errorf("decrypt subject id=%d: %w", p.id, err)
-		}
-		if p.fromAddr, err = d.decryptAddr(p.fromAddr, fCT); err != nil {
-			rows.Close()
-			return fmt.Errorf("decrypt from_addr id=%d: %w", p.id, err)
-		}
-		if p.toAddrs, err = d.decryptAddr(p.toAddrs, tCT); err != nil {
-			rows.Close()
-			return fmt.Errorf("decrypt to_addrs id=%d: %w", p.id, err)
 		}
 		if p.bodyText, err = d.decryptBody(p.bodyText, bCT); err != nil {
 			rows.Close()

--- a/cli/internal/store/store_test.go
+++ b/cli/internal/store/store_test.go
@@ -42,8 +42,8 @@ func TestOpenAndInit(t *testing.T) {
 	if err != nil {
 		t.Fatalf("read version: %v", err)
 	}
-	if version != 16 {
-		t.Errorf("version = %d, want 16", version)
+	if version != 17 {
+		t.Errorf("version = %d, want 17", version)
 	}
 }
 
@@ -168,8 +168,8 @@ func TestMigrateV9_PopulatesMailboxesAndAccounts(t *testing.T) {
 	if err := db.QueryRow("SELECT version FROM schema_version WHERE rowid = 1").Scan(&version); err != nil {
 		t.Fatalf("read version: %v", err)
 	}
-	if version != 16 {
-		t.Fatalf("version = %d, want 16", version)
+	if version != 17 {
+		t.Fatalf("version = %d, want 17", version)
 	}
 
 	// mailboxes must contain exactly INBOX and Drafts (case-collapsed).
@@ -349,8 +349,8 @@ func TestMigrateV10_BackfillsSubjectCt(t *testing.T) {
 	if err := sd.db.QueryRow("SELECT version FROM schema_version WHERE rowid = 1").Scan(&version); err != nil {
 		t.Fatalf("read version: %v", err)
 	}
-	if version != 16 {
-		t.Fatalf("version = %d, want 16", version)
+	if version != 17 {
+		t.Fatalf("version = %d, want 17", version)
 	}
 
 	// Raw check: subject_ct must be NULL for empty subject, non-NULL for the
@@ -483,8 +483,8 @@ func TestMigrateV11_BackfillsBodyCt(t *testing.T) {
 	if err := sd.db.QueryRow("SELECT version FROM schema_version WHERE rowid = 1").Scan(&version); err != nil {
 		t.Fatalf("read version: %v", err)
 	}
-	if version != 16 {
-		t.Fatalf("version = %d, want 16", version)
+	if version != 17 {
+		t.Fatalf("version = %d, want 17", version)
 	}
 
 	// Raw check: body_text_ct populated only where body_text non-empty.
@@ -545,150 +545,6 @@ func TestMigrateV11_BackfillsBodyCt(t *testing.T) {
 	}
 }
 
-// TestMigrateV12_BackfillsAddrsCt seeds a v11-shaped DB with a mix of
-// from/to/cc populations and asserts the v11→v12 migration encrypts
-// only the non-empty addresses, leaves the rest NULL, and that
-// GetByMessageID round-trips through decryptAddr.
-func TestMigrateV12_BackfillsAddrsCt(t *testing.T) {
-	dbPath := filepath.Join(t.TempDir(), "step6-addrs.db")
-	seedDB, err := sql.Open("sqlite", dbPath)
-	if err != nil {
-		t.Fatalf("open seed: %v", err)
-	}
-	seed := []string{
-		`CREATE TABLE schema_version (version INTEGER NOT NULL)`,
-		`INSERT INTO schema_version (rowid, version) VALUES (1, 11)`,
-		`CREATE TABLE messages (
-			id INTEGER PRIMARY KEY AUTOINCREMENT,
-			message_id TEXT NOT NULL,
-			thread_id TEXT NOT NULL,
-			in_reply_to TEXT,
-			refs TEXT,
-			subject TEXT,
-			subject_ct BLOB,
-			from_addr TEXT,
-			to_addrs TEXT,
-			cc_addrs TEXT,
-			date INTEGER,
-			created_at INTEGER NOT NULL,
-			body_text TEXT,
-			body_text_ct BLOB,
-			body_html TEXT,
-			body_html_ct BLOB,
-			mailbox TEXT,
-			flags TEXT,
-			uid INTEGER DEFAULT 0,
-			size INTEGER DEFAULT 0,
-			fetched_body INTEGER DEFAULT 0,
-			account TEXT DEFAULT '',
-			mailbox_id INTEGER,
-			account_id INTEGER,
-			is_seen INTEGER NOT NULL DEFAULT 0,
-			is_flagged INTEGER NOT NULL DEFAULT 0,
-			is_deleted INTEGER NOT NULL DEFAULT 0,
-			UNIQUE(message_id, account)
-		)`,
-		`INSERT INTO messages (message_id, thread_id, in_reply_to, refs, subject,
-		    from_addr, to_addrs, cc_addrs, date, created_at,
-		    body_text, body_html, mailbox, flags) VALUES
-		   ('m1', 't1', '', '', '', 'a@x.com',  'b@x.com',  '',         0, 1, '', '', '', ''),
-		   ('m2', 't2', '', '', '', '',         '',         'c@x.com',  0, 2, '', '', '', ''),
-		   ('m3', 't3', '', '', '', 'a@x.com',  'b@x.com',  'c@x.com',  0, 3, '', '', '', ''),
-		   ('m4', 't4', '', '', '', '',         '',         '',         0, 4, '', '', '', '')`,
-		`CREATE VIRTUAL TABLE messages_fts USING fts5(
-			subject, from_addr, to_addrs, body_text,
-			content='messages',
-			content_rowid='id'
-		)`,
-		`INSERT INTO messages_fts(rowid, subject, from_addr, to_addrs, body_text)
-		 SELECT id, COALESCE(subject, ''), COALESCE(from_addr, ''), COALESCE(to_addrs, ''), COALESCE(body_text, '')
-		 FROM messages`,
-	}
-	for _, stmt := range seed {
-		if _, err := seedDB.Exec(stmt); err != nil {
-			t.Fatalf("seed: %v\nstmt: %s", err, stmt)
-		}
-	}
-	seedDB.Close()
-
-	sd, err := Open(dbPath, testKeyring(t))
-	if err != nil {
-		t.Fatalf("store open: %v", err)
-	}
-	t.Cleanup(func() { sd.Close() })
-	if err := sd.Init(); err != nil {
-		t.Fatalf("init/migrate: %v", err)
-	}
-
-	var version int
-	if err := sd.db.QueryRow("SELECT version FROM schema_version WHERE rowid = 1").Scan(&version); err != nil {
-		t.Fatalf("read version: %v", err)
-	}
-	if version != 16 {
-		t.Fatalf("version = %d, want 16", version)
-	}
-
-	rows, err := sd.db.Query(`SELECT message_id, from_addr, from_addr_ct,
-		to_addrs, to_addrs_ct, cc_addrs, cc_addrs_ct
-		FROM messages ORDER BY message_id`)
-	if err != nil {
-		t.Fatalf("query: %v", err)
-	}
-	defer rows.Close()
-	type row struct {
-		id                                       string
-		from, to, cc                             string
-		fromCT, toCT, ccCT                       []byte
-	}
-	var got []row
-	for rows.Next() {
-		var r row
-		if err := rows.Scan(&r.id, &r.from, &r.fromCT, &r.to, &r.toCT, &r.cc, &r.ccCT); err != nil {
-			t.Fatalf("scan: %v", err)
-		}
-		got = append(got, r)
-	}
-	if len(got) != 4 {
-		t.Fatalf("rows = %d, want 4", len(got))
-	}
-	checks := []struct {
-		idx                                 int
-		wantFromCT, wantToCT, wantCCCT bool
-	}{
-		{0, true, true, false},
-		{1, false, false, true},
-		{2, true, true, true},
-		{3, false, false, false},
-	}
-	for _, c := range checks {
-		r := got[c.idx]
-		if (len(r.fromCT) > 0) != c.wantFromCT {
-			t.Errorf("%s from_addr_ct populated=%v, want %v", r.id, len(r.fromCT) > 0, c.wantFromCT)
-		}
-		if (len(r.toCT) > 0) != c.wantToCT {
-			t.Errorf("%s to_addrs_ct populated=%v, want %v", r.id, len(r.toCT) > 0, c.wantToCT)
-		}
-		if (len(r.ccCT) > 0) != c.wantCCCT {
-			t.Errorf("%s cc_addrs_ct populated=%v, want %v", r.id, len(r.ccCT) > 0, c.wantCCCT)
-		}
-	}
-
-	// Round-trip via the production read path.
-	for _, want := range got {
-		msg, err := sd.GetByMessageID(want.id)
-		if err != nil {
-			t.Fatalf("get %s: %v", want.id, err)
-		}
-		if msg == nil {
-			t.Fatalf("get %s: nil", want.id)
-		}
-		if msg.FromAddr != want.from || msg.ToAddrs != want.to || msg.CCAddrs != want.cc {
-			t.Errorf("%s addrs mismatch: got (%q/%q/%q), want (%q/%q/%q)",
-				want.id, msg.FromAddr, msg.ToAddrs, msg.CCAddrs,
-				want.from, want.to, want.cc)
-		}
-	}
-}
 
 // TestBlindFTS_InsertAndMatch verifies the step-7 (a+b) round-trip:
 // a message inserted via the store API populates messages_blind_fts,

--- a/cli/internal/store/store_test.go
+++ b/cli/internal/store/store_test.go
@@ -42,8 +42,8 @@ func TestOpenAndInit(t *testing.T) {
 	if err != nil {
 		t.Fatalf("read version: %v", err)
 	}
-	if version != 15 {
-		t.Errorf("version = %d, want 15", version)
+	if version != 16 {
+		t.Errorf("version = %d, want 16", version)
 	}
 }
 
@@ -168,8 +168,8 @@ func TestMigrateV9_PopulatesMailboxesAndAccounts(t *testing.T) {
 	if err := db.QueryRow("SELECT version FROM schema_version WHERE rowid = 1").Scan(&version); err != nil {
 		t.Fatalf("read version: %v", err)
 	}
-	if version != 15 {
-		t.Fatalf("version = %d, want 15", version)
+	if version != 16 {
+		t.Fatalf("version = %d, want 16", version)
 	}
 
 	// mailboxes must contain exactly INBOX and Drafts (case-collapsed).
@@ -349,8 +349,8 @@ func TestMigrateV10_BackfillsSubjectCt(t *testing.T) {
 	if err := sd.db.QueryRow("SELECT version FROM schema_version WHERE rowid = 1").Scan(&version); err != nil {
 		t.Fatalf("read version: %v", err)
 	}
-	if version != 15 {
-		t.Fatalf("version = %d, want 15", version)
+	if version != 16 {
+		t.Fatalf("version = %d, want 16", version)
 	}
 
 	// Raw check: subject_ct must be NULL for empty subject, non-NULL for the
@@ -483,8 +483,8 @@ func TestMigrateV11_BackfillsBodyCt(t *testing.T) {
 	if err := sd.db.QueryRow("SELECT version FROM schema_version WHERE rowid = 1").Scan(&version); err != nil {
 		t.Fatalf("read version: %v", err)
 	}
-	if version != 15 {
-		t.Fatalf("version = %d, want 15", version)
+	if version != 16 {
+		t.Fatalf("version = %d, want 16", version)
 	}
 
 	// Raw check: body_text_ct populated only where body_text non-empty.
@@ -624,8 +624,8 @@ func TestMigrateV12_BackfillsAddrsCt(t *testing.T) {
 	if err := sd.db.QueryRow("SELECT version FROM schema_version WHERE rowid = 1").Scan(&version); err != nil {
 		t.Fatalf("read version: %v", err)
 	}
-	if version != 15 {
-		t.Fatalf("version = %d, want 15", version)
+	if version != 16 {
+		t.Fatalf("version = %d, want 16", version)
 	}
 
 	rows, err := sd.db.Query(`SELECT message_id, from_addr, from_addr_ct,
@@ -687,6 +687,54 @@ func TestMigrateV12_BackfillsAddrsCt(t *testing.T) {
 				want.id, msg.FromAddr, msg.ToAddrs, msg.CCAddrs,
 				want.from, want.to, want.cc)
 		}
+	}
+}
+
+// TestBlindFTS_InsertAndMatch verifies the step-7 (a+b) round-trip:
+// a message inserted via the store API populates messages_blind_fts,
+// and a token computed independently with the same FTSToken sub-key
+// matches the right rowid via SQLite's FTS5 MATCH operator.
+func TestBlindFTS_InsertAndMatch(t *testing.T) {
+	db := newTestDB(t)
+	kr := testKeyring(t)
+
+	msg := &Message{
+		MessageID: "blindtest@example",
+		Subject:   "Hello Blindtoken World",
+		FromAddr:  "alice@example.com",
+		ToAddrs:   "bob@example.com",
+		BodyText:  "the quick brown fox",
+		CreatedAt: 1,
+		Account:   "acct1",
+	}
+	if err := db.InsertMessage(msg); err != nil {
+		t.Fatalf("insert: %v", err)
+	}
+
+	tok := dbcrypto.TokenizeFTS(kr.FTSToken, "blindtoken")
+	if tok == "" {
+		t.Fatal("tokenizer returned empty for non-empty input")
+	}
+	var rowid int64
+	err := db.db.QueryRow(
+		`SELECT rowid FROM messages_blind_fts WHERE subject_tok MATCH ? LIMIT 1`,
+		tok,
+	).Scan(&rowid)
+	if err != nil {
+		t.Fatalf("blind fts match: %v", err)
+	}
+	if rowid != msg.ID {
+		t.Errorf("rowid = %d, want %d", rowid, msg.ID)
+	}
+
+	notInSubject := dbcrypto.TokenizeFTS(kr.FTSToken, "kraftfahrzeughaftpflichtversicherung")
+	var dummy int64
+	err = db.db.QueryRow(
+		`SELECT rowid FROM messages_blind_fts WHERE subject_tok MATCH ? LIMIT 1`,
+		notInSubject,
+	).Scan(&dummy)
+	if err == nil {
+		t.Errorf("blind fts matched a word not in any subject (rowid=%d)", dummy)
 	}
 }
 

--- a/docs/content/docs/developers/design/0001-mail-content-encryption-at-rest.md
+++ b/docs/content/docs/developers/design/0001-mail-content-encryption-at-rest.md
@@ -106,11 +106,16 @@ no new direct dependency added).
 | `body_key`         | `"durian/v1/body"`       | encrypts `messages.body_text/html`     |
 | `subject_key`      | `"durian/v1/subject"`    | encrypts `messages.subject`            |
 | `headers_key`      | `"durian/v1/headers"`    | encrypts `message_headers.value`       |
-| `addrs_key`        | `"durian/v1/addrs"`      | encrypts `from_addr`, `to_addrs`, `cc_addrs` |
+| `addrs_key`        | `"durian/v1/addrs"`      | **(retired, see §3)** previously encrypted `from_addr`, `to_addrs`, `cc_addrs` |
 | `draft_key`        | `"durian/v1/draft"`      | encrypts `local_drafts.draft_json`, `outbox.draft_json` |
 | `contact_key`      | `"durian/v1/contact"`    | encrypts `contacts.email`, `contacts.name` |
 | `fts_token_key`    | `"durian/v1/fts-token"`  | HMAC key for blind FTS5 tokens (§4)    |
 | `meta_key`         | `"durian/v1/meta"`       | encrypts `mailbox` name, custom `flags`, `account` string |
+
+`addrs_key` is derived for backward-compatibility (the v11→v12 migration
+populated `from_addr_ct` / `to_addrs_ct` / `cc_addrs_ct` columns under
+this key) but no current read or write path consumes it — see §3 for
+why the addresses ended up staying plaintext.
 
 Keychain layout (new):
 
@@ -134,11 +139,38 @@ migration. Migrations are additive, gated on a new `schema_version` step.
 | Old column      | New column       | Notes                            |
 | --------------- | ---------------- | -------------------------------- |
 | `subject TEXT`  | `subject BLOB`   | encrypted with `subject_key`     |
-| `from_addr TEXT`| `from_addr BLOB` | encrypted with `addrs_key`       |
-| `to_addrs TEXT` | `to_addrs BLOB`  | encrypted with `addrs_key`       |
-| `cc_addrs TEXT` | `cc_addrs BLOB`  | encrypted with `addrs_key`       |
 | `body_text TEXT`| `body_text BLOB` | encrypted with `body_key`        |
 | `body_html TEXT`| `body_html BLOB` | encrypted with `body_key`        |
+
+`from_addr`, `to_addrs`, `cc_addrs` **stay plaintext TEXT** — moved
+from the encrypted set during implementation. Rationale: these
+addresses are already plaintext on the wire (IMAP server logs,
+recipient-side `From:` headers, anti-spam routing, sending-server
+`Return-Path:`), at every Mail Transfer Agent they cross, and in the
+recipient's Sent folder. Encrypting them at rest while they shout on
+the wire is an asymmetric, low-value tradeoff. The two implementable
+alternatives both fail their cost/benefit test:
+
+- **Determinstic-HMAC search tokens** ([Naveed et al, "Inference
+  Attacks on Property-Preserving Encrypted Databases", CCS 2015])
+  enable substring search but leak token-frequency tables that are
+  trivially attackable for address-class data — `com`, `gma`, `info`,
+  `support` are unambiguous markers in any normal mailbox.
+- **Char-trigram FTS5** preserves substring-search UX but produces a
+  dense, skewed frequency distribution that yields *strictly more*
+  leakage than the plaintext-on-disk we'd be trying to avoid (the
+  attacker who can build a trigram histogram over your DB already has
+  the file; the plaintext just spares them the statistical step).
+
+The cost side: `from:partial` substring queries (e.g. `from:ali`
+matching `alice@example.com`) are a real UX habit that any
+blind-FTS-MATCH path breaks at word boundary. Acceptable plaintext
+leak, undebatable UX preservation.
+
+Out of scope for V1: an opt-in power-user encrypt-from-to flag for
+threat models where the local DB is genuinely the only place these
+addresses live (e.g. an air-gapped mail archive). Will get its own
+ADR if asked for.
 
 Folder names, IMAP keywords and account email addresses can themselves be
 sensitive (`Archive/Healthcare`, `Drafts/Resignation`, `$Confidential`,
@@ -205,12 +237,10 @@ trigger replacement code path):
    does not ship a UAX #29 word-segmenter. Drop tokens that contain only
    punctuation or whitespace. Stop-words are **not** dropped (see Threat
    Model §6).
-3. **Address-field special case** (subject/body skip this step). For each
-   `local@domain` match in `from_addr`/`to_addrs`/`cc_addrs`, emit three
-   tokens: `local`, `domain`, and `local@domain`. Rationale: users expect
-   both "all mail from alice" (local-part) and "all mail from example.com"
-   (domain) to work; keeping the full address as a third token avoids
-   losing a bigram across the `@` boundary.
+3. **(retired)** Earlier drafts had an address-field special case here that
+   emitted `local`, `domain`, `local@domain` tokens. With `from_addr`,
+   `to_addrs`, `cc_addrs` now kept plaintext (see §3), the special case
+   is gone — address search uses `LIKE` on the plaintext column directly.
 4. For each token `t`: `tok = base32(truncate(HMAC-SHA256(fts_token_key, t), 10))`.
    Output is a 16-char ASCII string, FTS5-tokenizer-safe. 80-bit truncation
    is chosen over 64 bit to raise the cost of long-term token-frequency
@@ -226,12 +256,18 @@ FTS5 schema:
 ```sql
 CREATE VIRTUAL TABLE messages_fts USING fts5(
     subject_tokens,        -- unigrams + bigrams for subject
-    addrs_tokens,          -- unigrams + bigrams for from/to/cc combined
     body_tokens,           -- unigrams + bigrams for body_text
     content='',            -- contentless: we never store plaintext here
     tokenize='ascii'       -- input is already opaque base32 ASCII
 );
 ```
+
+The implementation (`store/store.go` v15→v16 migration) currently uses
+the column names `subject_tok` / `body_tok` and an `unicode61` tokenizer
+(plus `from_tok` / `to_tok` columns that are kept for the v11→v12
+migration's column-set but unused by the read path — see §3 on address
+plaintext). The ADR-vs-reality drift is intentional during the
+roll-out; the final §6 step-7e cleanup squares them up.
 
 Search at runtime:
 
@@ -341,6 +377,21 @@ Does **not** defend against:
   `refs` (see §3): thread topology and sometimes provider domain remain
   observable. Mitigation: none in V1 — a future ADR may revisit if a
   realistic threat model demands it.
+- Information leakage from `from_addr` / `to_addrs` / `cc_addrs` (see
+  §3): an attacker with the DB file can read every sender/recipient
+  address verbatim plus the frequency of correspondence per address —
+  enough to reconstruct the user's communication graph. Mitigation:
+  none, deliberately. The same data is already exposed at the IMAP
+  server, all MTAs in transit, the recipient's Sent folder and
+  anti-spam routing logs; encrypting it at rest while it shouts on
+  the wire is asymmetric protection. The two implementable encrypted
+  alternatives both fail their cost/benefit test (deterministic-HMAC
+  search tokens leak token-frequency tables — Naveed et al CCS 2015;
+  char-trigram FTS5 leaks dense skewed trigram frequencies that yield
+  *more* information than the plaintext we would be hiding). Future
+  ADR may add an opt-in encrypt-from-to flag for users whose threat
+  model puts the local DB as the genuinely-only-place these addresses
+  live (air-gapped archive, etc.).
 
 ### Threat-actor personas
 
@@ -623,7 +674,11 @@ Resolved (kept here for traceability):
 - ~~Token truncation width.~~ → 80 bit (§4). Resolved in response to
   early-review feedback re: token-frequency correlation across snapshots.
 - ~~Address tokenization.~~ → emit three tokens per address (local,
-  domain, full). Resolved in §4 step 3.
+  domain, full). ~~Resolved in §4 step 3.~~ **Superseded:** addresses
+  themselves moved to plaintext (see §3 "from_addr/to_addrs/cc_addrs
+  stay plaintext TEXT" + §6 threat-model bullet). Substring search
+  served by `LIKE` on the plaintext column; no FTS5 address tokens
+  exist in V1.
 - ~~Mailbox / flags / account plaintext leak.~~ → encrypted, with integer
   surrogate columns for indexing (§3). Resolved in response to early-review
   feedback.


### PR DESCRIPTION
## Summary

Flip the read path from the plaintext \`messages_fts\` to the blind-token \`messages_blind_fts\` introduced in step 7 a+b. User queries are tokenized with \`TokenizeFTSQuery\` (unigrams only, no bigrams — emitting query-time bigrams would accidentally turn word-AND into phrase-match; bigram phrase support arrives in a later sub-step).

Stacked on top of #241 (step 7 a+b).

## Test plan

- [x] All CLI unit tests pass.
- [x] Cumulative CI on the rolled-up stack via #240 (rebased onto main): all 10 checks green.