### PR TITLE
fix(go-dbcrypto,go-store): ADR-0001 audit medium — length-prefix bigram HMAC input

### DIFF
--- a/cli/internal/dbcrypto/tokenize.go
+++ b/cli/internal/dbcrypto/tokenize.go
@@ -3,6 +3,7 @@ package dbcrypto
 import (
 	"crypto/hmac"
 	"crypto/sha256"
+	"encoding/binary"
 	"encoding/hex"
 	"strings"
 	"unicode"
@@ -45,13 +46,37 @@ func TokenizeFTS(key []byte, plaintext string) string {
 		out = append(out, hmacHex(key, []byte(w)))
 	}
 	for i := 0; i < len(words)-1; i++ {
-		var buf strings.Builder
-		buf.WriteString(words[i])
-		buf.WriteByte(0x1f)
-		buf.WriteString(words[i+1])
-		out = append(out, hmacHex(key, []byte(buf.String())))
+		out = append(out, hmacHex(key, bigramInput(words[i], words[i+1])))
 	}
 	return strings.Join(out, " ")
+}
+
+// bigramInput encodes an adjacent-pair as length-prefixed bytes so the
+// HMAC input is unambiguous regardless of what characters appear in
+// the words. ADR-0001 audit medium: the previous encoding used a
+// literal 0x1F unit-separator byte between words. uniseg's behavior on
+// stray control characters within a Unicode word is not specified by
+// its API, so a future uniseg update that started segmenting U+001F
+// differently (or any attacker who could smuggle a literal 0x1F into
+// a word via HTML attributes / invisible body text) could forge a
+// bigram HMAC for a phrase pair that doesn't actually appear
+// adjacently in the source: HMAC(key, "foo" + 0x1F + "bar") equals
+// HMAC(key, "foo\x1Fbar") byte-for-byte.
+//
+// Length-prefix encoding (uvarint len(w1) || w1 || uvarint len(w2) || w2)
+// is bijective — no two distinct (w1, w2) pairs share the same byte
+// sequence — so the construction is forgery-free independent of
+// what runes the tokenizer accepts.
+func bigramInput(a, b string) []byte {
+	buf := make([]byte, 0, len(a)+len(b)+binary.MaxVarintLen64*2)
+	var tmp [binary.MaxVarintLen64]byte
+	n := binary.PutUvarint(tmp[:], uint64(len(a)))
+	buf = append(buf, tmp[:n]...)
+	buf = append(buf, a...)
+	n = binary.PutUvarint(tmp[:], uint64(len(b)))
+	buf = append(buf, tmp[:n]...)
+	buf = append(buf, b...)
+	return buf
 }
 
 // TokenizeFTSQuery returns the same per-word HMAC tokens TokenizeFTS
@@ -98,11 +123,7 @@ func TokenizeFTSPhrase(key []byte, plaintext string) string {
 		out = append(out, hmacHex(key, []byte(w)))
 	}
 	for i := 0; i < len(words)-1; i++ {
-		var buf strings.Builder
-		buf.WriteString(words[i])
-		buf.WriteByte(0x1f)
-		buf.WriteString(words[i+1])
-		out = append(out, hmacHex(key, []byte(buf.String())))
+		out = append(out, hmacHex(key, bigramInput(words[i], words[i+1])))
 	}
 	return strings.Join(out, " ")
 }

--- a/cli/internal/dbcrypto/tokenize_test.go
+++ b/cli/internal/dbcrypto/tokenize_test.go
@@ -142,6 +142,37 @@ func TestTokenizeFTSPhrase_SingleWordDegrades(t *testing.T) {
 	}
 }
 
