### PR TITLE
fix(go-store): ADR-0001 audit H3+H4 — VACUUM ordering + rebuild idempotency

### DIFF
--- a/cli/internal/store/BUILD.bazel
+++ b/cli/internal/store/BUILD.bazel
@@ -32,6 +32,7 @@ go_test(
         "headers_test.go",
         "local_drafts_test.go",
         "messages_test.go",
+        "migrate_audit_test.go",
         "outbox_test.go",
         "search_test.go",
         "store_test.go",

--- a/cli/internal/store/migrate_audit_test.go
+++ b/cli/internal/store/migrate_audit_test.go
@@ -1,0 +1,91 @@
+package store
+
+import (
+	"bytes"
+	"path/filepath"
+	"testing"
+
+	"github.com/durian-dev/durian/cli/internal/dbcrypto"
+)
+
+// TestRebuildMessages_IdempotentAfterPartialFailure asserts ADR-0001
+// audit H4: rebuildMessagesForStep7f tolerates re-entry after a
+// previous attempt left a half-built messages_new behind. The pre-fix
+// version used a bare CREATE TABLE messages_new without IF NOT EXISTS;
+// a mid-INSERT-SELECT crash (OOM on the multi-GB scan, disk-full,
+// power loss) wedged the next Init() at "table messages_new already
+// exists".
+//
+// We simulate the wedged state by manually creating a messages_new
+// table, then calling rebuildMessagesForStep7f directly and verifying
+// it doesn't error.
+func TestRebuildMessages_IdempotentAfterPartialFailure(t *testing.T) {
+	db := newTestDB(t)
+	// Simulate a leftover from a previous interrupted rebuild attempt.
+	// Use the simplest possible schema — the pre-fix code never
+	// checked the leftover's shape, just complained that the name was
+	// taken; same here.
+	if _, err := db.db.Exec("CREATE TABLE messages_new (id INTEGER, junk TEXT)"); err != nil {
+		t.Fatalf("seed leftover: %v", err)
+	}
+	if _, err := db.db.Exec("INSERT INTO messages_new (id, junk) VALUES (999, 'half-built')"); err != nil {
+		t.Fatalf("seed leftover row: %v", err)
+	}
+
+	// Calling rebuildMessagesForStep7f must DROP the leftover and
+	// rebuild from scratch. Without the H4 fix, this would error at
+	// the CREATE TABLE step.
+	if err := db.rebuildMessagesForStep7f(); err != nil {
+		t.Fatalf("rebuild after partial failure: %v", err)
+	}
+
+	// The junk row from the leftover must NOT appear in the rebuilt
+	// messages table — confirming the DROP fired before the rebuild.
+	var count int
+	if err := db.db.QueryRow("SELECT COUNT(*) FROM messages WHERE id = 999").Scan(&count); err != nil {
+		t.Fatalf("verify junk gone: %v", err)
+	}
+	if count != 0 {
+		t.Errorf("junk row from previous attempt leaked into rebuilt messages table")
+	}
+}
+
+// TestMigrateV17V18_VacuumBeforeBump asserts ADR-0001 audit H3: the
+// v17→v18 migration runs VACUUM before bumping schema_version. The
+// pre-fix order was bump-then-VACUUM; a VACUUM failure left the DB
+// stuck at v18 with the dropped step-7e plaintext bytes (subject,
+// body_text, body_html, message_headers.value, draft_json) stranded
+// in free pages forever, defeating the at-rest encryption story for
+// any cold filesystem image taken thereafter.
+//
+// The contract is: after migrate() completes for a fresh DB,
+// schema_version reaches the latest version AND a VACUUM has been
+// executed at least once on the v18 transition.
+//
+// We can't easily mock VACUUM failure inside SQLite, so the test
+// instead asserts the migration reaches v20+ (the v19→v20 follow-up
+// migration is itself a re-VACUUM that catches users who crossed v18
+// under the buggy order — its presence proves the audit-H3 cleanup
+// is wired in).
+func TestMigrateV17V18_VacuumBeforeBump(t *testing.T) {
+	dir := t.TempDir()
+	kr, err := dbcrypto.NewKeyring(bytes.Repeat([]byte{0x42}, dbcrypto.MasterKeyLen))
+	if err != nil {
+		t.Fatalf("test keyring: %v", err)
+	}
+	db, err := Open(filepath.Join(dir, "vac.db"), kr)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	defer db.Close()
+	if err := db.Init(); err != nil {
+		t.Fatalf("init: %v", err)
+	}
+	var version int
+	if err := db.db.QueryRow("SELECT version FROM schema_version WHERE rowid = 1").Scan(&version); err != nil {
+		t.Fatalf("read version: %v", err)
+	}
+	if version < 20 {
+		t.Errorf("schema_version = %d, want >= 20 (v19→v20 H3-followup re-VACUUM must be applied)", version)
+	}
+}

--- a/cli/internal/store/store.go
+++ b/cli/internal/store/store.go
@@ -761,20 +761,26 @@ func (d *DB) migrate() error {
 		}
 
 
-		if _, err := d.db.Exec("UPDATE schema_version SET version = 18 WHERE rowid = 1"); err != nil {
-			return fmt.Errorf("migrate v17→v18 bump: %w", err)
-		}
-
 		// VACUUM rebuilds the DB file to reclaim space from the dropped
 		// columns + FTS5 table. On a 20k-message mailbox this rewrites
 		// ~900 MB (the body plaintext duplication that's been sitting
 		// alongside body_text_ct since step 6). Slow — typically 30-90 s
 		// on a warm filesystem cache — but one-shot, after which the
 		// 1.8 GB DB should shrink back near the pre-encryption ~980 MB
-		// baseline (encrypted ct adds 29 bytes per blob; the plaintext
-		// duplication is gone).
+		// baseline.
+		//
+		// ADR-0001 audit H3: VACUUM runs BEFORE the schema_version bump.
+		// Earlier versions bumped first; a VACUUM crash (out of disk,
+		// interrupt, power loss) then left the DB stuck at v18 with the
+		// dropped columns' plaintext bytes still in free pages, and no
+		// migration code ever revisiting VACUUM. The v19→v20 migration
+		// below catches users who already crossed v18 under the old
+		// ordering and re-VACUUMs idempotently.
 		if _, err := d.db.Exec("VACUUM"); err != nil {
 			return fmt.Errorf("migrate v17→v18 vacuum: %w", err)
+		}
+		if _, err := d.db.Exec("UPDATE schema_version SET version = 18 WHERE rowid = 1"); err != nil {
+			return fmt.Errorf("migrate v17→v18 bump: %w", err)
 		}
 	}
 
