### PR TITLE
fix(go-master-key,go-handler): ADR-0001 audit medium — env-var lifecycle + outbox error sanitization

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,7 +30,7 @@ jobs:
         # The integration test starts `durian serve`, which normally
         # bootstraps the ADR-0001 master key from the OS keychain.
         # Headless CI has no Secret Service implementation, so we pass
-        # the key in via DURIAN_MASTER_KEY_HEX — see cmd/durian/master_key.go
+        # the key in via DURIAN_MASTER_KEY_HEX_SECRET — see cmd/durian/master_key.go
         # for the bypass behaviour. The value is throwaway test data.
         run: bazel test //integration:integration_test --test_output=all
 

--- a/cli/cmd/durian/master_key.go
+++ b/cli/cmd/durian/master_key.go
@@ -17,10 +17,24 @@ import (
 
 // envMasterKeyHex is an override env var read by bootstrapKeyring before
 // touching the OS keychain. Intended exclusively for integration tests
-// and CI environments that have no Secret Service implementation. Setting
-// this in production is logged at Warn level on every startup so the
-// misuse is visible in serve.log.
-const envMasterKeyHex = "DURIAN_MASTER_KEY_HEX"
+// and CI environments that have no Secret Service implementation.
+//
+// ADR-0001 audit medium-priority: the variable name includes "SECRET"
+// so log scrubbers, GitHub push-protection, and generic
+// secret-detection patterns flag it automatically. The legacy name
+// DURIAN_MASTER_KEY_HEX (without _SECRET) is still recognized for
+// one release as a deprecation grace period; setting it emits a Warn
+// telling the operator to rename.
+//
+// On any successful read, bootstrapKeyring immediately os.Unsetenv's
+// the variable so it doesn't propagate to child processes (sync
+// helpers, exec'd hooks) and doesn't appear in coredumps captured
+// after the read. Visibility into legitimate test/CI use is preserved
+// via the Warn log line.
+const (
+	envMasterKeyHex          = "DURIAN_MASTER_KEY_HEX_SECRET"
+	envMasterKeyHexLegacy    = "DURIAN_MASTER_KEY_HEX"
+)
 
 // Flags
 var (
@@ -89,18 +103,41 @@ func init() {
 // store.Open. Fatal-exits on any error so the daemon never starts in a
 // state where encrypt-on-write would silently no-op.
 //
-// If DURIAN_MASTER_KEY_HEX is set, the keychain path is skipped entirely
-// and the env var's 64-char hex is used verbatim. This exists for the
-// integration test and headless CI where there is no Secret Service
-// implementation. A Warn-level audit line accompanies every use so
-// accidental production deployments are visible in serve.log.
+// If DURIAN_MASTER_KEY_HEX_SECRET (or the legacy DURIAN_MASTER_KEY_HEX)
+// is set, the keychain path is skipped entirely and the env var's
+// 64-char hex is used verbatim. This exists for the integration test
+// and headless CI where there is no Secret Service implementation.
+// A Warn-level audit line accompanies every use so accidental
+// production deployments are visible in serve.log.
+//
+// ADR-0001 audit medium: the env var is os.Unsetenv'd immediately on
+// read so it doesn't propagate to child processes or land in coredumps
+// captured after the read. The legacy name emits an additional Warn
+// asking the operator to rename — one-release deprecation grace period.
 func bootstrapKeyring() *dbcrypto.Keyring {
-	if raw := strings.TrimSpace(os.Getenv(envMasterKeyHex)); raw != "" {
+	rawCanonical := strings.TrimSpace(os.Getenv(envMasterKeyHex))
+	rawLegacy := strings.TrimSpace(os.Getenv(envMasterKeyHexLegacy))
+	raw := rawCanonical
+	source := envMasterKeyHex
+	if raw == "" && rawLegacy != "" {
+		raw = rawLegacy
+		source = envMasterKeyHexLegacy
+		slog.Warn("DURIAN_MASTER_KEY_HEX is deprecated — rename to DURIAN_MASTER_KEY_HEX_SECRET so secret-detection tooling catches it",
+			"module", "MASTER-KEY")
+	}
+	// Clear BOTH names from the process environment regardless of which
+	// (if either) was set — defense in depth against later code
+	// re-reading. Errors from Unsetenv are not actionable here; in the
+	// worst case the original value stays in /proc/self/environ but we
+	// have not made things worse than the pre-fix state.
+	_ = os.Unsetenv(envMasterKeyHex)
+	_ = os.Unsetenv(envMasterKeyHexLegacy)
+	if raw != "" {
 		master, err := hex.DecodeString(raw)
 		if err != nil || len(master) != dbcrypto.MasterKeyLen {
-			slog.Error("DURIAN_MASTER_KEY_HEX is set but not a valid 64-char hex of 32 bytes",
+			slog.Error(source+" is set but not a valid 64-char hex of 32 bytes",
 				"module", "MASTER-KEY", "err", err, "len", len(master))
-			fmt.Fprintln(os.Stderr, "Error: DURIAN_MASTER_KEY_HEX must be a 64-character hex string (32 bytes)")
+			fmt.Fprintln(os.Stderr, "Error: "+source+" must be a 64-character hex string (32 bytes)")
 			os.Exit(1)
 		}
 		kr, err := dbcrypto.NewKeyring(master)
@@ -109,7 +146,7 @@ func bootstrapKeyring() *dbcrypto.Keyring {
 			fmt.Fprintln(os.Stderr, "Error: keyring derivation failed:", err)
 			os.Exit(1)
 		}
-		slog.Warn("Master key sourced from DURIAN_MASTER_KEY_HEX (test/CI mode — NOT for production)",
+		slog.Warn("Master key sourced from "+source+" (test/CI mode — NOT for production)",
 			"module", "MASTER-KEY")
 		return kr
 	}

--- a/cli/cmd/testseeder/main.go
+++ b/cli/cmd/testseeder/main.go
@@ -19,16 +19,21 @@ import (
 // code never touches this path — the seeder builds throwaway fixtures
 // for integration tests against an HTTP server it controls.
 //
-// Honours DURIAN_MASTER_KEY_HEX (same env var that durian serve reads)
-// so the integration test can seed and serve with the same key — without
-// it, ciphertexts written by the seeder would be unreadable by serve.
-// Falls back to a fixed 0xee*32 master when the env var is unset.
+// Honours DURIAN_MASTER_KEY_HEX_SECRET (the env var that durian serve
+// reads — ADR-0001 audit medium renamed it from DURIAN_MASTER_KEY_HEX
+// so secret-detection tooling catches it). Legacy name still
+// recognized for grace period. Falls back to a fixed 0xee*32 master
+// when neither env var is set.
 func testKeyring() *dbcrypto.Keyring {
 	var master []byte
-	if raw := strings.TrimSpace(os.Getenv("DURIAN_MASTER_KEY_HEX")); raw != "" {
+	raw := strings.TrimSpace(os.Getenv("DURIAN_MASTER_KEY_HEX_SECRET"))
+	if raw == "" {
+		raw = strings.TrimSpace(os.Getenv("DURIAN_MASTER_KEY_HEX"))
+	}
+	if raw != "" {
 		m, err := hex.DecodeString(raw)
 		if err != nil || len(m) != dbcrypto.MasterKeyLen {
-			panic(fmt.Sprintf("testseeder: DURIAN_MASTER_KEY_HEX must be 64-char hex of 32 bytes (got len=%d, err=%v)", len(m), err))
+			panic(fmt.Sprintf("testseeder: DURIAN_MASTER_KEY_HEX_SECRET must be 64-char hex of 32 bytes (got len=%d, err=%v)", len(m), err))
 		}
 		master = m
 	} else {

--- a/cli/internal/handler/BUILD.bazel
+++ b/cli/internal/handler/BUILD.bazel
@@ -5,6 +5,7 @@ go_library(
     srcs = [
         "contacts.go",
         "drafts.go",
+        "error_sanitize.go",
         "events.go",
         "handler.go",
         "http.go",
@@ -41,6 +42,7 @@ go_test(
     srcs = [
         "convert_thread_test.go",
         "drafts_test.go",
+        "error_sanitize_test.go",
         "handler_test.go",
         "http_test.go",
         "ratelimit_test.go",
@@ -51,6 +53,7 @@ go_test(
         "//cli/internal/contacts",
         "//cli/internal/dbcrypto",
         "//cli/internal/protocol",
+        "//cli/internal/smtp",
         "//cli/internal/store",
         "@com_github_emersion_go_imap//:go-imap",
         "@com_github_gorilla_mux//:mux",

--- a/cli/internal/handler/error_sanitize.go
+++ b/cli/internal/handler/error_sanitize.go
@@ -1,0 +1,74 @@
+package handler
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net"
+
+	"github.com/durian-dev/durian/cli/internal/smtp"
+)
+
+// sanitizeOutboxError returns a string safe to persist in outbox.last_error
+// and broadcast over SSE to the GUI. ADR-0001 audit medium: the raw
+// err.Error() string from json.Unmarshal, base64.DecodeString,
+// SMTP-server 5xx responses, etc. can echo fragments of the draft body
+// (subject, recipient addresses, raw bytes) — none of which should
+// reach a serialized DB column or the SSE channel that any GUI tab can
+// observe.
+//
+// Strategy: classify into known-safe categories that return a fixed
+// or value-stripped sentence; unknown errors fall back to a generic
+// "send failed (see serve.log)" so the full message is only available
+// in the redact-wrapped slog stream, not in user-facing surfaces.
+func sanitizeOutboxError(err error) string {
+	if err == nil {
+		return ""
+	}
+
+	// SMTP errors: keep the protocol code, drop the server-supplied
+	// message which on Gmail/Office365 frequently echoes the offending
+	// header (To: address, Subject fragment) verbatim.
+	var smtpErr *smtp.SMTPError
+	if errors.As(err, &smtpErr) {
+		category := "transient"
+		if smtpErr.IsPermanent() {
+			category = "permanent"
+		}
+		return fmt.Sprintf("smtp %d %s (server response stripped)", smtpErr.Code, category)
+	}
+
+	// JSON unmarshal errors: the type-error variant echoes the value at
+	// the offending offset. The syntax-error variant echoes the byte
+	// offset only (safe) but other implementations may include context.
+	var jsonSyntax *json.SyntaxError
+	var jsonType *json.UnmarshalTypeError
+	if errors.As(err, &jsonSyntax) {
+		return fmt.Sprintf("invalid draft JSON: syntax error at offset %d", jsonSyntax.Offset)
+	}
+	if errors.As(err, &jsonType) {
+		return fmt.Sprintf("invalid draft JSON: type mismatch at offset %d (expected %s)", jsonType.Offset, jsonType.Type)
+	}
+
+	// Base64 attachment decode: the corrupt-input error includes the
+	// offending byte position which can be a substring of the encoded
+	// data; the position alone is benign.
+	var b64Err base64.CorruptInputError
+	if errors.As(err, &b64Err) {
+		return fmt.Sprintf("attachment decode failed: corrupt base64 at byte %d", int64(b64Err))
+	}
+
+	// Network errors: timeout / connection refused / DNS — these
+	// include host names which are public (the configured SMTP server)
+	// and do not echo draft content. Safe to surface verbatim.
+	var netErr *net.OpError
+	if errors.As(err, &netErr) {
+		return fmt.Sprintf("network error (%s): %s", netErr.Op, netErr.Err)
+	}
+
+	// Default: opaque sentinel. The full error is in serve.log via the
+	// matching slog.Error call at the original site; the GUI sees only
+	// that something failed, not what the server said.
+	return "send failed (details in serve.log)"
+}

--- a/cli/internal/handler/error_sanitize_test.go
+++ b/cli/internal/handler/error_sanitize_test.go
@@ -1,0 +1,114 @@
+package handler
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"net"
+	"strings"
+	"testing"
+
+	"github.com/durian-dev/durian/cli/internal/smtp"
+)
+
+// TestSanitizeOutboxError_StripsSMTPServerResponse asserts ADR-0001
+// audit medium: an SMTP 5xx response body (which on Gmail / Office365
+// commonly echoes the offending To: address or Subject fragment) must
+// not appear in outbox.last_error (DB-persisted, shown in GUI) or in
+// the SSE broadcast. The sanitized form keeps the protocol code so
+// triage stays possible.
+func TestSanitizeOutboxError_StripsSMTPServerResponse(t *testing.T) {
+	// Construct a realistic SMTP error carrying a server message that
+	// references private content.
+	leaky := &smtp.SMTPError{
+		Code:    550,
+		Message: "5.7.1 [alice@private.example] Recipient address rejected: Subject 'Acquisition Q4 plans' triggered policy",
+	}
+	got := sanitizeOutboxError(leaky)
+	if strings.Contains(got, "alice@private.example") {
+		t.Errorf("sanitized output leaks recipient address: %q", got)
+	}
+	if strings.Contains(got, "Acquisition Q4") {
+		t.Errorf("sanitized output leaks subject fragment: %q", got)
+	}
+	if !strings.Contains(got, "550") {
+		t.Errorf("sanitized output should keep the protocol code, got %q", got)
+	}
+	if !strings.Contains(got, "permanent") {
+		t.Errorf("sanitized output should classify 5xx as permanent, got %q", got)
+	}
+}
+
+func TestSanitizeOutboxError_JSONUnmarshalKeepsOffset(t *testing.T) {
+	// json.SyntaxError carries .Offset; the message body may also
+	// echo bytes near that offset depending on Go version. We keep
+	// the offset (useful for debugging) but never the surrounding
+	// bytes — sanitizer should produce a fixed-shape message.
+	bad := []byte(`{"subject": "secret-draft-content", THIS-IS-INVALID}`)
+	var dst map[string]any
+	err := json.Unmarshal(bad, &dst)
+	if err == nil {
+		t.Fatal("unmarshal should have errored on malformed JSON")
+	}
+	got := sanitizeOutboxError(err)
+	if strings.Contains(got, "secret-draft-content") {
+		t.Errorf("sanitized output leaks draft content: %q", got)
+	}
+	if !strings.Contains(got, "offset") {
+		t.Errorf("sanitized output should mention the offset for debugging, got %q", got)
+	}
+}
+
+func TestSanitizeOutboxError_Base64KeepsBytePos(t *testing.T) {
+	_, err := base64.StdEncoding.DecodeString("totally-not-base64-data-with-secret-bytes")
+	if err == nil {
+		t.Fatal("decode should have errored")
+	}
+	got := sanitizeOutboxError(err)
+	if strings.Contains(got, "secret-bytes") {
+		t.Errorf("sanitized output leaks attachment data: %q", got)
+	}
+	if !strings.Contains(got, "corrupt base64") {
+		t.Errorf("sanitized output should name the category, got %q", got)
+	}
+}
+
+func TestSanitizeOutboxError_NetworkSafeVerbatim(t *testing.T) {
+	// Network errors carry hostnames (public, configured by user) and
+	// op names (e.g. "dial"). Verbatim is acceptable — there's no
+	// draft content in this category.
+	netErr := &net.OpError{
+		Op:  "dial",
+		Net: "tcp",
+		Err: errors.New("connection refused"),
+	}
+	got := sanitizeOutboxError(netErr)
+	if !strings.Contains(got, "dial") {
+		t.Errorf("sanitized output should retain the op for triage, got %q", got)
+	}
+	if !strings.Contains(got, "connection refused") {
+		t.Errorf("sanitized output should retain the underlying cause for network errors, got %q", got)
+	}
+}
+
+func TestSanitizeOutboxError_UnknownIsOpaque(t *testing.T) {
+	// An error type the sanitizer doesn't recognize. The raw .Error()
+	// might contain anything — return the opaque sentinel.
+	mystery := errors.New("Subject: Top-secret merger draft contents reflected in error wrap")
+	got := sanitizeOutboxError(mystery)
+	if strings.Contains(got, "merger draft") {
+		t.Errorf("sanitized output leaks unknown-class error contents: %q", got)
+	}
+	if !strings.Contains(got, "send failed") {
+		t.Errorf("sanitized output should use opaque sentinel, got %q", got)
+	}
+	if !strings.Contains(got, "serve.log") {
+		t.Errorf("sanitized output should point operator to the log file for the full error, got %q", got)
+	}
+}
+
+func TestSanitizeOutboxError_NilIsEmpty(t *testing.T) {
+	if got := sanitizeOutboxError(nil); got != "" {
+		t.Errorf("sanitizeOutboxError(nil) = %q, want empty", got)
+	}
+}

--- a/cli/internal/handler/outbox.go
+++ b/cli/internal/handler/outbox.go
@@ -197,7 +197,7 @@ func (w *OutboxWorker) sendItem(item *store.OutboxItem) {
 	var draft OutboxDraft
 	if err := json.Unmarshal([]byte(item.DraftJSON), &draft); err != nil {
 		slog.Error("Failed to unmarshal draft", "module", "OUTBOX", "id", item.ID, "err", err)
-		w.store.MarkAttempted(item.ID, "invalid draft JSON: "+err.Error())
+		w.store.MarkAttempted(item.ID, sanitizeOutboxError(err))
 		return
 	}
 
@@ -215,8 +215,9 @@ func (w *OutboxWorker) sendItem(item *store.OutboxItem) {
 	smtpAuth, err := auth.GetSMTPAuth(account)
 	if err != nil {
 		slog.Error("Auth failed for outbox item", "module", "OUTBOX", "id", item.ID, "err", err)
-		w.store.MarkAttempted(item.ID, "auth: "+err.Error())
-		w.broadcastStatus(item.ID, "failed", err.Error(), draft.Subject, strings.Join(draft.To, ", "))
+		safeMsg := "auth: " + sanitizeOutboxError(err)
+		w.store.MarkAttempted(item.ID, safeMsg)
+		w.broadcastStatus(item.ID, "failed", safeMsg, draft.Subject, strings.Join(draft.To, ", "))
 		return
 	}
 
@@ -243,8 +244,11 @@ func (w *OutboxWorker) sendItem(item *store.OutboxItem) {
 		data, err := base64.StdEncoding.DecodeString(att.DataBase64)
 		if err != nil {
 			slog.Error("Failed to decode attachment", "module", "OUTBOX", "id", item.ID, "filename", att.Filename, "err", err)
-			w.store.MarkAttempted(item.ID, "attachment decode: "+err.Error())
-			w.broadcastStatus(item.ID, "failed", "Bad attachment: "+att.Filename, draft.Subject, strings.Join(draft.To, ", "))
+			safeMsg := "attachment decode: " + sanitizeOutboxError(err)
+			w.store.MarkAttempted(item.ID, safeMsg)
+			// Drop the filename from the SSE broadcast too — it's
+			// user-supplied content that may carry sensitive metadata.
+			w.broadcastStatus(item.ID, "failed", safeMsg, draft.Subject, strings.Join(draft.To, ", "))
 			return
 		}
 		msg.Attachments = append(msg.Attachments, smtp.Attachment{
@@ -268,13 +272,17 @@ func (w *OutboxWorker) sendItem(item *store.OutboxItem) {
 		smtpErr := smtp.ParseSMTPError(err)
 		slog.Error("SMTP send failed", "module", "OUTBOX", "id", item.ID, "err", err)
 
+		// ADR-0001 audit medium: sanitize before DB-persist + SSE so
+		// the server-supplied response body (Gmail/O365 echo To: /
+		// Subject: fragments in 5xx) never reaches the GUI.
+		safeMsg := sanitizeOutboxError(err)
 		if smtpErr != nil && smtpErr.IsPermanent() {
 			// 5xx permanent error — poison immediately
-			w.store.PoisonOutboxItem(item.ID, "permanent: "+err.Error())
+			w.store.PoisonOutboxItem(item.ID, safeMsg)
 		} else {
-			w.store.MarkAttempted(item.ID, err.Error())
+			w.store.MarkAttempted(item.ID, safeMsg)
 		}
-		w.broadcastStatus(item.ID, "failed", err.Error(), draft.Subject, strings.Join(draft.To, ", "))
+		w.broadcastStatus(item.ID, "failed", safeMsg, draft.Subject, strings.Join(draft.To, ", "))
 		return
 	}
 

--- a/integration/integration_test.sh
+++ b/integration/integration_test.sh
@@ -65,10 +65,13 @@ assert_http_code() {
 
 # ADR-0001 step 4/5: seeder and serve must agree on the master encryption
 # key, otherwise serve cannot decrypt the subjects the seeder wrote.
-# DURIAN_MASTER_KEY_HEX is read by both binaries; the keychain is bypassed
-# in this test environment (headless CI has no Secret Service). The value
-# is throwaway test data — no production secret.
-export DURIAN_MASTER_KEY_HEX="0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+# DURIAN_MASTER_KEY_HEX_SECRET is read by both binaries; the keychain is
+# bypassed in this test environment (headless CI has no Secret Service).
+# The value is throwaway test data — no production secret. The _SECRET
+# suffix is intentional (audit medium): generic secret-detection
+# scanners pattern-match on SECRET / KEY / TOKEN word fragments and will
+# now flag this variable if it ever leaks into a log file or commit.
+export DURIAN_MASTER_KEY_HEX_SECRET="0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
 
 echo "==> Seeding test databases"
 "$SEEDER" "$EMAIL_DB" "$CONTACTS_DB"


### PR DESCRIPTION
## Summary

Two audit-medium fixes that share the same threat shape (sensitive content leaking into surfaces the redact wrapper doesn't cover), landed together per the audit ship-stop sequence.

### env-var lifecycle

- Rename \`DURIAN_MASTER_KEY_HEX\` → \`DURIAN_MASTER_KEY_HEX_SECRET\`. The \`_SECRET\` suffix triggers generic secret-detection tooling (GitHub push-protection, log scrubbers, trufflehog-class scanners); the previous name was generic enough that none of those caught it if a user ever exported it in a shell rc and committed shell history.
- \`bootstrapKeyring\` \`os.Unsetenv\`'s BOTH the canonical and legacy names immediately on read, so the value doesn't propagate to child processes or appear in coredumps captured after the read.
- Legacy name still recognized for one release with a Warn telling the operator to rename.
- testseeder, integration_test.sh, CI workflow comment all updated.

### outbox \`last_error\` sanitization

- New \`sanitizeOutboxError(err)\` classifier (\`cli/internal/handler/error_sanitize.go\`). Recognizes \`smtp.SMTPError\`, \`json.SyntaxError\`, \`json.UnmarshalTypeError\`, \`base64.CorruptInputError\`, \`net.OpError\`; everything else collapses to opaque \`send failed (details in serve.log)\`.
- SMTP 5xx responses on Gmail / O365 commonly echo the offending \`To:\` address or \`Subject:\` fragment in the server-supplied message body; sanitizer keeps the protocol code for triage and strips the rest.
- 5 call sites in \`outbox.go\` routed through the sanitizer (Unmarshal, GetSMTPAuth, base64 decode, transient SMTP send, permanent SMTP send). The full \`err\` continues to go to slog (redact-wrapped); only the DB-persisted \`last_error\` and SSE broadcast use the sanitized form.

## Test plan

- [x] All 18 CLI unit tests pass; encryption grep-gate clean.
- [x] 6 new \`TestSanitizeOutboxError_*\` cases cover SMTP server-response leak, JSON-body leak, base64-data leak, network-error verbatim path, unknown-class opaque path, and the nil-input contract.