### PR TITLE
ADR-0001 step 8 — PRAGMA secure_delete = ON

### DIFF
--- a/cli/internal/contacts/db.go
+++ b/cli/internal/contacts/db.go
@@ -65,6 +65,15 @@ func Open(dbPath string) (*DB, error) {
 		db.Close()
 		return nil, fmt.Errorf("set journal mode: %w", err)
 	}
+	// ADR-0001 step 8: overwrite freed pages with zeros on DELETE /
+	// UPDATE. contacts.email and contacts.name stay plaintext per the
+	// step 7g β-revision (ADR §3); a deleted contact row otherwise
+	// leaves its address bytes recoverable in the .db file until that
+	// page gets reused. secure_delete plugs the page-reuse window.
+	if _, err := db.Exec("PRAGMA secure_delete = ON"); err != nil {
+		db.Close()
+		return nil, fmt.Errorf("set secure_delete pragma: %w", err)
+	}
 
 	return &DB{db: db}, nil
 }

--- a/cli/internal/contacts/db_test.go
+++ b/cli/internal/contacts/db_test.go
@@ -20,6 +20,21 @@ func newTestDB(t *testing.T) *DB {
 	return db
 }
 
+// TestOpen_SecureDeleteEnabled mirrors the store-side smoke test:
+// ADR-0001 step 8 requires PRAGMA secure_delete = ON on every fresh
+// contacts.db connection so deleted email / name bytes don't stay
+// recoverable in the .db file via page-reuse delay.
+func TestOpen_SecureDeleteEnabled(t *testing.T) {
+	db := newTestDB(t)
+	var v int
+	if err := db.db.QueryRow("PRAGMA secure_delete").Scan(&v); err != nil {
+		t.Fatalf("query pragma: %v", err)
+	}
+	if v != 1 {
+		t.Errorf("PRAGMA secure_delete = %d, want 1", v)
+	}
+}
+
 func TestAddAndSearch(t *testing.T) {
 	db := newTestDB(t)
 

--- a/cli/internal/store/store.go
+++ b/cli/internal/store/store.go
@@ -63,6 +63,15 @@ func Open(dbPath string, kr *dbcrypto.Keyring) (*DB, error) {
 		"PRAGMA busy_timeout=5000",
 		"PRAGMA foreign_keys=ON",
 		"PRAGMA synchronous=NORMAL",
+		// ADR-0001 step 8: overwrite freed pages with zeros on DELETE /
+		// UPDATE so the ciphertext-and-still-plaintext columns we keep
+		// (from_addr, to_addrs, cc_addrs, message_id, dates, sizes,
+		// is_seen / is_flagged / is_deleted) don't leak old values via
+		// page-reuse delay to a forensic analyst with the raw .db file.
+		// Encrypted columns are safe under page reuse anyway, but
+		// secure_delete is the forward-looking guarantee for the
+		// plaintext set documented in ADR §3 "Stays plaintext".
+		"PRAGMA secure_delete = ON",
 	}
 	for _, p := range pragmas {
 		if _, err := db.Exec(p); err != nil {

--- a/cli/internal/store/store_test.go
+++ b/cli/internal/store/store_test.go
@@ -53,6 +53,23 @@ func TestOpen_RejectsNilKeyring(t *testing.T) {
 	}
 }
 
+// TestOpen_SecureDeleteEnabled asserts ADR-0001 step 8: every fresh
+// connection has PRAGMA secure_delete = ON, so DELETE / UPDATE
+// overwrites freed pages with zeros before reuse. The plaintext
+// metadata Durian deliberately keeps (from_addr, to_addrs, cc_addrs,
+// message_id, dates) would otherwise stay recoverable in the .db file
+// until something else writes over the page.
+func TestOpen_SecureDeleteEnabled(t *testing.T) {
+	db := newTestDB(t)
+	var v int
+	if err := db.db.QueryRow("PRAGMA secure_delete").Scan(&v); err != nil {
+		t.Fatalf("query pragma: %v", err)
+	}
+	if v != 1 {
+		t.Errorf("PRAGMA secure_delete = %d, want 1", v)
+	}
+}
+
 func TestInitIdempotent(t *testing.T) {
 	db := newTestDB(t)
 

--- a/docs/content/docs/developers/design/0001-mail-content-encryption-at-rest.md
+++ b/docs/content/docs/developers/design/0001-mail-content-encryption-at-rest.md
@@ -454,6 +454,40 @@ still:
   need memory-dump resistance run an FDE-encrypted suspend / hibernate or
   exit `durian serve` when stepping away.
 
+### Disk hygiene
+
+SQLite by default treats DELETE / UPDATE as "mark the page free for
+later reuse" — the old row bytes stay in the `.db` file until some
+later write happens to land on that page. For the columns we
+deliberately keep plaintext per the β-revisions (`from_addr`,
+`to_addrs`, `cc_addrs`, RFC-5322 IDs, `is_seen` / `is_flagged` /
+`is_deleted`, dates, sizes, `contacts.email`, `contacts.name`), that
+delay is a Persona 1 leak: a forensic analyst with the raw file can
+recover the bytes of mails the user thought they deleted.
+
+Mitigation: **`PRAGMA secure_delete = ON`** is set on every fresh
+connection in both `store.Open` and `contacts.Open` (step 8). SQLite
+then zeroes freed pages before releasing them. Cost is one extra
+zero-write per delete — negligible for Durian's mailbox-scale delete
+rate.
+
+What secure_delete does **not** cover:
+
+- WAL-mode journal pages (`email.db-wal`) may briefly hold pre-delete
+  bytes before checkpoint. `journal_mode=DELETE` would close that
+  window but at the cost of write throughput; we accept the brief
+  WAL window because the WAL file gets checkpointed and rewritten
+  often. `contacts.db` is `journal_mode=DELETE` so it does not have
+  this gap.
+- Filesystem-level snapshots (Time Machine, APFS local snapshots,
+  iCloud backups) hold whole-file copies independent of SQLite's
+  page management. Persona 2's defense rests on the file being
+  ciphertext-mostly + locked-keychain, not on secure_delete.
+- SSD wear-leveling. The physical block the "zeroed" page sat in may
+  still hold old bits, accessible only to physical-media forensics
+  (chip-off attacks). Out of scope; mitigation is FileVault /
+  full-disk encryption, which Durian assumes the user enables.
+
 ### Logging audit
 
 A Durian build with encryption is only as private as its least careful log
@@ -688,9 +722,13 @@ user-runnable.
      bigrams written by the step-7 a+b tokenizer; quoted phrases
      (`"foo bar"`, `subject:"foo bar"`) now ride the bigram path to
      anchor word order.
-8. **`PRAGMA secure_delete = ON`** flipped in `store.Open` and verified by
-   a smoke test that asserts the pragma is set on every new connection.
-   **Pending** — separate PR after the step-7 stack lands.
+8. **`PRAGMA secure_delete = ON`** flipped in both `store.Open` and
+   `contacts.Open`, verified by smoke tests that assert the pragma is
+   set on every new connection. Overwrites freed pages with zeros so
+   the plaintext metadata the β-revisions deliberately kept (addresses,
+   IDs, dates, activity booleans, contact names) doesn't leak old
+   values via page-reuse delay to a forensic analyst with the raw
+   `.db` file. **Shipped.**
 
 Steps 1–4 are pure infrastructure and can ship as alpha-grade without
 user-visible change. The first user-visible behaviour change is step 5.


### PR DESCRIPTION
## Summary

Closes the ADR-0001 implementation plan. Flips \`secure_delete\` on in both \`store.Open\` and \`contacts.Open\` so SQLite overwrites freed pages with zeros on DELETE / UPDATE before reuse — without this, the plaintext columns Durian deliberately keeps per the β-revisions (\`from_addr\`, \`to_addrs\`, \`cc_addrs\`, RFC-5322 IDs, activity booleans, dates, sizes, \`contacts.email\`, \`contacts.name\`) stay recoverable in the raw \`.db\` file via page-reuse delay. Persona 1 (forensic analyst with cold filesystem image) leak that the ADR threat-model table already credited as defended but the code hadn't actually delivered until now.

- Pragma added to both \`Open\` paths alongside the existing journal/foreign_keys/synchronous pragmas.
- New \`TestOpen_SecureDeleteEnabled\` smoke test in both \`store\` and \`contacts\` packages asserts \`PRAGMA secure_delete = 1\` on a fresh connection.
- ADR §6 step 8 marked Shipped; new §Disk hygiene section documents what the pragma covers (Persona 1 page-reuse delay) and what it does not (WAL journal pages — brief gap, FS snapshots — Persona 2 territory, SSD wear-leveling — out of scope).

## Test plan

- [x] All 18 CLI unit tests pass; encryption grep-gate clean.
- [x] New \`TestOpen_SecureDeleteEnabled\` smoke tests pass in both packages.