@@ -806,6 +812,29 @@ func (d *DB) migrate() error {
 
 		if _, err := d.db.Exec("UPDATE schema_version SET version = 19 WHERE rowid = 1"); err != nil {
 			return fmt.Errorf("migrate v18→v19 bump: %w", err)
+		}
+	}
+
+	if version < 20 {
+		// ADR-0001 audit H3 follow-up: users who crossed v18 under the
+		// pre-fix bump-then-VACUUM ordering may have had VACUUM fail or
+		// be killed between the bump and the rewrite; the dropped step-7e
+		// plaintext bytes (subject / body_text / body_html / message_headers
+		// .value / draft_json) would have stayed stranded in free pages
+		// forever, defeating the at-rest encryption story for any cold
+		// filesystem image taken thereafter. Backups taken from such a
+		// DB carry the same residue. One-time idempotent re-VACUUM
+		// scrubs the free pages either way; on a clean v18→v19 install
+		// it is a relatively cheap no-op rewrite.
+		//
+		// VACUUM runs BEFORE the schema_version bump (lesson from H3
+		// itself): if it crashes, we want v20 to NOT be marked done so
+		// the next Init() retries it.
+		if _, err := d.db.Exec("VACUUM"); err != nil {
+			return fmt.Errorf("migrate v19→v20 vacuum: %w", err)
+		}
+		if _, err := d.db.Exec("UPDATE schema_version SET version = 20 WHERE rowid = 1"); err != nil {
+			return fmt.Errorf("migrate v19→v20 bump: %w", err)
 		}
 	}
 
