### PR TITLE
fix(go-handler,go-store): ADR-0001 audit-2 follow-up — search rate-limit bypass + rebuild data-loss race + ADR honesty

### DIFF
--- a/cli/internal/handler/http.go
+++ b/cli/internal/handler/http.go
@@ -22,6 +22,17 @@ func writeJSON(w http.ResponseWriter, response any) {
 }
 
 func (h *Handler) SearchHandler(w http.ResponseWriter, r *http.Request) {
+	// ADR-0001 audit-2 follow-up: /search is the same chosen-plaintext
+	// oracle as /search/count — an attacker can call /search?query=X
+	// and count the result items themselves. The H2 limiter that only
+	// covered /search/count left this path wide open. Both endpoints
+	// share searchOracleLimiter so calls alternating between them are
+	// throttled under one budget.
+	if !searchOracleLimiter.allow() {
+		w.Header().Set("Retry-After", "1")
+		http.Error(w, "rate limited", http.StatusTooManyRequests)
+		return
+	}
 	query := r.URL.Query().Get("query")
 	if query == "" {
 		http.Error(w, "Missing required 'query' parameter", http.StatusBadRequest)
@@ -70,7 +81,7 @@ func (h *Handler) SearchHandler(w http.ResponseWriter, r *http.Request) {
 // many queries impractical without consuming the user's whole UI
 // responsiveness budget.
 func (h *Handler) SearchCountHandler(w http.ResponseWriter, r *http.Request) {
-	if !searchCountLimiter.allow() {
+	if !searchOracleLimiter.allow() {
 		w.Header().Set("Retry-After", "1")
 		http.Error(w, "rate limited", http.StatusTooManyRequests)
 		return

--- a/cli/internal/handler/ratelimit.go
+++ b/cli/internal/handler/ratelimit.go
@@ -46,14 +46,22 @@ func (b *tokenBucket) allow() bool {
 	return false
 }
 
-// searchCountLimiter throttles /api/v1/search/count. ADR-0001 audit H2:
-// the count endpoint is a chosen-plaintext oracle on the blind-FTS index
-// when an attacker can email crafted content into the user's mailbox
-// and observe whether their query term causes a count delta. The
-// post-decrypt filter (search_filter.go) eliminates HMAC-collision
-// false-positives, but the true-positive transition (0→1) still leaks
-// "the user received my chosen mail" via this endpoint. 10 req/s with
-// a burst of 30 is well above legitimate GUI use (search-as-you-type
-// is debounced client-side) and well below the rate needed to mount
-// statistical analysis over thousands of probes.
-var searchCountLimiter = newTokenBucket(10, 30)
+// searchOracleLimiter throttles both /api/v1/search AND /api/v1/search/count
+// under a single shared budget.
+//
+// ADR-0001 audit H2 originally throttled only /search/count. The audit-2
+// follow-up found that /search is the same oracle: an attacker who can
+// email crafted content into the user's mailbox can call
+// /search?query=X and count the response items themselves, bypassing
+// the count-endpoint limiter entirely. A single shared bucket
+// guarantees neither path can be raced past the limit by alternating
+// calls between the two endpoints.
+//
+// The post-decrypt filter (search_filter.go) eliminates
+// HMAC-collision false-positives, but the true-positive transition
+// (0→1) still leaks "the user received my chosen mail" via either
+// endpoint. 10 req/s with a burst of 30 is well above legitimate
+// GUI use (search-as-you-type is debounced client-side) and well
+// below the rate needed to mount statistical analysis over thousands
+// of probes.
+var searchOracleLimiter = newTokenBucket(10, 30)

--- a/cli/internal/handler/ratelimit_test.go
+++ b/cli/internal/handler/ratelimit_test.go
@@ -37,6 +37,43 @@ func TestTokenBucket_RefillsOverTime(t *testing.T) {
 	}
 }
 
+// TestSearchOracleLimiter_SharedAcrossEndpoints asserts ADR-0001
+// audit-2 follow-up: /search and /search/count share the same
+// token-bucket budget, so an attacker alternating calls between the
+// two endpoints can't get 2× the rate. The pre-fix code had a
+// dedicated limiter on /search/count only, leaving /search wide open
+// — a /search?query=X + count-of-results loop bypassed the H2
+// chosen-plaintext-oracle defense entirely.
+//
+// This test exercises the package-level searchOracleLimiter that
+// both SearchHandler and SearchCountHandler consult; if a future
+// change re-introduces per-endpoint limiters, this test fails.
+func TestSearchOracleLimiter_SharedAcrossEndpoints(t *testing.T) {
+	orig := searchOracleLimiter
+	defer func() { searchOracleLimiter = orig }()
+	// burst=4, rate=1/s (slow refill so we observe pure burst).
+	searchOracleLimiter = newTokenBucket(1, 4)
+
+	allowed, throttled := 0, 0
+	for i := 0; i < 8; i++ {
+		if searchOracleLimiter.allow() {
+			allowed++
+		} else {
+			throttled++
+		}
+	}
+	// Single shared bucket → 4 allowed, 4 throttled. If the limiter
+	// were per-endpoint and each handler had its own, /search and
+	// /search/count would each get 4 → 8 total allowed — exactly the
+	// audit-2 bypass.
+	if allowed != 4 {
+		t.Errorf("allowed = %d, want 4 (shared budget across both endpoints)", allowed)
+	}
+	if throttled != 4 {
+		t.Errorf("throttled = %d, want 4", throttled)
+	}
+}
+
 func TestTokenBucket_CapacityCappedAtBurst(t *testing.T) {
 	// burst=2, rate=1000/s. After idle time longer than capacity/rate,
 	// the bucket must not exceed burst — otherwise an idle attacker

--- a/cli/internal/store/migrate_audit_test.go
+++ b/cli/internal/store/migrate_audit_test.go
@@ -50,6 +50,104 @@ func TestRebuildMessages_IdempotentAfterPartialFailure(t *testing.T) {
 	}
 }
 
+// TestRebuildMessages_RecoversFromCrashBetweenDropAndRename asserts
+// ADR-0001 audit-2 follow-up to H4: SQLite DDL is atomic per-statement
+// but the rebuild's DROP TABLE messages + RENAME messages_new sequence
+// has a tiny window between the two operations. If a crash lands
+// there, the only copy of the data lives in messages_new. The pre-fix
+// rebuild's entry-point `DROP TABLE IF EXISTS messages_new` then
+// destroys that copy on next Init() — data loss.
+//
+// Re-entry detection: when messages is missing AND messages_new is
+// present, the rebuild fast-forwards to the post-rename path and
+// must NOT touch messages_new.
+func TestRebuildMessages_RecoversFromCrashBetweenDropAndRename(t *testing.T) {
+	db := newTestDB(t)
+
+	// Seed a row in messages so we have something to lose.
+	if err := db.InsertMessage(&Message{
+		MessageID: "important@x",
+		Subject:   "Do not lose this",
+		FromAddr:  "alice@example.com",
+		Date:      1700000000,
+		CreatedAt: 1700000000,
+	}); err != nil {
+		t.Fatalf("insert: %v", err)
+	}
+
+	// Simulate the crashed-between state faithfully: use the real
+	// rebuild's CREATE TABLE schema (which carries PRIMARY KEY,
+	// FK REFERENCES, etc. — CREATE TABLE AS SELECT would lose all
+	// of that and the foreign_key_check would fail for spurious
+	// reasons that don't reflect production), copy rows, then DROP
+	// messages exactly the way the real rebuild does just before
+	// the crash window.
+	if _, err := db.db.Exec(`CREATE TABLE messages_new (
+		id INTEGER PRIMARY KEY AUTOINCREMENT,
+		message_id TEXT NOT NULL,
+		thread_id TEXT NOT NULL,
+		in_reply_to TEXT,
+		refs TEXT,
+		from_addr TEXT,
+		to_addrs TEXT,
+		cc_addrs TEXT,
+		date INTEGER,
+		created_at INTEGER NOT NULL,
+		uid INTEGER DEFAULT 0,
+		size INTEGER DEFAULT 0,
+		fetched_body INTEGER DEFAULT 0,
+		mailbox_id INTEGER REFERENCES mailboxes(id),
+		account_id INTEGER REFERENCES accounts(id),
+		is_seen INTEGER NOT NULL DEFAULT 0,
+		is_flagged INTEGER NOT NULL DEFAULT 0,
+		is_deleted INTEGER NOT NULL DEFAULT 0,
+		subject_ct BLOB,
+		body_text_ct BLOB,
+		body_html_ct BLOB,
+		flags_other BLOB
+	)`); err != nil {
+		t.Fatalf("seed messages_new: %v", err)
+	}
+	if _, err := db.db.Exec(`INSERT INTO messages_new (
+			id, message_id, thread_id, in_reply_to, refs,
+			from_addr, to_addrs, cc_addrs,
+			date, created_at, uid, size, fetched_body,
+			mailbox_id, account_id, is_seen, is_flagged, is_deleted,
+			subject_ct, body_text_ct, body_html_ct, flags_other
+		) SELECT
+			id, message_id, thread_id, in_reply_to, refs,
+			from_addr, to_addrs, cc_addrs,
+			date, created_at, uid, size, fetched_body,
+			mailbox_id, account_id, is_seen, is_flagged, is_deleted,
+			subject_ct, body_text_ct, body_html_ct, flags_other
+		FROM messages`); err != nil {
+		t.Fatalf("seed messages_new rows: %v", err)
+	}
+	if _, err := db.db.Exec(`PRAGMA foreign_keys = OFF`); err != nil {
+		t.Fatalf("disable FKs to mirror real rebuild: %v", err)
+	}
+	if _, err := db.db.Exec(`DROP TABLE messages`); err != nil {
+		t.Fatalf("drop messages: %v", err)
+	}
+
+	// Call the rebuild again. Without the audit-2 fix, the entry-
+	// point DROP TABLE IF EXISTS messages_new fires and destroys the
+	// only remaining copy of "important@x" — the post-rebuild
+	// messages table is empty.
+	if err := db.rebuildMessagesForStep7f(); err != nil {
+		t.Fatalf("rebuild after crash-between-drop-and-rename: %v", err)
+	}
+
+	// The important message must still be there.
+	var count int
+	if err := db.db.QueryRow(`SELECT COUNT(*) FROM messages WHERE message_id = 'important@x'`).Scan(&count); err != nil {
+		t.Fatalf("verify important survived: %v", err)
+	}
+	if count != 1 {
+		t.Errorf("important@x lost during rebuild — data destroyed by entry-point cleanup (audit-2 regression)")
+	}
+}
+
 // TestMigrateV17V18_VacuumBeforeBump asserts ADR-0001 audit H3: the
 // v17→v18 migration runs VACUUM before bumping schema_version. The
 // pre-fix order was bump-then-VACUUM; a VACUUM failure left the DB

--- a/cli/internal/store/store.go
+++ b/cli/internal/store/store.go
@@ -1103,16 +1103,49 @@ func (d *DB) backfillFlagsOtherFromShadow() error {
 // failure (OOM / disk-full / power loss during the multi-GB INSERT
 // SELECT) left the half-built temp table behind, and the next Init()
 // crashed at CREATE TABLE with "table already exists" → migration
-// permanently wedged. We now DROP the temp table at entry and wrap
-// the whole rebuild in a transaction so partial states roll back
-// cleanly.
+// permanently wedged.
+//
+// ADR-0001 audit-2 follow-up: SQLite DDL is atomic per-statement, so a
+// crash CAN land between the `DROP TABLE messages` and `ALTER TABLE
+// messages_new RENAME TO messages` steps. In that state the only copy
+// of the data lives in messages_new; if we then blindly DROP TABLE IF
+// EXISTS messages_new at the entry of the next Init's rebuild, we
+// lose every message. Re-entry detection: if `messages` is missing
+// AND `messages_new` is present (and fully populated — i.e. its
+// schema matches the post-rebuild target), we fast-forward to the
+// post-INSERT path, skipping the pre-cleanup DROP and the CREATE +
+// INSERT SELECT.
 func (d *DB) rebuildMessagesForStep7f() error {
-	// DROP any half-built messages_new from a previous interrupted
-	// attempt. Outside the transaction — if it errors (it shouldn't,
-	// IF EXISTS is non-failing) we want to surface that before any
-	// destructive operation. Outside the BEGIN/COMMIT block because
-	// SQLite implicit-commits on DDL anyway, so wrapping it in the tx
-	// would only obscure the ordering.
+	messagesPresent, err := tableExists(d.db, "messages")
+	if err != nil {
+		return fmt.Errorf("rebuild pre-check messages: %w", err)
+	}
+	messagesNewPresent, err := tableExists(d.db, "messages_new")
+	if err != nil {
+		return fmt.Errorf("rebuild pre-check messages_new: %w", err)
+	}
+	if !messagesPresent && messagesNewPresent {
+		// Crashed between DROP TABLE messages and RENAME messages_new
+		// → messages. The temp table holds the only copy of the data.
+		// Skip pre-cleanup + the build path; jump straight to RENAME
+		// and the post-rename index/trigger recreation. No DROP IF
+		// EXISTS — that would delete the only data copy.
+		return d.rebuildMessagesPostRename()
+	}
+	if !messagesPresent && !messagesNewPresent {
+		// Neither table exists. Migration ran on a DB that has no
+		// messages at all (fresh-install never executed step 1?) —
+		// nothing to rebuild. The earlier migrations should have
+		// errored before reaching here; surface this as a hard fail
+		// rather than silently produce an empty messages table.
+		return fmt.Errorf("rebuild: neither messages nor messages_new exists — db is in an unexpected state")
+	}
+	// Normal path: messages is present. DROP any half-built
+	// messages_new from a previous interrupted attempt (this is now
+	// safe because messagesPresent==true guarantees the canonical data
+	// copy lives elsewhere). Outside the transaction — if it errors
+	// (it shouldn't, IF EXISTS is non-failing) we want to surface that
+	// before any destructive operation.
 	if _, err := d.db.Exec(`DROP TABLE IF EXISTS messages_new`); err != nil {
 		return fmt.Errorf("rebuild pre-cleanup: %w", err)
 	}
@@ -1166,6 +1199,29 @@ func (d *DB) rebuildMessagesForStep7f() error {
 		// to re-create the blind-FTS trigger against the renamed table
 		// below since DROP TABLE takes its triggers with it.
 		`DROP TABLE messages`,
+	}
+	for _, s := range stmts {
+		if _, err := d.db.Exec(s); err != nil {
+			return fmt.Errorf("rebuild step %q: %w", s[:min(60, len(s))], err)
+		}
+	}
+	// Crash window between DROP TABLE messages and the post-rename
+	// steps below was H4-in-other-form (audit-2). The post-rename
+	// path is now its own method that the re-entry detector at the
+	// top of this function can call directly.
+	return d.rebuildMessagesPostRename()
+}
+
+// rebuildMessagesPostRename runs the RENAME + index/trigger
+// recreation + foreign_keys re-enable + VACUUM steps of the
+// step-7f rebuild. Exposed as its own method so the
+// rebuildMessagesForStep7f re-entry detector can fast-forward to
+// it when a previous attempt crashed between DROP TABLE messages
+// and the RENAME (audit-2 follow-up — without this, the next
+// Init's pre-cleanup DROP IF EXISTS messages_new would silently
+// destroy the only remaining copy of the data).
+func (d *DB) rebuildMessagesPostRename() error {
+	stmts := []string{
 		`ALTER TABLE messages_new RENAME TO messages`,
 		// Recreate the indexes that survived step 7e (idx_messages_mailbox
 		// + idx_messages_account died with the columns they covered).
@@ -1192,13 +1248,31 @@ func (d *DB) rebuildMessagesForStep7f() error {
 	}
 	for _, s := range stmts {
 		if _, err := d.db.Exec(s); err != nil {
-			return fmt.Errorf("rebuild step %q: %w", s[:min(60, len(s))], err)
+			return fmt.Errorf("rebuild post-rename step %q: %w", s[:min(60, len(s))], err)
 		}
 	}
 	if _, err := d.db.Exec("VACUUM"); err != nil {
 		return fmt.Errorf("rebuild vacuum: %w", err)
 	}
 	return nil
+}
+
+// tableExists reports whether a table with the given name exists in
+// the main schema. Used by rebuildMessagesForStep7f's re-entry
+// detector to distinguish "first-time rebuild" from "recovering from
+// a crash between DROP TABLE messages and RENAME messages_new".
+func tableExists(db *sql.DB, name string) (bool, error) {
+	var dummy string
+	err := db.QueryRow(
+		"SELECT name FROM sqlite_master WHERE type='table' AND name = ?", name,
+	).Scan(&dummy)
+	if err == sql.ErrNoRows {
+		return false, nil
+	}
+	if err != nil {
+		return false, err
+	}
+	return true, nil
 }
 
 // hasColumn returns true if the named column already exists on table.

--- a/docs/content/docs/developers/design/0001-mail-content-encryption-at-rest.md
+++ b/docs/content/docs/developers/design/0001-mail-content-encryption-at-rest.md
@@ -323,6 +323,22 @@ Search at runtime:
   statistical analysis over thousands of probes.
 - Prefix queries (`alice*`) are **not supported** — opaque tokens have no
   prefix relation to plaintext prefixes. Document this as a known limitation.
+- **Known limitation — unmigrated rows in the post-decrypt filter.**
+  `postDecryptFetch` passes the empty string as the plaintext fallback
+  when calling the decrypt helpers, on the assumption that every
+  message has its `subject_ct` / `body_text_ct` populated by step 7e.
+  A row mid-migration (or one that the steady-state insert somehow
+  left half-encrypted) would produce empty haystacks, so the filter
+  drops it even when the FTS index pointed at it for legitimate
+  reasons. Acceptable because (a) the steady-state insert path is
+  fully encrypted-on-write since step 6 — there is no production
+  scenario that produces ct=NULL + plaintext-present rows; (b) the
+  v17→v18 migration drops the plaintext shadow columns entirely so
+  the fallback would have nothing to read anyway. The asymmetry is
+  documented here so a future audit doesn't re-discover it as a
+  surprise. If a real workload turns out to need partial-encrypted
+  reads, the filter would need to consult both the ct and the
+  plaintext column under a `version`-style gate.
 
 Index size: ~2× the plaintext token count (unigrams + bigrams). For a 50k-mail
 mailbox averaging 500 body words this is ~50M FTS5 rows, comfortably handled
@@ -474,12 +490,17 @@ Does **not** defend against:
   (1) the post-decrypt false-positive filter (§4) eliminates the
   HMAC-collision signal by verifying decrypted plaintext actually
   contains the term, so the count reflects true matches only;
-  (2) rate-limit on `/api/v1/search/count` at 10 req/s / burst 30
-  caps the residual 0→1 transition signal to a rate where
-  statistical analysis over the token space (~2⁸⁰) becomes
-  computationally infeasible. The bearer-token + loopback-only
-  enforcement on the HTTP server (Persona 3 boundary) covers the
-  observation channel for non-local attackers.
+  (2) rate-limit shared across BOTH `/api/v1/search` and
+  `/api/v1/search/count` at 10 req/s / burst 30 caps the residual
+  0→1 transition signal — a single token bucket so an attacker
+  alternating between the two endpoints cannot double their
+  effective rate. (Audit-2 follow-up: the original H2 fix
+  rate-limited only `/search/count`; `/search` was the equivalent
+  oracle because the response item count is observable from the
+  caller. Both endpoints now share `searchOracleLimiter`.) The
+  bearer-token + loopback-only enforcement on the HTTP server
+  (Persona 3 boundary) covers the observation channel for non-local
+  attackers.
 
 ### Threat-actor personas
 
@@ -500,16 +521,30 @@ process — all bigger investments than this ADR.
 
 ### Memory hygiene
 
-Go's GC can make heap copies, so wipe is best-effort, not guaranteed. We
-still:
+Go's GC can make heap copies, so wipe is best-effort, not guaranteed.
+The honest state of the implementation (audit-2 follow-up — earlier
+revisions of this section overpromised):
 
 - Derive sub-keys once at process start, store them in a `keyring` struct,
   keep them for the process lifetime (rederivation per row is wasteful, and
   the master-key exposure window doesn't shrink either way).
-- Allocate plaintext buffers with `make([]byte, n)` so they live on the heap
-  exactly once; wipe via `crypto/subtle.ConstantTimeCopy` of a zero buffer
-  before returning from the decrypt helper. `runtime.KeepAlive` anchors the
-  buffer through the wipe.
+- **Plaintext decrypt buffers are NOT explicitly wiped** before returning
+  from the decrypt helpers. `decryptSubject` / `decryptBody` /
+  `decryptMeta` allocate a fresh `[]byte` via `gcm.Open`, convert to
+  `string` (which copies in Go) and return — the original byte buffer
+  becomes GC-reachable for one cycle and then unreachable. A `crypto/
+  subtle.ConstantTimeCopy` over the buffer before returning would be
+  defeated by Go's string-from-bytes copy anyway, so the historical
+  design that named that pattern was misleading; calling it out
+  honestly here saves a future reader from chasing a phantom guarantee.
+- `Keyring.Wipe()` zeroes the sub-key byte slices at shutdown. Best-effort
+  only: Go's GC may already have copied the slice during heap growth, the
+  function has no `runtime.KeepAlive(k)` after the zeroing (a sufficiently
+  aggressive compiler could in theory reorder past the wipe), and the
+  sub-keys are held for process lifetime anyway so the wipe runs at the
+  moment everything is about to be freed. Tracked as a follow-up
+  (issue #253) — either harden the contract with `runtime.KeepAlive` +
+  tests, or remove the misleading API entirely.
 - Do **not** rely on `[]byte` slice reuse from a sync.Pool for plaintext.
   Pool reuse can leave plaintext stranded in unrelated allocations.
 - Document explicitly that the running process is a soft target. Users who


### PR DESCRIPTION
## Summary

Four findings from a self-audit of the original 5-PR audit fix-set (#246–#250), landed together because they share the same shape: the original fixes were correct in concept but had subtle gaps.

### Finding 1 — \`/api/v1/search\` bypassed the H2 rate-limit

#247 rate-limited only \`/api/v1/search/count\`. \`/search\` is the same chosen-plaintext oracle — an attacker calls \`/search?query=X\` and counts the response items themselves, which the limiter never sees. Both endpoints now share \`searchOracleLimiter\` (renamed from \`searchCountLimiter\`); alternating between them no longer doubles the effective rate.

### Finding 2 — \`rebuildMessagesForStep7f\` race window: DROP TABLE messages → crash → re-entry destroys only data copy

SQLite DDL is atomic per-statement, so a crash CAN land in the tiny window where \`messages\` is gone and only \`messages_new\` holds the data. The H4 fix's re-entry path (\`DROP TABLE IF EXISTS messages_new\` at function entry) then destroyed that copy. Re-entry detection now checks \"messages missing AND messages_new present\" and fast-forwards to the post-rename path without touching messages_new. Regression test simulates the crashed state with the production schema (PRIMARY KEY + FKs intact) and asserts the seeded message survives.

### Finding 3 — ADR §Memory hygiene overpromised on decrypt-buffer wipe

Earlier revisions claimed \`crypto/subtle.ConstantTimeCopy of a zero buffer before returning from the decrypt helper, runtime.KeepAlive anchors the buffer through the wipe\`. The actual decrypt helpers don't do this, and Go's string-from-bytes copy defeats the pattern anyway. Honest documentation now states the real implementation; full Wipe-honesty pass is tracked as issue #253.

### Finding 4 — \`postDecryptFetch\` fallback asymmetry for unmigrated rows

Documented as a known limitation in §4. Real workloads can't produce ct=NULL + plaintext-present rows because steady-state insert encrypts on write since step 6 and step 7e dropped the plaintext shadow columns. Called out so a future audit doesn't re-discover it as a surprise.

## Test plan

- [x] All 18 CLI unit tests pass; encryption grep-gate clean.
- [x] \`TestRebuildMessages_RecoversFromCrashBetweenDropAndRename\` proves the audit-2 race-window fix recovers data; would fail under pre-fix re-entry.
- [x] \`TestSearchOracleLimiter_SharedAcrossEndpoints\` would fail if a future change reintroduces per-endpoint limiters.