### PR TITLE
ADR-0001 step 7d — keep from/to/cc plaintext + drop dead addrs_ct columns + search-side cleanups

### DIFF
--- a/cli/internal/dbcrypto/tokenize.go
+++ b/cli/internal/dbcrypto/tokenize.go
@@ -54,6 +54,26 @@ func TokenizeFTS(key []byte, plaintext string) string {
 	return strings.Join(out, " ")
 }
 
+// TokenizeFTSQuery returns the same per-word HMAC tokens TokenizeFTS
+// produces but WITHOUT the adjacent-pair bigrams. Use this on the
+// read side for plain word-AND queries — emitting the index-time
+// bigrams as additional query tokens would AND-require the searcher's
+// word pair to also appear consecutively in the source, turning a
+// word-AND query into a phrase-match by accident. Phrase-query
+// support reuses TokenizeFTS (with bigrams) once the parser learns
+// quote-for-phrase syntax.
+func TokenizeFTSQuery(key []byte, plaintext string) string {
+	words := wordsForFTS(plaintext)
+	if len(words) == 0 {
+		return ""
+	}
+	out := make([]string, len(words))
+	for i, w := range words {
+		out[i] = hmacHex(key, []byte(w))
+	}
+	return strings.Join(out, " ")
+}
+
 // wordsForFTS runs plaintext through the segment+normalize pipeline,
 // returning the lowercase word forms ready to HMAC. Exposed (lowercase)
 // for tests only — production callers always go through TokenizeFTS.

--- a/cli/internal/store/headers.go
+++ b/cli/internal/store/headers.go
@@ -65,9 +65,10 @@ func (d *DB) GetMessageDBID(messageID, account string) (int64, error) {
 }
 
 // AllMessages returns all messages with fields needed for rule matching.