@@ -977,7 +1006,25 @@ func (d *DB) backfillFlagsOtherFromShadow() error {
 // plaintext mailbox / account / flags columns and replace the
 // UNIQUE(message_id, account) constraint with UNIQUE(message_id,
 // account_id). SQLite's 12-step ALTER procedure.
+//
+// ADR-0001 audit H4: idempotent on retry. Earlier versions used a bare
+// CREATE TABLE messages_new without IF NOT EXISTS — a mid-stream
+// failure (OOM / disk-full / power loss during the multi-GB INSERT
+// SELECT) left the half-built temp table behind, and the next Init()
+// crashed at CREATE TABLE with "table already exists" → migration
+// permanently wedged. We now DROP the temp table at entry and wrap
+// the whole rebuild in a transaction so partial states roll back
+// cleanly.
 func (d *DB) rebuildMessagesForStep7f() error {
+	// DROP any half-built messages_new from a previous interrupted
+	// attempt. Outside the transaction — if it errors (it shouldn't,
+	// IF EXISTS is non-failing) we want to surface that before any
+	// destructive operation. Outside the BEGIN/COMMIT block because
+	// SQLite implicit-commits on DDL anyway, so wrapping it in the tx
+	// would only obscure the ordering.
+	if _, err := d.db.Exec(`DROP TABLE IF EXISTS messages_new`); err != nil {
+		return fmt.Errorf("rebuild pre-cleanup: %w", err)
+	}
 	stmts := []string{
 		`PRAGMA foreign_keys = OFF`,
 		// The new table mirrors the current messages schema minus the

--- a/cli/internal/store/store_test.go
+++ b/cli/internal/store/store_test.go
@@ -42,8 +42,8 @@ func TestOpenAndInit(t *testing.T) {
 	if err != nil {
 		t.Fatalf("read version: %v", err)
 	}
-	if version != 19 {
-		t.Errorf("version = %d, want 19", version)
+	if version != 20 {
+		t.Errorf("version = %d, want 20", version)
 	}
 }
 
@@ -185,8 +185,8 @@ func TestMigrateV9_PopulatesMailboxesAndAccounts(t *testing.T) {
 	if err := db.QueryRow("SELECT version FROM schema_version WHERE rowid = 1").Scan(&version); err != nil {
 		t.Fatalf("read version: %v", err)
 	}
-	if version != 19 {
-		t.Fatalf("version = %d, want 19", version)
+	if version != 20 {
+		t.Fatalf("version = %d, want 20", version)
 	}
 
 	// mailboxes must contain exactly INBOX and Drafts (case-collapsed).

--- a/docs/content/docs/developers/design/0001-mail-content-encryption-at-rest.md
+++ b/docs/content/docs/developers/design/0001-mail-content-encryption-at-rest.md
@@ -326,15 +326,37 @@ whole corpus.
 
 V1 migration (`store.migrate()` adds a new version step):
 
-1. Bump `schema_version` to next free integer.
-2. Open transaction, for each `messages` row: read plaintext, encrypt each
+1. Open transaction, for each `messages` row: read plaintext, encrypt each
    sensitive field with the appropriate sub-key, write `BLOB` back via
    `UPDATE`. Same for `message_headers`, `local_drafts`, `outbox`, `contacts`.
-3. Drop and recreate `messages_fts` using the new schema, repopulate by
+2. Drop and recreate `messages_fts` using the new schema, repopulate by
    reading decrypted rows and running them through the tokenizer pipeline.
-4. `VACUUM` to reclaim plaintext pages.
-5. Run `PRAGMA secure_delete = ON` permanently from this point on (a
-   forward-only switch on the DB header).
+3. `VACUUM` to reclaim plaintext pages.
+4. Only then bump `schema_version` to the next free integer.
+5. `PRAGMA secure_delete = ON` is set on every connection in `store.Open` /
+   `contacts.Open` (step 8) so subsequent DELETEs / UPDATEs scrub freed
+   pages too.
+
+**Step ordering note (ADR-0001 audit H3).** VACUUM must precede the
+`schema_version` bump on any migration that drops plaintext columns or
+tables. The pre-fix v17→v18 reversed this; a VACUUM failure on a
+multi-GB DB left users stuck at v18 with the dropped step-7e plaintext
+bytes (`subject`, `body_text`, `body_html`, `message_headers.value`,
+`draft_json`) stranded in free pages forever, defeating the at-rest
+encryption story for any cold filesystem image taken thereafter. A
+follow-up v19→v20 migration is a one-shot re-VACUUM that catches
+users who already crossed v18 under the buggy ordering. Same lesson
+applies to any future migration that drops sensitive content.
+
+**Table rebuild idempotency (ADR-0001 audit H4).** Migrations that use
+SQLite's 12-step table-rebuild (e.g. `rebuildMessagesForStep7f` for the
+step 7f UNIQUE-constraint swap) must `DROP TABLE IF EXISTS` the
+temp-table name at entry. A mid-rebuild crash (OOM on a multi-GB INSERT
+SELECT, disk-full, power loss) otherwise leaves a half-built
+`messages_new` behind, and the next `Init()` wedges at "table already
+exists" with no recovery path. A regression test
+(`TestRebuildMessages_IdempotentAfterPartialFailure`) simulates the
+leftover state and asserts the rebuild re-enters cleanly.
 
 Since Durian is pre-1.0 and has no production users with multi-GB mailboxes,
 the migration runs synchronously at first open after upgrade. Progress is


### PR DESCRIPTION
## Summary

Two migration-correctness fixes from the post-step-8 audit, landed together because they touch the same \`migrate()\` function and share the audit-driven framing.

### H3 — VACUUM-before-bump

The v17→v18 migration bumped \`schema_version\` BEFORE running VACUUM. A VACUUM failure (OOM, disk-full, power loss) locked the DB at v18 with the dropped step-7e plaintext bytes (subject / body_text / body_html / message_headers.value / draft_json) stranded in free pages forever. No subsequent migration revisited VACUUM, so the at-rest encryption story silently broke for any cold filesystem image taken thereafter. Step 8's \`PRAGMA secure_delete = ON\` does NOT retroactively scrub existing free pages.

- Swap the order in v17→v18: VACUUM first, then bump.
- New v19→v20 migration is a one-shot re-VACUUM that catches users who already crossed v18 under the buggy ordering. Idempotent on clean installs.

### H4 — \`rebuildMessagesForStep7f\` idempotency

The function CREATE TABLEd \`messages_new\` without IF NOT EXISTS. A crash mid INSERT-SELECT (the multi-GB row copy) left the half-built temp table behind; the next Init() crashed at CREATE TABLE with \"table already exists\" → migration permanently wedged.

- Prepend \`DROP TABLE IF EXISTS messages_new\` at function entry so re-entry is clean. Rest of the rebuild already used CREATE INDEX/TRIGGER IF NOT EXISTS.

### Tests

- \`TestRebuildMessages_IdempotentAfterPartialFailure\` — seeds a fake leftover \`messages_new\` with junk content, calls the rebuild directly, asserts no error and the junk doesn't leak into the rebuilt table.
- \`TestMigrateV17V18_VacuumBeforeBump\` — asserts a fresh DB reaches \`schema_version >= 20\` (the v19→v20 H3-followup re-VACUUM proves the audit-H3 cleanup is wired in).
- \`TestOpenAndInit\` + \`TestMigrateV9_PopulatesMailboxesAndAccounts\` expected-version bumped from 19 to 20.

### ADR

- §5 Migration: order rewritten — VACUUM precedes the bump.
- New \"Step ordering note (ADR-0001 audit H3)\" subsection.
- New \"Table rebuild idempotency (ADR-0001 audit H4)\" subsection.

## Test plan

- [x] All 18 CLI unit tests pass; encryption grep-gate clean.
- [x] New regression tests cover both H3 (v19→v20 re-VACUUM wired in) and H4 (re-entry after partial rebuild).