+// TestTokenizeFTS_BigramForgeryUnitSeparator asserts ADR-0001 audit
+// medium: a literal U+001F (unit separator) byte smuggled into a word
+// must NOT produce the same HMAC as the legitimate adjacent-pair
+// bigram of the two halves. The pre-fix encoding wrote bigrams as
+// `word_i || 0x1F || word_{i+1}`, so HMAC("foo" + 0x1F + "bar") was
+// byte-identical to HMAC of the single segment "foo\x1Fbar" treated
+// as one word. Length-prefixed encoding is bijective: distinct word
+// pairs cannot collide regardless of contents.
+func TestTokenizeFTS_BigramForgeryUnitSeparator(t *testing.T) {
+	key := bytes.Repeat([]byte{0x42}, KeyLen)
+	// Legitimate bigram from the two-word segmentation. Use unigram-
+	// only TokenizeFTSQuery on "foo bar" and full TokenizeFTS to
+	// compare the bigram token shape.
+	full := strings.Fields(TokenizeFTS(key, "foo bar"))
+	if len(full) != 3 {
+		t.Fatalf("expected 2 unigrams + 1 bigram = 3 tokens, got %d", len(full))
+	}
+	legitimateBigram := full[2]
+
+	// Attempt to forge: HMAC of the bigram-input bytes assembled by
+	// the pre-fix encoding, "foo" + 0x1F + "bar".
+	forgeryInput := []byte("foo")
+	forgeryInput = append(forgeryInput, 0x1F)
+	forgeryInput = append(forgeryInput, "bar"...)
+	forgery := hmacHex(key, forgeryInput)
+
+	if legitimateBigram == forgery {
+		t.Errorf("bigram forgery via 0x1F succeeded — encoding is not bijective")
+	}
+}
+
 func TestTokenizeFTSPhrase_EmptyInput(t *testing.T) {
 	key := bytes.Repeat([]byte{0x42}, KeyLen)
 	for _, s := range []string{"", "   ", "..."} {

--- a/cli/internal/store/migrate_audit_test.go
+++ b/cli/internal/store/migrate_audit_test.go
@@ -88,4 +88,9 @@ func TestMigrateV17V18_VacuumBeforeBump(t *testing.T) {
 	if version < 20 {
 		t.Errorf("schema_version = %d, want >= 20 (v19→v20 H3-followup re-VACUUM must be applied)", version)
 	}
+	// audit-medium follow-up: v20→v21 must also have applied (bigram
+	// HMAC encoding fix that rebuilds messages_blind_fts).
+	if version < 21 {
+		t.Errorf("schema_version = %d, want >= 21 (v20→v21 bigram-encoding rebuild must be applied)", version)
+	}
 }

--- a/cli/internal/store/store.go
+++ b/cli/internal/store/store.go
@@ -838,6 +838,97 @@ func (d *DB) migrate() error {
 		}
 	}
 
+	if version < 21 {
+		// ADR-0001 audit medium follow-up: bigram-HMAC input encoding
+		// changed from `word_i || 0x1F || word_{i+1}` to length-prefixed
+		// `uvarint(len(w1)) || w1 || uvarint(len(w2)) || w2`. The old
+		// encoding was vulnerable to a forgery class where a literal
+		// 0x1F (U+001F unit separator) smuggled into a word — via HTML
+		// attribute / invisible body text / a future uniseg change in
+		// how it segments control characters — would HMAC-collide with
+		// a legitimate bigram and forge a phrase match. The new
+		// encoding is bijective: no two distinct (w1, w2) pairs share
+		// the same input bytes, regardless of what runes are in the
+		// words.
+		//
+		// Every existing messages_blind_fts row was tokenized with the
+		// old encoding; phrase queries would silently stop matching.
+		// Wipe and rebuild the FTS index from authoritative ct
+		// columns. Word-AND queries (unigrams only) survive across
+		// the change but we rebuild those too for consistency — the
+		// extra cost is one VACUUM-class re-tokenization, comparable
+		// to step-7a's original index build.
+		if err := d.rebuildBlindFTSForBigramEncoding(); err != nil {
+			return fmt.Errorf("migrate v20→v21 rebuild blind fts: %w", err)
+		}
+		if _, err := d.db.Exec("UPDATE schema_version SET version = 21 WHERE rowid = 1"); err != nil {
+			return fmt.Errorf("migrate v20→v21 bump: %w", err)
+		}
+	}
+
+	return nil
+}
+
+// rebuildBlindFTSForBigramEncoding wipes and repopulates
+// messages_blind_fts. Used by the v20→v21 migration after the bigram
+// HMAC input encoding changed. Reads exclusively from the ct columns
+// (step 7e dropped the plaintext subject / body_text shadows that
+// backfillBlindFTS still references for v15→v16 backfills on legacy
+// schemas), and uses the d.blindTokens helper that the steady-state
+// insert path also uses so the migration produces bit-identical output
+// to a fresh INSERT.
+func (d *DB) rebuildBlindFTSForBigramEncoding() error {
+	if d.keyring == nil || d.keyring.FTSToken == nil {
+		return fmt.Errorf("no keyring for blind fts rebuild")
+	}
+	if _, err := d.db.Exec("DELETE FROM messages_blind_fts"); err != nil {
+		return fmt.Errorf("wipe messages_blind_fts: %w", err)
+	}
+	// COALESCE the plaintext addrs columns — legacy rows can carry
+	// NULL there even though the steady-state insert path writes ''.
+	rows, err := d.db.Query(`SELECT m.id, m.subject_ct,
+		COALESCE(m.from_addr, ''), COALESCE(m.to_addrs, ''),
+		m.body_text_ct
+		FROM messages m`)
+	if err != nil {
+		return fmt.Errorf("select rows: %w", err)
+	}
+	defer rows.Close()
+	type pending struct {
+		id                            int64
+		subject, fromAddr, toAddrs, body string
+	}
+	var batch []pending
+	for rows.Next() {
+		var p pending
+		var sCT, bCT []byte
+		if err := rows.Scan(&p.id, &sCT, &p.fromAddr, &p.toAddrs, &bCT); err != nil {
+			return fmt.Errorf("scan row: %w", err)
+		}
+		if p.subject, err = d.decryptSubject("", sCT); err != nil {
+			return fmt.Errorf("decrypt subject id=%d: %w", p.id, err)
+		}
+		if p.body, err = d.decryptBody("", bCT); err != nil {
+			return fmt.Errorf("decrypt body id=%d: %w", p.id, err)
+		}
+		batch = append(batch, p)
+	}
+	if err := rows.Err(); err != nil {
+		return fmt.Errorf("iterate rows: %w", err)
+	}
+
+	stmt, err := d.db.Prepare(`INSERT INTO messages_blind_fts(rowid, subject_tok, from_tok, to_tok, body_tok)
+		VALUES (?, ?, ?, ?, ?)`)
+	if err != nil {
+		return fmt.Errorf("prepare insert: %w", err)
+	}
+	defer stmt.Close()
+	for _, p := range batch {
+		sTok, fTok, tTok, bTok := d.blindTokens(p.subject, p.fromAddr, p.toAddrs, p.body)
+		if _, err := stmt.Exec(p.id, sTok, fTok, tTok, bTok); err != nil {
+			return fmt.Errorf("insert tokens id=%d: %w", p.id, err)
+		}
+	}
 	return nil
 }
 