+// from_addr/to_addrs/cc_addrs are plaintext (ADR-0001 §3 revision).
 func (d *DB) AllMessages() ([]*Message, error) {
 	rows, err := d.db.Query(`SELECT id, message_id, subject, subject_ct,
-		from_addr, from_addr_ct, to_addrs, to_addrs_ct, cc_addrs, cc_addrs_ct,
+		from_addr, to_addrs, cc_addrs,
 		body_text, body_text_ct, account FROM messages`)
 	if err != nil {
 		return nil, fmt.Errorf("query messages: %w", err)
@@ -77,22 +78,13 @@ func (d *DB) AllMessages() ([]*Message, error) {
 	var msgs []*Message
 	for rows.Next() {
 		m := &Message{}
-		var subjectCT, fromAddrCT, toAddrsCT, ccAddrsCT, bodyTextCT []byte
+		var subjectCT, bodyTextCT []byte
 		if err := rows.Scan(&m.ID, &m.MessageID, &m.Subject, &subjectCT,
-			&m.FromAddr, &fromAddrCT, &m.ToAddrs, &toAddrsCT, &m.CCAddrs, &ccAddrsCT,
+			&m.FromAddr, &m.ToAddrs, &m.CCAddrs,
 			&m.BodyText, &bodyTextCT, &m.Account); err != nil {
 			return nil, fmt.Errorf("scan message: %w", err)
 		}
 		if m.Subject, err = d.decryptSubject(m.Subject, subjectCT); err != nil {
-			return nil, err
-		}
-		if m.FromAddr, err = d.decryptAddr(m.FromAddr, fromAddrCT); err != nil {
-			return nil, err
-		}
-		if m.ToAddrs, err = d.decryptAddr(m.ToAddrs, toAddrsCT); err != nil {
-			return nil, err
-		}
-		if m.CCAddrs, err = d.decryptAddr(m.CCAddrs, ccAddrsCT); err != nil {
 			return nil, err
 		}
 		if m.BodyText, err = d.decryptBody(m.BodyText, bodyTextCT); err != nil {

--- a/cli/internal/store/messages.go
+++ b/cli/internal/store/messages.go
@@ -66,19 +66,6 @@ func (d *DB) insertMessageTx(tx *sql.Tx, msg *Message) error {
 	if err != nil {
 		return fmt.Errorf("encrypt body_html: %w", err)
 	}
-	// ADR-0001 step 6: addrs columns.
-	fromAddrCT, err := d.encryptAddr(msg.FromAddr)
-	if err != nil {
-		return fmt.Errorf("encrypt from_addr: %w", err)
-	}
-	toAddrsCT, err := d.encryptAddr(msg.ToAddrs)
-	if err != nil {
-		return fmt.Errorf("encrypt to_addrs: %w", err)
-	}
-	ccAddrsCT, err := d.encryptAddr(msg.CCAddrs)
-	if err != nil {
-		return fmt.Errorf("encrypt cc_addrs: %w", err)
-	}
 	// ADR-0001 step 6: non-boolean flag parts go to flags_other under
 	// the meta sub-key. Booleans (is_seen/is_flagged/is_deleted) are
 	// derived elsewhere in this insert path's downstream tag flow.
@@ -87,23 +74,25 @@ func (d *DB) insertMessageTx(tx *sql.Tx, msg *Message) error {
 		return fmt.Errorf("encrypt flags_other: %w", err)
 	}
 
+	// ADR-0001 step 7d / §3 revision: from_addr/to_addrs/cc_addrs stay
+	// plaintext (substring-search UX, addresses already public on the
+	// wire). No *_ct columns written for the addrs columns — v17
+	// migration drops them.
+
 	err = tx.QueryRow(`
 		INSERT INTO messages (
 			message_id, thread_id, in_reply_to, refs, subject, subject_ct,
-			from_addr, from_addr_ct, to_addrs, to_addrs_ct, cc_addrs, cc_addrs_ct,
+			from_addr, to_addrs, cc_addrs,
 			date, created_at,
 			body_text, body_text_ct, body_html, body_html_ct,
 			mailbox, flags, flags_other, uid, size, fetched_body, account
-		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 		ON CONFLICT(message_id, account) DO UPDATE SET
 			subject = excluded.subject,
 			subject_ct = excluded.subject_ct,
 			from_addr = excluded.from_addr,
-			from_addr_ct = excluded.from_addr_ct,
 			to_addrs = excluded.to_addrs,
-			to_addrs_ct = excluded.to_addrs_ct,
 			cc_addrs = excluded.cc_addrs,
-			cc_addrs_ct = excluded.cc_addrs_ct,
 			body_text = CASE WHEN excluded.fetched_body = 1 AND messages.fetched_body = 0
 			                 THEN excluded.body_text ELSE messages.body_text END,
 			body_text_ct = CASE WHEN excluded.fetched_body = 1 AND messages.fetched_body = 0
@@ -119,7 +108,7 @@ func (d *DB) insertMessageTx(tx *sql.Tx, msg *Message) error {
 			mailbox = CASE WHEN excluded.mailbox != '' THEN excluded.mailbox ELSE messages.mailbox END
 		RETURNING id`,
 		msg.MessageID, threadID, msg.InReplyTo, msg.Refs, msg.Subject, subjectCT,
-		msg.FromAddr, fromAddrCT, msg.ToAddrs, toAddrsCT, msg.CCAddrs, ccAddrsCT,
+		msg.FromAddr, msg.ToAddrs, msg.CCAddrs,
 		msg.Date, msg.CreatedAt,
 		msg.BodyText, bodyTextCT, msg.BodyHTML, bodyHTMLCT,
 		msg.Mailbox, msg.Flags, flagsOtherCT, msg.UID, msg.Size, fetchedBody, msg.Account,
@@ -157,7 +146,15 @@ func (d *DB) UpdateBody(messageID, bodyText, bodyHTML string) error {
 	if err != nil {
 		return fmt.Errorf("encrypt body_html: %w", err)
 	}
-	result, err := d.db.Exec(`
+	// Wrap in a tx so the messages UPDATE and the blind FTS refresh are
+	// atomic. Without this, a crash between them would leave body_tok
+	// stale (search wouldn't find body content of lazy-fetched mail).
+	tx, err := d.db.Begin()
+	if err != nil {
+		return fmt.Errorf("begin tx: %w", err)
+	}
+	defer tx.Rollback() //nolint:errcheck
+	result, err := tx.Exec(`
 		UPDATE messages SET body_text = ?, body_text_ct = ?,
 		                    body_html = ?, body_html_ct = ?,
 		                    fetched_body = 1
@@ -170,7 +167,26 @@ func (d *DB) UpdateBody(messageID, bodyText, bodyHTML string) error {
 	if rows == 0 {
 		return fmt.Errorf("message not found: %s", messageID)
 	}
-	return nil
+
+	// ADR-0001 step 7d: refresh the blind FTS row so body_tok matches
+	// the newly-fetched body. Need the other three fields too because
+	// contentless FTS5 can't UPDATE column-by-column — DELETE + INSERT
+	// the whole row is the only path.
+	var rowid int64
+	var subject, fromAddr, toAddrs string
+	if err := tx.QueryRow(`SELECT id, COALESCE(subject, ''), COALESCE(from_addr, ''), COALESCE(to_addrs, '')
+		FROM messages WHERE message_id = ? LIMIT 1`, messageID).Scan(&rowid, &subject, &fromAddr, &toAddrs); err != nil {
+		return fmt.Errorf("fetch row for blind FTS refresh: %w", err)
+	}
+	sTok, fTok, tTok, bTok := d.blindTokens(subject, fromAddr, toAddrs, bodyText)
+	if _, err := tx.Exec("DELETE FROM messages_blind_fts WHERE rowid = ?", rowid); err != nil {
+		return fmt.Errorf("blind fts delete: %w", err)
+	}
+	if _, err := tx.Exec(`INSERT INTO messages_blind_fts(rowid, subject_tok, from_tok, to_tok, body_tok)
+		VALUES (?, ?, ?, ?, ?)`, rowid, sTok, fTok, tTok, bTok); err != nil {
+		return fmt.Errorf("blind fts insert: %w", err)
+	}
+	return tx.Commit()
 }
 
 // UpdateMailbox sets the mailbox and UID for a message identified by message_id and account.
@@ -201,18 +217,16 @@ func (d *DB) BackfillUID(messageID, account string, uid uint32, mailbox string) 
 func (d *DB) GetByMessageID(messageID string) (*Message, error) {
 	msg := &Message{}
 	var fetchedBody int
-	var subjectCT, fromAddrCT, toAddrsCT, ccAddrsCT, bodyTextCT, bodyHTMLCT []byte
+	var subjectCT, bodyTextCT, bodyHTMLCT []byte
 	err := d.db.QueryRow(`
 		SELECT id, message_id, thread_id, in_reply_to, refs, subject, subject_ct,
-		       from_addr, from_addr_ct, to_addrs, to_addrs_ct, cc_addrs, cc_addrs_ct,
-		       date, created_at,
+		       from_addr, to_addrs, cc_addrs, date, created_at,
 		       body_text, body_text_ct, body_html, body_html_ct,
 		       mailbox, flags, uid, size, fetched_body, account
 		FROM messages WHERE message_id = ? LIMIT 1`, messageID,
 	).Scan(
 		&msg.ID, &msg.MessageID, &msg.ThreadID, &msg.InReplyTo, &msg.Refs, &msg.Subject, &subjectCT,
-		&msg.FromAddr, &fromAddrCT, &msg.ToAddrs, &toAddrsCT, &msg.CCAddrs, &ccAddrsCT,
-		&msg.Date, &msg.CreatedAt,
+		&msg.FromAddr, &msg.ToAddrs, &msg.CCAddrs, &msg.Date, &msg.CreatedAt,
 		&msg.BodyText, &bodyTextCT, &msg.BodyHTML, &bodyHTMLCT,
 		&msg.Mailbox, &msg.Flags, &msg.UID, &msg.Size, &fetchedBody, &msg.Account,
 	)
@@ -226,15 +240,7 @@ func (d *DB) GetByMessageID(messageID string) (*Message, error) {
 	if msg.Subject, err = d.decryptSubject(msg.Subject, subjectCT); err != nil {
 		return nil, err
 	}
-	if msg.FromAddr, err = d.decryptAddr(msg.FromAddr, fromAddrCT); err != nil {
-		return nil, err
-	}
-	if msg.ToAddrs, err = d.decryptAddr(msg.ToAddrs, toAddrsCT); err != nil {
-		return nil, err
-	}
-	if msg.CCAddrs, err = d.decryptAddr(msg.CCAddrs, ccAddrsCT); err != nil {
-		return nil, err
-	}
+	// from_addr/to_addrs/cc_addrs stay plaintext (ADR-0001 §3 revision).
 	if msg.BodyText, err = d.decryptBody(msg.BodyText, bodyTextCT); err != nil {
 		return nil, err
 	}
@@ -249,8 +255,7 @@ func (d *DB) GetByMessageID(messageID string) (*Message, error) {
 func (d *DB) GetByThread(threadID string) ([]*Message, error) {
 	rows, err := d.db.Query(`
 		SELECT id, message_id, thread_id, in_reply_to, refs, subject, subject_ct,
-		       from_addr, from_addr_ct, to_addrs, to_addrs_ct, cc_addrs, cc_addrs_ct,
-		       date, created_at,
+		       from_addr, to_addrs, cc_addrs, date, created_at,
 		       body_text, body_text_ct, body_html, body_html_ct,
 		       mailbox, flags, uid, size, fetched_body, account
 		FROM messages WHERE thread_id = ?
@@ -284,8 +289,7 @@ func (d *DB) GetByThread(threadID string) ([]*Message, error) {
 func (d *DB) GetAllByThread(threadID string) ([]*Message, error) {
 	rows, err := d.db.Query(`
 		SELECT id, message_id, thread_id, in_reply_to, refs, subject, subject_ct,
-		       from_addr, from_addr_ct, to_addrs, to_addrs_ct, cc_addrs, cc_addrs_ct,
-		       date, created_at,
+		       from_addr, to_addrs, cc_addrs, date, created_at,
 		       body_text, body_text_ct, body_html, body_html_ct,
 		       mailbox, flags, uid, size, fetched_body, account
 		FROM messages WHERE thread_id = ?
@@ -405,19 +409,19 @@ func (d *DB) GetRecipientAddresses() ([]string, error) {
 }
 
 // scanMessages scans rows into a slice of Message pointers. Caller's
-// SELECT must interleave each encrypted column's *_ct BLOB right after
-// its plaintext column, in this order: subject, from_addr, to_addrs,
-// cc_addrs, body_text, body_html.
+// SELECT must interleave subject_ct after subject and body_text_ct /
+// body_html_ct after their plaintext columns. from_addr/to_addrs/
+// cc_addrs stay plaintext (ADR-0001 §3 revision); their plaintext
+// values are scanned directly with no decrypt step.
 func (d *DB) scanMessages(rows *sql.Rows) ([]*Message, error) {
 	var msgs []*Message
 	for rows.Next() {
 		msg := &Message{}
 		var fetchedBody int
-		var subjectCT, fromAddrCT, toAddrsCT, ccAddrsCT, bodyTextCT, bodyHTMLCT []byte
+		var subjectCT, bodyTextCT, bodyHTMLCT []byte
 		err := rows.Scan(
 			&msg.ID, &msg.MessageID, &msg.ThreadID, &msg.InReplyTo, &msg.Refs, &msg.Subject, &subjectCT,
-			&msg.FromAddr, &fromAddrCT, &msg.ToAddrs, &toAddrsCT, &msg.CCAddrs, &ccAddrsCT,
-			&msg.Date, &msg.CreatedAt,
+			&msg.FromAddr, &msg.ToAddrs, &msg.CCAddrs, &msg.Date, &msg.CreatedAt,
 			&msg.BodyText, &bodyTextCT, &msg.BodyHTML, &bodyHTMLCT,
 			&msg.Mailbox, &msg.Flags, &msg.UID, &msg.Size, &fetchedBody, &msg.Account,
 		)
@@ -426,15 +430,6 @@ func (d *DB) scanMessages(rows *sql.Rows) ([]*Message, error) {
 		}
 		msg.FetchedBody = fetchedBody == 1
 		if msg.Subject, err = d.decryptSubject(msg.Subject, subjectCT); err != nil {
-			return nil, err
-		}
-		if msg.FromAddr, err = d.decryptAddr(msg.FromAddr, fromAddrCT); err != nil {
-			return nil, err
-		}
-		if msg.ToAddrs, err = d.decryptAddr(msg.ToAddrs, toAddrsCT); err != nil {
-			return nil, err
-		}
-		if msg.CCAddrs, err = d.decryptAddr(msg.CCAddrs, ccAddrsCT); err != nil {
 			return nil, err
 		}
 		if msg.BodyText, err = d.decryptBody(msg.BodyText, bodyTextCT); err != nil {

--- a/cli/internal/store/search.go
+++ b/cli/internal/store/search.go
@@ -451,7 +451,7 @@ func (d *DB) exprToSQL(node exprNode) (string, []interface{}, error) {
 		// user term is run through the same TokenizeFTS pipeline that
 		// populated the index in step 7a+b, so the hex tokens produced
 		// here line up with the tokens stored at write time.
-		toks := dbcrypto.TokenizeFTS(d.keyring.FTSToken, n.value)
+		toks := dbcrypto.TokenizeFTSQuery(d.keyring.FTSToken, n.value)
 		if toks == "" {
 			// All-stop-words / punctuation-only input — never matches anything.
 			return "1=0", nil, nil
@@ -498,7 +498,7 @@ func (d *DB) fieldToSQL(f *fieldExpr) (string, []interface{}, error) {
 		// ADR-0001 step 7c: subject: scoped FTS flips to messages_blind_fts.
 		// subject_tok:(tok1 tok2 ...) AND's each token against the
 		// subject_tok column only.
-		toks := dbcrypto.TokenizeFTS(d.keyring.FTSToken, f.value)
+		toks := dbcrypto.TokenizeFTSQuery(d.keyring.FTSToken, f.value)
 		if toks == "" {
 			return "1=0", nil, nil
 		}

--- a/cli/internal/store/store.go
+++ b/cli/internal/store/store.go
@@ -690,6 +690,32 @@ func (d *DB) migrate() error {
 		if _, err := d.db.Exec("UPDATE schema_version SET version = 16 WHERE rowid = 1"); err != nil {
 			return fmt.Errorf("migrate v15→v16 bump: %w", err)
 		}
+		version = 16
+	}
+
+	if version < 17 {
+		// ADR-0001 step 7d (prep for 7e): drop the dead from_addr_ct /
+		// to_addrs_ct / cc_addrs_ct columns the v11→v12 migration added.
+		// During that step the addresses were on the encrypt-at-rest
+		// roadmap; ADR-0001 §3 was updated to keep them plaintext
+		// (substring search UX outweighs the asymmetric protection vs.
+		// wire-plaintext leak). The BLOB columns are written but never
+		// read, so dropping them is pure cleanup. SQLite 3.35+ supports
+		// ALTER TABLE DROP COLUMN; idempotent via PRAGMA table_info.
+		for _, col := range []string{"from_addr_ct", "to_addrs_ct", "cc_addrs_ct"} {
+			has, err := hasColumn(d.db, "messages", col)
+			if err != nil {
+				return fmt.Errorf("migrate v16→v17 inspect %s: %w", col, err)
+			}
+			if has {
+				if _, err := d.db.Exec("ALTER TABLE messages DROP COLUMN " + col); err != nil {
+					return fmt.Errorf("migrate v16→v17 drop %s: %w", col, err)
+				}
+			}
+		}
+		if _, err := d.db.Exec("UPDATE schema_version SET version = 17 WHERE rowid = 1"); err != nil {
+			return fmt.Errorf("migrate v16→v17 bump: %w", err)
+		}
 	}
 
 	return nil
@@ -930,39 +956,33 @@ func (d *DB) backfillBlindFTS() error {
 	// COALESCE the plaintext columns to '' — early-schema messages can
 	// have NULL subject/from/to/body where the new schema treats them as
 	// empty strings. NULL would error scanning into a *string.
+	// from_addr/to_addrs are plaintext per ADR-0001 §3 revision; no
+	// decrypt needed here.
 	rows, err := tx.Query(`SELECT m.id,
-		COALESCE(m.subject,    ''), m.subject_ct,
-		COALESCE(m.from_addr,  ''), m.from_addr_ct,
-		COALESCE(m.to_addrs,   ''), m.to_addrs_ct,
-		COALESCE(m.body_text,  ''), m.body_text_ct
+		COALESCE(m.subject,   ''), m.subject_ct,
+		COALESCE(m.from_addr, ''),
+		COALESCE(m.to_addrs,  ''),
+		COALESCE(m.body_text, ''), m.body_text_ct
 		FROM messages m
 		WHERE NOT EXISTS (SELECT 1 FROM messages_blind_fts WHERE rowid = m.id)`)
 	if err != nil {
 		return fmt.Errorf("select rows: %w", err)
 	}
 	type pending struct {
-		id                                                  int64
-		subject, fromAddr, toAddrs, bodyText                 string
+		id                                  int64
+		subject, fromAddr, toAddrs, bodyText string
 	}
 	var batch []pending
 	for rows.Next() {
 		var p pending
-		var sCT, fCT, tCT, bCT []byte
-		if err := rows.Scan(&p.id, &p.subject, &sCT, &p.fromAddr, &fCT, &p.toAddrs, &tCT, &p.bodyText, &bCT); err != nil {
+		var sCT, bCT []byte
+		if err := rows.Scan(&p.id, &p.subject, &sCT, &p.fromAddr, &p.toAddrs, &p.bodyText, &bCT); err != nil {
 			rows.Close()
 			return fmt.Errorf("scan: %w", err)
 		}
 		if p.subject, err = d.decryptSubject(p.subject, sCT); err != nil {
 			rows.Close()
 			return fmt.Errorf("decrypt subject id=%d: %w", p.id, err)
-		}
-		if p.fromAddr, err = d.decryptAddr(p.fromAddr, fCT); err != nil {
-			rows.Close()
-			return fmt.Errorf("decrypt from_addr id=%d: %w", p.id, err)
-		}
-		if p.toAddrs, err = d.decryptAddr(p.toAddrs, tCT); err != nil {
-			rows.Close()
-			return fmt.Errorf("decrypt to_addrs id=%d: %w", p.id, err)
 		}
 		if p.bodyText, err = d.decryptBody(p.bodyText, bCT); err != nil {
 			rows.Close()

--- a/cli/internal/store/store_test.go
+++ b/cli/internal/store/store_test.go
@@ -42,8 +42,8 @@ func TestOpenAndInit(t *testing.T) {
 	if err != nil {
 		t.Fatalf("read version: %v", err)
 	}
-	if version != 16 {
-		t.Errorf("version = %d, want 16", version)
+	if version != 17 {
+		t.Errorf("version = %d, want 17", version)
 	}
 }
 
@@ -168,8 +168,8 @@ func TestMigrateV9_PopulatesMailboxesAndAccounts(t *testing.T) {
 	if err := db.QueryRow("SELECT version FROM schema_version WHERE rowid = 1").Scan(&version); err != nil {
 		t.Fatalf("read version: %v", err)
 	}
-	if version != 16 {
-		t.Fatalf("version = %d, want 16", version)
+	if version != 17 {
+		t.Fatalf("version = %d, want 17", version)
 	}
 
 	// mailboxes must contain exactly INBOX and Drafts (case-collapsed).
@@ -349,8 +349,8 @@ func TestMigrateV10_BackfillsSubjectCt(t *testing.T) {
 	if err := sd.db.QueryRow("SELECT version FROM schema_version WHERE rowid = 1").Scan(&version); err != nil {
 		t.Fatalf("read version: %v", err)
 	}
-	if version != 16 {
-		t.Fatalf("version = %d, want 16", version)
+	if version != 17 {
+		t.Fatalf("version = %d, want 17", version)
 	}
 
 	// Raw check: subject_ct must be NULL for empty subject, non-NULL for the
@@ -483,8 +483,8 @@ func TestMigrateV11_BackfillsBodyCt(t *testing.T) {
 	if err := sd.db.QueryRow("SELECT version FROM schema_version WHERE rowid = 1").Scan(&version); err != nil {
 		t.Fatalf("read version: %v", err)
 	}
-	if version != 16 {
-		t.Fatalf("version = %d, want 16", version)
+	if version != 17 {
+		t.Fatalf("version = %d, want 17", version)
 	}
 
 	// Raw check: body_text_ct populated only where body_text non-empty.
@@ -545,150 +545,6 @@ func TestMigrateV11_BackfillsBodyCt(t *testing.T) {
 	}
 }
 
-// TestMigrateV12_BackfillsAddrsCt seeds a v11-shaped DB with a mix of
-// from/to/cc populations and asserts the v11→v12 migration encrypts
-// only the non-empty addresses, leaves the rest NULL, and that
-// GetByMessageID round-trips through decryptAddr.
-func TestMigrateV12_BackfillsAddrsCt(t *testing.T) {
-	dbPath := filepath.Join(t.TempDir(), "step6-addrs.db")
-	seedDB, err := sql.Open("sqlite", dbPath)
-	if err != nil {
-		t.Fatalf("open seed: %v", err)
-	}
-	seed := []string{
-		`CREATE TABLE schema_version (version INTEGER NOT NULL)`,
-		`INSERT INTO schema_version (rowid, version) VALUES (1, 11)`,
-		`CREATE TABLE messages (
-			id INTEGER PRIMARY KEY AUTOINCREMENT,
-			message_id TEXT NOT NULL,
-			thread_id TEXT NOT NULL,
-			in_reply_to TEXT,
-			refs TEXT,
-			subject TEXT,
-			subject_ct BLOB,
-			from_addr TEXT,
-			to_addrs TEXT,
-			cc_addrs TEXT,
-			date INTEGER,
-			created_at INTEGER NOT NULL,
-			body_text TEXT,
-			body_text_ct BLOB,
-			body_html TEXT,
-			body_html_ct BLOB,
-			mailbox TEXT,
-			flags TEXT,
-			uid INTEGER DEFAULT 0,
-			size INTEGER DEFAULT 0,
-			fetched_body INTEGER DEFAULT 0,
-			account TEXT DEFAULT '',
-			mailbox_id INTEGER,
-			account_id INTEGER,
-			is_seen INTEGER NOT NULL DEFAULT 0,
-			is_flagged INTEGER NOT NULL DEFAULT 0,
-			is_deleted INTEGER NOT NULL DEFAULT 0,
-			UNIQUE(message_id, account)
-		)`,
-		`INSERT INTO messages (message_id, thread_id, in_reply_to, refs, subject,
-		    from_addr, to_addrs, cc_addrs, date, created_at,
-		    body_text, body_html, mailbox, flags) VALUES
-		   ('m1', 't1', '', '', '', 'a@x.com',  'b@x.com',  '',         0, 1, '', '', '', ''),
-		   ('m2', 't2', '', '', '', '',         '',         'c@x.com',  0, 2, '', '', '', ''),
-		   ('m3', 't3', '', '', '', 'a@x.com',  'b@x.com',  'c@x.com',  0, 3, '', '', '', ''),
-		   ('m4', 't4', '', '', '', '',         '',         '',         0, 4, '', '', '', '')`,
-		`CREATE VIRTUAL TABLE messages_fts USING fts5(
-			subject, from_addr, to_addrs, body_text,
-			content='messages',
-			content_rowid='id'
-		)`,
-		`INSERT INTO messages_fts(rowid, subject, from_addr, to_addrs, body_text)
-		 SELECT id, COALESCE(subject, ''), COALESCE(from_addr, ''), COALESCE(to_addrs, ''), COALESCE(body_text, '')
-		 FROM messages`,
-	}
-	for _, stmt := range seed {
-		if _, err := seedDB.Exec(stmt); err != nil {
-			t.Fatalf("seed: %v\nstmt: %s", err, stmt)
-		}
-	}
-	seedDB.Close()
-
-	sd, err := Open(dbPath, testKeyring(t))
-	if err != nil {
-		t.Fatalf("store open: %v", err)
-	}
-	t.Cleanup(func() { sd.Close() })
-	if err := sd.Init(); err != nil {
-		t.Fatalf("init/migrate: %v", err)
-	}
-
-	var version int
-	if err := sd.db.QueryRow("SELECT version FROM schema_version WHERE rowid = 1").Scan(&version); err != nil {
-		t.Fatalf("read version: %v", err)
-	}
-	if version != 16 {
-		t.Fatalf("version = %d, want 16", version)
-	}
-
-	rows, err := sd.db.Query(`SELECT message_id, from_addr, from_addr_ct,
-		to_addrs, to_addrs_ct, cc_addrs, cc_addrs_ct
-		FROM messages ORDER BY message_id`)
-	if err != nil {
-		t.Fatalf("query: %v", err)
-	}
-	defer rows.Close()
-	type row struct {
-		id                                       string
-		from, to, cc                             string
-		fromCT, toCT, ccCT                       []byte
-	}
-	var got []row
-	for rows.Next() {
-		var r row
-		if err := rows.Scan(&r.id, &r.from, &r.fromCT, &r.to, &r.toCT, &r.cc, &r.ccCT); err != nil {
-			t.Fatalf("scan: %v", err)
-		}
-		got = append(got, r)
-	}
-	if len(got) != 4 {
-		t.Fatalf("rows = %d, want 4", len(got))
-	}
-	checks := []struct {
-		idx                                 int
-		wantFromCT, wantToCT, wantCCCT bool
-	}{
-		{0, true, true, false},
-		{1, false, false, true},
-		{2, true, true, true},
-		{3, false, false, false},
-	}
-	for _, c := range checks {
-		r := got[c.idx]
-		if (len(r.fromCT) > 0) != c.wantFromCT {
-			t.Errorf("%s from_addr_ct populated=%v, want %v", r.id, len(r.fromCT) > 0, c.wantFromCT)
-		}
-		if (len(r.toCT) > 0) != c.wantToCT {
-			t.Errorf("%s to_addrs_ct populated=%v, want %v", r.id, len(r.toCT) > 0, c.wantToCT)
-		}
-		if (len(r.ccCT) > 0) != c.wantCCCT {
-			t.Errorf("%s cc_addrs_ct populated=%v, want %v", r.id, len(r.ccCT) > 0, c.wantCCCT)
-		}
-	}
-
-	// Round-trip via the production read path.
-	for _, want := range got {
-		msg, err := sd.GetByMessageID(want.id)
-		if err != nil {
-			t.Fatalf("get %s: %v", want.id, err)
-		}
-		if msg == nil {
-			t.Fatalf("get %s: nil", want.id)
-		}
-		if msg.FromAddr != want.from || msg.ToAddrs != want.to || msg.CCAddrs != want.cc {
-			t.Errorf("%s addrs mismatch: got (%q/%q/%q), want (%q/%q/%q)",
-				want.id, msg.FromAddr, msg.ToAddrs, msg.CCAddrs,
-				want.from, want.to, want.cc)
-		}
-	}
-}
 
 // TestBlindFTS_InsertAndMatch verifies the step-7 (a+b) round-trip:
 // a message inserted via the store API populates messages_blind_fts,

--- a/docs/content/docs/developers/design/0001-mail-content-encryption-at-rest.md
+++ b/docs/content/docs/developers/design/0001-mail-content-encryption-at-rest.md
@@ -106,11 +106,16 @@ no new direct dependency added).
 | `body_key`         | `"durian/v1/body"`       | encrypts `messages.body_text/html`     |
 | `subject_key`      | `"durian/v1/subject"`    | encrypts `messages.subject`            |
 | `headers_key`      | `"durian/v1/headers"`    | encrypts `message_headers.value`       |
-| `addrs_key`        | `"durian/v1/addrs"`      | encrypts `from_addr`, `to_addrs`, `cc_addrs` |
+| `addrs_key`        | `"durian/v1/addrs"`      | **(retired, see §3)** previously encrypted `from_addr`, `to_addrs`, `cc_addrs` |
 | `draft_key`        | `"durian/v1/draft"`      | encrypts `local_drafts.draft_json`, `outbox.draft_json` |
 | `contact_key`      | `"durian/v1/contact"`    | encrypts `contacts.email`, `contacts.name` |
 | `fts_token_key`    | `"durian/v1/fts-token"`  | HMAC key for blind FTS5 tokens (§4)    |
 | `meta_key`         | `"durian/v1/meta"`       | encrypts `mailbox` name, custom `flags`, `account` string |
+
+`addrs_key` is derived for backward-compatibility (the v11→v12 migration
+populated `from_addr_ct` / `to_addrs_ct` / `cc_addrs_ct` columns under
+this key) but no current read or write path consumes it — see §3 for
+why the addresses ended up staying plaintext.
 
 Keychain layout (new):
 
@@ -134,11 +139,38 @@ migration. Migrations are additive, gated on a new `schema_version` step.
 | Old column      | New column       | Notes                            |
 | --------------- | ---------------- | -------------------------------- |
 | `subject TEXT`  | `subject BLOB`   | encrypted with `subject_key`     |
-| `from_addr TEXT`| `from_addr BLOB` | encrypted with `addrs_key`       |
-| `to_addrs TEXT` | `to_addrs BLOB`  | encrypted with `addrs_key`       |
-| `cc_addrs TEXT` | `cc_addrs BLOB`  | encrypted with `addrs_key`       |
 | `body_text TEXT`| `body_text BLOB` | encrypted with `body_key`        |
 | `body_html TEXT`| `body_html BLOB` | encrypted with `body_key`        |
+
+`from_addr`, `to_addrs`, `cc_addrs` **stay plaintext TEXT** — moved
+from the encrypted set during implementation. Rationale: these
+addresses are already plaintext on the wire (IMAP server logs,
+recipient-side `From:` headers, anti-spam routing, sending-server
+`Return-Path:`), at every Mail Transfer Agent they cross, and in the
+recipient's Sent folder. Encrypting them at rest while they shout on
+the wire is an asymmetric, low-value tradeoff. The two implementable
+alternatives both fail their cost/benefit test:
+
+- **Determinstic-HMAC search tokens** ([Naveed et al, "Inference
+  Attacks on Property-Preserving Encrypted Databases", CCS 2015])
+  enable substring search but leak token-frequency tables that are
+  trivially attackable for address-class data — `com`, `gma`, `info`,
+  `support` are unambiguous markers in any normal mailbox.
+- **Char-trigram FTS5** preserves substring-search UX but produces a
+  dense, skewed frequency distribution that yields *strictly more*
+  leakage than the plaintext-on-disk we'd be trying to avoid (the
+  attacker who can build a trigram histogram over your DB already has
+  the file; the plaintext just spares them the statistical step).
+
+The cost side: `from:partial` substring queries (e.g. `from:ali`
+matching `alice@example.com`) are a real UX habit that any
+blind-FTS-MATCH path breaks at word boundary. Acceptable plaintext
+leak, undebatable UX preservation.
+
+Out of scope for V1: an opt-in power-user encrypt-from-to flag for
+threat models where the local DB is genuinely the only place these
+addresses live (e.g. an air-gapped mail archive). Will get its own
+ADR if asked for.
 
 Folder names, IMAP keywords and account email addresses can themselves be
 sensitive (`Archive/Healthcare`, `Drafts/Resignation`, `$Confidential`,
@@ -205,12 +237,10 @@ trigger replacement code path):
    does not ship a UAX #29 word-segmenter. Drop tokens that contain only
    punctuation or whitespace. Stop-words are **not** dropped (see Threat
    Model §6).
-3. **Address-field special case** (subject/body skip this step). For each
-   `local@domain` match in `from_addr`/`to_addrs`/`cc_addrs`, emit three
-   tokens: `local`, `domain`, and `local@domain`. Rationale: users expect
-   both "all mail from alice" (local-part) and "all mail from example.com"
-   (domain) to work; keeping the full address as a third token avoids
-   losing a bigram across the `@` boundary.
+3. **(retired)** Earlier drafts had an address-field special case here that
+   emitted `local`, `domain`, `local@domain` tokens. With `from_addr`,
+   `to_addrs`, `cc_addrs` now kept plaintext (see §3), the special case
+   is gone — address search uses `LIKE` on the plaintext column directly.
 4. For each token `t`: `tok = base32(truncate(HMAC-SHA256(fts_token_key, t), 10))`.
    Output is a 16-char ASCII string, FTS5-tokenizer-safe. 80-bit truncation
    is chosen over 64 bit to raise the cost of long-term token-frequency
@@ -226,12 +256,18 @@ FTS5 schema:
 ```sql
 CREATE VIRTUAL TABLE messages_fts USING fts5(
     subject_tokens,        -- unigrams + bigrams for subject
-    addrs_tokens,          -- unigrams + bigrams for from/to/cc combined
     body_tokens,           -- unigrams + bigrams for body_text
     content='',            -- contentless: we never store plaintext here
     tokenize='ascii'       -- input is already opaque base32 ASCII
 );
 ```
+
+The implementation (`store/store.go` v15→v16 migration) currently uses
+the column names `subject_tok` / `body_tok` and an `unicode61` tokenizer
+(plus `from_tok` / `to_tok` columns that are kept for the v11→v12
+migration's column-set but unused by the read path — see §3 on address
+plaintext). The ADR-vs-reality drift is intentional during the
+roll-out; the final §6 step-7e cleanup squares them up.
 
 Search at runtime:
 
@@ -341,6 +377,21 @@ Does **not** defend against:
   `refs` (see §3): thread topology and sometimes provider domain remain
   observable. Mitigation: none in V1 — a future ADR may revisit if a
   realistic threat model demands it.
+- Information leakage from `from_addr` / `to_addrs` / `cc_addrs` (see
+  §3): an attacker with the DB file can read every sender/recipient
+  address verbatim plus the frequency of correspondence per address —
+  enough to reconstruct the user's communication graph. Mitigation:
+  none, deliberately. The same data is already exposed at the IMAP
+  server, all MTAs in transit, the recipient's Sent folder and
+  anti-spam routing logs; encrypting it at rest while it shouts on
+  the wire is asymmetric protection. The two implementable encrypted
+  alternatives both fail their cost/benefit test (deterministic-HMAC
+  search tokens leak token-frequency tables — Naveed et al CCS 2015;
+  char-trigram FTS5 leaks dense skewed trigram frequencies that yield
+  *more* information than the plaintext we would be hiding). Future
+  ADR may add an opt-in encrypt-from-to flag for users whose threat
+  model puts the local DB as the genuinely-only-place these addresses
+  live (air-gapped archive, etc.).
 
 ### Threat-actor personas
 
@@ -623,7 +674,11 @@ Resolved (kept here for traceability):
 - ~~Token truncation width.~~ → 80 bit (§4). Resolved in response to
   early-review feedback re: token-frequency correlation across snapshots.
 - ~~Address tokenization.~~ → emit three tokens per address (local,
-  domain, full). Resolved in §4 step 3.
+  domain, full). ~~Resolved in §4 step 3.~~ **Superseded:** addresses
+  themselves moved to plaintext (see §3 "from_addr/to_addrs/cc_addrs
+  stay plaintext TEXT" + §6 threat-model bullet). Substring search
+  served by `LIKE` on the plaintext column; no FTS5 address tokens
+  exist in V1.
 - ~~Mailbox / flags / account plaintext leak.~~ → encrypted, with integer
   surrogate columns for indexing (§3). Resolved in response to early-review
   feedback.


### PR DESCRIPTION
## Summary

β-revision: \`from_addr\` / \`to_addrs\` / \`cc_addrs\` move back to plaintext. Argument: these addresses are already plaintext on the wire (IMAP server logs, recipient \`From:\` headers, MTAs in transit, anti-spam routing, recipient Sent folders). Encrypting only the local mirror is asymmetric protection that costs the \`from:partial\` substring-search UX users rely on, and the two implementable encrypted alternatives both fail their cost/benefit test (deterministic-HMAC search tokens leak token-frequency tables per Naveed et al CCS 2015; char-trigram FTS5 leaks dense skewed trigram frequencies that yield *more* information than the plaintext we'd be hiding).

- Drop dead \`from_addr_ct\` / \`to_addrs_ct\` / \`cc_addrs_ct\` BLOB columns (v17 migration).
- \`addrs_key\` retired in ADR §2 — still derived for forward compat.
- Substring search served by \`LIKE\` on the plaintext column.
- ADR §3 + §6 threat-model bullet document the leak.

Stacked on top of #242 (step 7c).

## Test plan

- [x] All CLI unit tests pass.
- [x] Cumulative CI on the rolled-up stack via #240 (rebased onto main): all 10 checks green.