--- a/cli/internal/store/store_test.go
+++ b/cli/internal/store/store_test.go
@@ -42,8 +42,8 @@ func TestOpenAndInit(t *testing.T) {
 	if err != nil {
 		t.Fatalf("read version: %v", err)
 	}
-	if version != 20 {
-		t.Errorf("version = %d, want 20", version)
+	if version != 21 {
+		t.Errorf("version = %d, want 21", version)
 	}
 }
 
@@ -185,8 +185,8 @@ func TestMigrateV9_PopulatesMailboxesAndAccounts(t *testing.T) {
 	if err := db.QueryRow("SELECT version FROM schema_version WHERE rowid = 1").Scan(&version); err != nil {
 		t.Fatalf("read version: %v", err)
 	}
-	if version != 20 {
-		t.Fatalf("version = %d, want 20", version)
+	if version != 21 {
+		t.Fatalf("version = %d, want 21", version)
 	}
 
 	// mailboxes must contain exactly INBOX and Drafts (case-collapsed).

--- a/docs/content/docs/developers/design/0001-mail-content-encryption-at-rest.md
+++ b/docs/content/docs/developers/design/0001-mail-content-encryption-at-rest.md
@@ -295,7 +295,14 @@ Search at runtime:
 - Two-word phrase `"alice bob"` → exact bigram MATCH (precise).
 - Longer phrase `"alice bob charlie"` → bigram intersection
   `(alice⌒bob) AND (bob⌒charlie)`. May have false positives where the words
-  appear in the same mail but not adjacent in that order.
+  appear in the same mail but not adjacent in that order. The bigram
+  HMAC input is **length-prefixed** (uvarint(len(w1)) || w1 ||
+  uvarint(len(w2)) || w2) rather than separator-delimited — ADR-0001
+  audit medium found that a literal U+001F unit-separator byte
+  smuggled into a word would HMAC-collide with the legitimate bigram
+  under the old encoding and forge a phrase match. The length-prefix
+  form is bijective: no two distinct (w1, w2) pairs share the same
+  byte sequence, regardless of what runes are in the words.
 - **Post-decrypt false-positive filter** (`cli/internal/store/search_filter.go`)
   runs on every blind-FTS query, not only long phrases. Even a single
   unigram MATCH has a non-zero 2⁻⁸⁰ collision probability per token-pair;


### PR DESCRIPTION
## Summary

Closes the bigram-encoding forgery class. The pre-fix encoding wrote adjacent-pair bigrams as \`word_i || 0x1F || word_{i+1}\` before HMAC-ing — relying on the tokenizer dropping any literal U+001F that appears in a single word to keep the encoding unambiguous. uniseg's behavior on stray control characters within a Unicode word isn't specified by its API, and an attacker who could smuggle a literal 0x1F into a word via HTML attribute / invisible body text would HMAC-collide with the legitimate bigram of the two halves: \`HMAC(key, 'foo' + 0x1F + 'bar')\` was byte-identical to HMAC of the single segment \`'foo\\x1Fbar'\` treated as one word. Combined with the missing post-decrypt filter (closed by #247), this gave attackers a phrase-query forgery primitive.

Length-prefix encoding (\`uvarint(len(w1)) || w1 || uvarint(len(w2)) || w2\`) is bijective: distinct word pairs cannot share input bytes regardless of contents. Closes the class structurally rather than via tokenizer-side character filtering.

- \`cli/internal/dbcrypto/tokenize.go\`: new \`bigramInput\` helper; \`TokenizeFTS\` and \`TokenizeFTSPhrase\` both use it.
- \`cli/internal/store/store.go\`: new v20→v21 migration that wipes and rebuilds \`messages_blind_fts\` from authoritative ct columns (every existing row was tokenized with the old encoding; phrase queries would silently stop matching after the encoding change without the rebuild).
- \`TestTokenizeFTS_BigramForgeryUnitSeparator\`: regression test asserts \`HMAC('foo' + 0x1F + 'bar')\` no longer equals the legitimate \`TokenizeFTS('foo bar')\` bigram.

ADR §4 updated to document the length-prefix encoding and the audit reasoning.

## Test plan

- [x] All 18 CLI unit tests pass; encryption grep-gate clean.
- [x] New \`TestTokenizeFTS_BigramForgeryUnitSeparator\` would fail under the pre-fix encoding.
- [x] Schema-version expectations bumped from 20 to 21 across 3 tests.