### PR TITLE
feat(go-store): ADR-0001 attachments-encryption — filename + content_type + size encrypted at rest

### DIFF
--- a/cli/internal/store/attachments.go
+++ b/cli/internal/store/attachments.go
@@ -3,6 +3,7 @@ package store
 import (
 	"database/sql"
 	"fmt"
+	"strconv"
 	"strings"
 )
 
@@ -29,19 +30,83 @@ func (d *DB) InsertAttachment(att *Attachment) error {
 	return tx.Commit()
 }
 
-// InsertAttachmentTx inserts attachment metadata within an existing transaction.
+// insertAttachmentTx inserts attachment metadata within an existing
+// transaction. ADR-0001 attachments-encryption step: filename,
+// content_type and size are encrypted with meta_key — the three columns
+// that carry content-classification signal (filename "Tax_Return.pdf"
+// is subject-grade, content_type "application/dicom" reveals medical
+// context, size combined with from_addr + date is a sharp activity
+// pattern). disposition / content_id / part_id stay plaintext (low
+// entropy / opaque / structural).
 func (d *DB) insertAttachmentTx(tx *sql.Tx, att *Attachment) error {
+	filenameCT, err := d.encryptMeta(att.Filename)
+	if err != nil {
+		return fmt.Errorf("encrypt filename: %w", err)
+	}
+	contentTypeCT, err := d.encryptMeta(att.ContentType)
+	if err != nil {
+		return fmt.Errorf("encrypt content_type: %w", err)
+	}
+	// Size is an int64 — encrypt the decimal-string form so the
+	// envelope is human-debuggable post-decrypt and the round-trip
+	// stays pure ASCII through the meta_key path. 0 maps to empty
+	// plaintext → NULL ct (no separate "encrypted zero" sentinel).
+	var sizeStr string
+	if att.Size != 0 {
+		sizeStr = strconv.Itoa(att.Size)
+	}
+	sizeCT, err := d.encryptMeta(sizeStr)
+	if err != nil {
+		return fmt.Errorf("encrypt size: %w", err)
+	}
 	result, err := tx.Exec(`
-		INSERT INTO attachments (message_db_id, part_id, filename, content_type, size, disposition, content_id)
+		INSERT INTO attachments (message_db_id, part_id, filename_ct, content_type_ct, size_ct, disposition, content_id)
 		VALUES (?, ?, ?, ?, ?, ?, ?)`,
-		att.MessageDBID, att.PartID, att.Filename, att.ContentType,
-		att.Size, att.Disposition, att.ContentID)
+		att.MessageDBID, att.PartID, filenameCT, contentTypeCT,
+		sizeCT, att.Disposition, att.ContentID)
 	if err != nil {
 		return fmt.Errorf("insert attachment: %w", err)
 	}
 	id, _ := result.LastInsertId()
 	att.ID = id
 	return nil
+}
+
+// attachmentSelectColumns is the canonical SELECT list for every
+// attachments read site. Centralised so the column order tracks the
+// scan helper below without per-call drift.
+const attachmentSelectColumns = `id, message_db_id, part_id,
+	filename_ct, content_type_ct, size_ct,
+	disposition, content_id`
+
+// scanAttachmentRow scans one row whose SELECT names attachmentSelectColumns
+// (in order) and decrypts the three meta-key columns into the Attachment
+// struct's plaintext fields.
+func (d *DB) scanAttachmentRow(scan func(...any) error) (Attachment, error) {
+	var a Attachment
+	var filenameCT, contentTypeCT, sizeCT []byte
+	if err := scan(&a.ID, &a.MessageDBID, &a.PartID,
+		&filenameCT, &contentTypeCT, &sizeCT,
+		&a.Disposition, &a.ContentID); err != nil {
+		return a, err
+	}
+	var err error
+	if a.Filename, err = d.decryptMeta("", filenameCT); err != nil {
+		return a, fmt.Errorf("decrypt filename id=%d: %w", a.ID, err)
+	}
+	if a.ContentType, err = d.decryptMeta("", contentTypeCT); err != nil {
+		return a, fmt.Errorf("decrypt content_type id=%d: %w", a.ID, err)
+	}
+	sizeStr, err := d.decryptMeta("", sizeCT)
+	if err != nil {
+		return a, fmt.Errorf("decrypt size id=%d: %w", a.ID, err)
+	}
+	if sizeStr != "" {
+		if a.Size, err = strconv.Atoi(sizeStr); err != nil {
+			return a, fmt.Errorf("parse size id=%d: %w", a.ID, err)
+		}
+	}
+	return a, nil
 }
 
 // GetAttachmentsByMessages returns attachments for multiple messages in a single query.
@@ -58,7 +123,7 @@ func (d *DB) GetAttachmentsByMessages(ids []int64) (map[int64][]Attachment, erro
 		params[i] = id
 	}
 
-	q := "SELECT id, message_db_id, part_id, filename, content_type, size, disposition, content_id FROM attachments WHERE message_db_id IN (" +
+	q := "SELECT " + attachmentSelectColumns + " FROM attachments WHERE message_db_id IN (" +
 		strings.Join(placeholders, ",") + ") ORDER BY message_db_id, part_id"
 
 	rows, err := d.db.Query(q, params...)
@@ -69,9 +134,7 @@ func (d *DB) GetAttachmentsByMessages(ids []int64) (map[int64][]Attachment, erro
 
 	result := make(map[int64][]Attachment)
 	for rows.Next() {
-		var a Attachment
-		err := rows.Scan(&a.ID, &a.MessageDBID, &a.PartID, &a.Filename,
-			&a.ContentType, &a.Size, &a.Disposition, &a.ContentID)
+		a, err := d.scanAttachmentRow(rows.Scan)
 		if err != nil {
 			return nil, fmt.Errorf("scan attachment: %w", err)
 		}
@@ -83,17 +146,17 @@ func (d *DB) GetAttachmentsByMessages(ids []int64) (map[int64][]Attachment, erro
 // GetAttachmentsByMessage returns all attachments for a message by its DB ID.
 func (d *DB) GetAttachmentsByMessage(messageDBID int64) ([]Attachment, error) {
 	return d.queryAttachments(
-		"SELECT id, message_db_id, part_id, filename, content_type, size, disposition, content_id FROM attachments WHERE message_db_id = ? ORDER BY part_id",
+		"SELECT "+attachmentSelectColumns+" FROM attachments WHERE message_db_id = ? ORDER BY part_id",
 		messageDBID)
 }
 
 // GetAttachmentsByMessageID returns all attachments for a message by its Message-ID header.
 func (d *DB) GetAttachmentsByMessageID(messageID string) ([]Attachment, error) {
 	return d.queryAttachments(`
-		SELECT a.id, a.message_db_id, a.part_id, a.filename, a.content_type, a.size, a.disposition, a.content_id
-		FROM attachments a
-		WHERE a.message_db_id = (SELECT id FROM messages WHERE message_id = ? LIMIT 1)
-		ORDER BY a.part_id`, messageID)
+		SELECT `+attachmentSelectColumns+`
+		FROM attachments
+		WHERE message_db_id = (SELECT id FROM messages WHERE message_id = ? LIMIT 1)
+		ORDER BY part_id`, messageID)
 }
 
 func (d *DB) queryAttachments(query string, args ...interface{}) ([]Attachment, error) {
@@ -105,9 +168,7 @@ func (d *DB) queryAttachments(query string, args ...interface{}) ([]Attachment, 
 
 	var atts []Attachment
 	for rows.Next() {
-		var a Attachment
-		err := rows.Scan(&a.ID, &a.MessageDBID, &a.PartID, &a.Filename,
-			&a.ContentType, &a.Size, &a.Disposition, &a.ContentID)
+		a, err := d.scanAttachmentRow(rows.Scan)
 		if err != nil {
 			return nil, fmt.Errorf("scan attachment: %w", err)
 		}

--- a/cli/internal/store/attachments_test.go
+++ b/cli/internal/store/attachments_test.go
@@ -1,8 +1,88 @@
 package store
 
 import (
+	"bytes"
+	"strings"
 	"testing"
 )
+
+// TestAttachmentMetadata_EncryptedAtRest asserts ADR-0001 attachments-
+// encryption: filename, content_type, and size never appear as their
+// distinctive plaintext bytes in the raw filename_ct / content_type_ct
+// / size_ct BLOB columns. A forensic analyst opening the .db file
+// must not be able to grep for "Tax_Return_2026.pdf" and find it.
+func TestAttachmentMetadata_EncryptedAtRest(t *testing.T) {
+	db := newTestDB(t)
+	msgID := insertTestMessage(t, db, "atrest@x")
+
+	const distinctiveFilename = "Tax_Return_2026.pdf"
+	const distinctiveContentType = "application/dicom"
+	const distinctiveSize = 314159
+
+	if err := db.InsertAttachment(&Attachment{
+		MessageDBID: msgID,
+		PartID:      1,
+		Filename:    distinctiveFilename,
+		ContentType: distinctiveContentType,
+		Size:        distinctiveSize,
+		Disposition: "attachment",
+	}); err != nil {
+		t.Fatalf("insert: %v", err)
+	}
+
+	// Read the raw ct bytes for the row and assert none of them
+	// contain the plaintext substrings.
+	var filenameCT, contentTypeCT, sizeCT []byte
+	if err := db.db.QueryRow(`SELECT filename_ct, content_type_ct, size_ct
+		FROM attachments WHERE message_db_id = ?`, msgID).Scan(&filenameCT, &contentTypeCT, &sizeCT); err != nil {
+		t.Fatalf("read raw ct: %v", err)
+	}
+	if bytes.Contains(filenameCT, []byte(distinctiveFilename)) {
+		t.Errorf("filename leaked into filename_ct ciphertext bytes")
+	}
+	if bytes.Contains(contentTypeCT, []byte(distinctiveContentType)) {
+		t.Errorf("content_type leaked into content_type_ct ciphertext bytes")
+	}
+	if bytes.Contains(sizeCT, []byte("314159")) {
+		t.Errorf("size leaked into size_ct ciphertext bytes")
+	}
+
+	// Read-through-API decrypts and returns the plaintext correctly.
+	atts, err := db.GetAttachmentsByMessage(msgID)
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if len(atts) != 1 || atts[0].Filename != distinctiveFilename || atts[0].ContentType != distinctiveContentType || atts[0].Size != distinctiveSize {
+		t.Errorf("round-trip failed: got %+v", atts)
+	}
+
+	// Plaintext columns must not exist after the v21→v22 migration.
+	for _, col := range []string{"filename", "content_type", "size"} {
+		has, err := hasColumn(db.db, "attachments", col)
+		if err != nil {
+			t.Fatalf("hasColumn: %v", err)
+		}
+		if has {
+			t.Errorf("plaintext column %q still exists post-migration", col)
+		}
+	}
+	// Sanity: the only attachment columns left are the structural /
+	// low-entropy ones documented as plaintext-by-design.
+	cols, err := db.db.Query(`SELECT name FROM pragma_table_info('attachments')`)
+	if err != nil {
+		t.Fatalf("pragma table_info: %v", err)
+	}
+	defer cols.Close()
+	var present []string
+	for cols.Next() {
+		var n string
+		cols.Scan(&n)
+		present = append(present, n)
+	}
+	if strings.Contains(strings.Join(present, ","), "filename,") || strings.Contains(strings.Join(present, ","), ",size,") {
+		t.Errorf("post-migration attachments table still carries plaintext columns: %v", present)
+	}
+}
 
 func TestInsertAndGetAttachments(t *testing.T) {
 	db := newTestDB(t)

--- a/cli/internal/store/store.go
+++ b/cli/internal/store/store.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 
 	"github.com/durian-dev/durian/cli/internal/dbcrypto"
@@ -146,13 +147,18 @@ func (d *DB) Init() error {
 		`CREATE INDEX IF NOT EXISTS idx_tags_message_id ON tags(message_id)`,
 		`CREATE INDEX IF NOT EXISTS idx_tags_tag ON tags(tag)`,
 
+		// ADR-0001 attachments-encryption (v21→v22): filename / content_type /
+		// size encrypted with meta_key. The plaintext columns the old schema
+		// carried are now ct BLOBs; the v21→v22 migration handles the
+		// ALTER+backfill+drop path for existing DBs. Fresh installs at
+		// schema_version >= 22 land directly in this shape.
 		`CREATE TABLE IF NOT EXISTS attachments (
 			id INTEGER PRIMARY KEY AUTOINCREMENT,
 			message_db_id INTEGER NOT NULL REFERENCES messages(id) ON DELETE CASCADE,
 			part_id INTEGER,
-			filename TEXT,
-			content_type TEXT,
-			size INTEGER DEFAULT 0,
+			filename_ct BLOB,
+			content_type_ct BLOB,
+			size_ct BLOB,
 			disposition TEXT,
 			content_id TEXT
 		)`,
@@ -866,7 +872,155 @@ func (d *DB) migrate() error {
 		}
 	}
 
+	if version < 22 {
+		// ADR-0001 attachments-encryption: encrypt three columns of
+		// the attachments table with meta_key — filename,
+		// content_type, size. Filename like "Tax_Return_2026.pdf"
+		// carries subject-grade content-classification signal that
+		// the original ADR §3 missed (was scoped to body / subject /
+		// addrs / drafts but treated attachments as pure metadata).
+		// content_type "application/dicom" reveals as sharp a
+		// category as the filename; size combined with the already-
+		// plaintext from_addr + date is a sharp activity pattern
+		// ("Tuesday 9am 2.4MB PDF from accountant@x" = recurring
+		// report). The remaining columns (disposition, content_id,
+		// part_id) stay plaintext — disposition is 2 values,
+		// content_id is opaque MIME id, part_id is structural.
+		//
+		// ALTER TABLE cannot be wrapped in a transaction with the
+		// backfill (SQLite implicitly commits before DDL), so the
+		// column-add is idempotent via PRAGMA table_info: if a
+		// previous attempt added the columns but failed in the
+		// backfill, we re-detect and skip straight to the backfill.
+		alters := []string{"filename_ct", "content_type_ct", "size_ct"}
+		for _, col := range alters {
+			has, err := hasColumn(d.db, "attachments", col)
+			if err != nil {
+				return fmt.Errorf("migrate v21→v22 inspect %s: %w", col, err)
+			}
+			if !has {
+				if _, err := d.db.Exec("ALTER TABLE attachments ADD COLUMN " + col + " BLOB"); err != nil {
+					return fmt.Errorf("migrate v21→v22 add %s: %w", col, err)
+				}
+			}
+		}
+		if err := d.backfillAttachmentMetaCt(); err != nil {
+			return fmt.Errorf("migrate v21→v22 backfill: %w", err)
+		}
+		// Drop the plaintext columns. Idempotent via hasColumn so a
+		// crash mid-drop sequence retries cleanly on next Init.
+		drops := []string{"filename", "content_type", "size"}
+		for _, col := range drops {
+			has, err := hasColumn(d.db, "attachments", col)
+			if err != nil {
+				return fmt.Errorf("migrate v21→v22 inspect drop %s: %w", col, err)
+			}
+			if has {
+				if _, err := d.db.Exec("ALTER TABLE attachments DROP COLUMN " + col); err != nil {
+					return fmt.Errorf("migrate v21→v22 drop %s: %w", col, err)
+				}
+			}
+		}
+		// VACUUM before the schema_version bump (lesson from audit
+		// H3): a VACUUM crash must not lock us at v22 with the
+		// dropped plaintext bytes stranded in free pages.
+		if _, err := d.db.Exec("VACUUM"); err != nil {
+			return fmt.Errorf("migrate v21→v22 vacuum: %w", err)
+		}
+		if _, err := d.db.Exec("UPDATE schema_version SET version = 22 WHERE rowid = 1"); err != nil {
+			return fmt.Errorf("migrate v21→v22 bump: %w", err)
+		}
+	}
+
 	return nil
+}
+
+// backfillAttachmentMetaCt encrypts every existing attachments row's
+// filename / content_type / size into the BLOB columns added by the
+// v21→v22 migration. Idempotent via WHERE *_ct IS NULL — rows already
+// backfilled by a prior partial attempt are filtered out.
+//
+// On a fresh install the base CREATE TABLE in Init() already lands at
+// the v22 shape (no plaintext columns), so there's nothing to read
+// from the legacy filename/content_type/size triple — the helper
+// short-circuits if any of those columns is missing.
+func (d *DB) backfillAttachmentMetaCt() error {
+	if d.keyring == nil || d.keyring.Meta == nil {
+		return fmt.Errorf("no keyring for attachment backfill")
+	}
+	for _, col := range []string{"filename", "content_type", "size"} {
+		has, err := hasColumn(d.db, "attachments", col)
+		if err != nil {
+			return fmt.Errorf("inspect %s: %w", col, err)
+		}
+		if !has {
+			// Fresh-install schema or already-dropped post-migration —
+			// either way, nothing to backfill.
+			return nil
+		}
+	}
+	tx, err := d.db.Begin()
+	if err != nil {
+		return fmt.Errorf("begin tx: %w", err)
+	}
+	defer tx.Rollback() //nolint:errcheck
+
+	rows, err := tx.Query(`SELECT id,
+		COALESCE(filename, ''), COALESCE(content_type, ''), COALESCE(size, 0)
+		FROM attachments
+		WHERE filename_ct IS NULL OR content_type_ct IS NULL OR size_ct IS NULL`)
+	if err != nil {
+		return fmt.Errorf("select rows: %w", err)
+	}
+	type pending struct {
+		id          int64
+		filename    string
+		contentType string
+		size        int64
+	}
+	var batch []pending
+	for rows.Next() {
+		var p pending
+		if err := rows.Scan(&p.id, &p.filename, &p.contentType, &p.size); err != nil {
+			rows.Close()
+			return fmt.Errorf("scan: %w", err)
+		}
+		batch = append(batch, p)
+	}
+	rows.Close()
+	if err := rows.Err(); err != nil {
+		return fmt.Errorf("iterate: %w", err)
+	}
+
+	stmt, err := tx.Prepare(`UPDATE attachments
+		SET filename_ct = ?, content_type_ct = ?, size_ct = ?
+		WHERE id = ?`)
+	if err != nil {
+		return fmt.Errorf("prepare update: %w", err)
+	}
+	defer stmt.Close()
+	for _, p := range batch {
+		filenameCT, err := d.encryptMeta(p.filename)
+		if err != nil {
+			return fmt.Errorf("encrypt filename id=%d: %w", p.id, err)
+		}
+		contentTypeCT, err := d.encryptMeta(p.contentType)
+		if err != nil {
+			return fmt.Errorf("encrypt content_type id=%d: %w", p.id, err)
+		}
+		var sizeStr string
+		if p.size != 0 {
+			sizeStr = strconv.FormatInt(p.size, 10)
+		}
+		sizeCT, err := d.encryptMeta(sizeStr)
+		if err != nil {
+			return fmt.Errorf("encrypt size id=%d: %w", p.id, err)
+		}
+		if _, err := stmt.Exec(filenameCT, contentTypeCT, sizeCT, p.id); err != nil {
+			return fmt.Errorf("update id=%d: %w", p.id, err)
+		}
+	}
+	return tx.Commit()
 }
 
 // rebuildBlindFTSForBigramEncoding wipes and repopulates

--- a/cli/internal/store/store_test.go
+++ b/cli/internal/store/store_test.go
@@ -42,8 +42,8 @@ func TestOpenAndInit(t *testing.T) {
 	if err != nil {
 		t.Fatalf("read version: %v", err)
 	}
-	if version != 21 {
-		t.Errorf("version = %d, want 21", version)
+	if version != 22 {
+		t.Errorf("version = %d, want 22", version)
 	}
 }
 
@@ -185,8 +185,8 @@ func TestMigrateV9_PopulatesMailboxesAndAccounts(t *testing.T) {
 	if err := db.QueryRow("SELECT version FROM schema_version WHERE rowid = 1").Scan(&version); err != nil {
 		t.Fatalf("read version: %v", err)
 	}
-	if version != 21 {
-		t.Fatalf("version = %d, want 21", version)
+	if version != 22 {
+		t.Fatalf("version = %d, want 22", version)
 	}
 
 	// mailboxes must contain exactly INBOX and Drafts (case-collapsed).

--- a/docs/content/docs/developers/design/0001-mail-content-encryption-at-rest.md
+++ b/docs/content/docs/developers/design/0001-mail-content-encryption-at-rest.md
@@ -231,6 +231,25 @@ plaintext as before.
 
 `outbox.draft_json`, `local_drafts.draft_json` → `BLOB`.
 
+`attachments.filename`, `attachments.content_type`, `attachments.size` →
+`BLOB` (encrypted with `meta_key`, v21→v22). Filenames like
+`Tax_Return_2026.pdf` or `MRI_results.dcm` carry subject-grade
+content-classification signal — the original ADR scope treated
+attachments as pure metadata and missed this; post-audit-2 deep
+review corrected the gap. `content_type` ("application/dicom" reveals
+medical context as sharply as the filename) and `size` (combined with
+the already-plaintext `from_addr` + `date`, sharpens an
+activity-pattern signal like "Tuesday 9am 2.4MB PDF from
+accountant@x") get the same treatment. The remaining columns —
+`disposition` (2 values, encrypt-buys-nothing), `content_id` (opaque
+random MIME Content-ID, no content signal), `part_id` (structural
+MIME-part enumeration) — stay plaintext. β-revision argument is
+**partial** here: inbound attachment metadata was on the wire over
+all MTAs (β applies on the read side), but `local_drafts` / `outbox`
+filenames are pre-wire if the user cancels send (β does NOT apply, same
+shape as `draft_json` which the ADR already encrypts). Encrypting the
+combined set is the conservative choice that closes both halves.
+
 Indexes that referenced encrypted columns (e.g. `idx_messages_from_addr`) are
 **dropped**. They are unusable on ciphertext. Replacement: the blind-token
 FTS5 index covers the common search cases; for exact lookups on `from_addr`
@@ -627,9 +646,11 @@ statement. Mitigations, all part of the implementation PR:
 ### 7. Out of scope (separate future ADRs)
 
 - Master-key rotation procedure.
-- Encrypted attachments-on-disk (`attachments` table only stores metadata
-  today; raw attachment bytes live in the IMAP server cache or are fetched
-  on demand).
+- Encrypted attachment **payload bytes**-on-disk (raw bytes live in the
+  IMAP server cache or are fetched on demand; the local attachments
+  table only stores metadata). Attachment metadata that carries
+  content-classification signal (`filename`, `content_type`, `size`) IS
+  encrypted post-v22 — see §3.
 - Sync server (`sync/main.go`): different data domain (tag changes only, no
   user content). Stays unencrypted.
 - Linux-Wayland-clipboard plaintext leakage of decrypted bodies — UI concern.


### PR DESCRIPTION
## Summary

Closes one of two audit-2 deep-review findings: \`attachments.filename\` was plaintext while bodies + subjects were encrypted. Filenames like \`Tax_Return_2026.pdf\` carry subject-grade content-classification signal that the original ADR §3 missed.

- **filename → \`filename_ct\` BLOB** (encrypt with meta_key) — \"Tax_Return.pdf\" / \"MRI.dcm\" is content
- **content_type → \`content_type_ct\` BLOB** — \"application/dicom\" reveals as sharply as filename
- **size → \`size_ct\` BLOB** — combined with already-plaintext from_addr + date is a sharp activity pattern (\"Tuesday 9am 2.4MB PDF from accountant@x\")
- **disposition / content_id / part_id** stay plaintext (2 values / opaque / structural)

### Migration v21→v22

- ALTER TABLE adds three ct BLOBs (idempotent via PRAGMA table_info).
- backfillAttachmentMetaCt encrypts existing rows, gated on \`hasColumn\` so fresh installs (which land at v22 shape directly) short-circuit.
- DROP plaintext columns.
- VACUUM-before-bump (audit-H3 ordering: if VACUUM crashes, schema_version stays at 21 so next Init retries).

### Code

- New \`scanAttachmentRow\` + \`attachmentSelectColumns\` helpers replace 3 copies of the field-list-and-scan boilerplate. \`handler/show.go\`'s Content-Disposition formatter reads \`storeAtt.Filename\` which now comes through the decrypt path transparently — no handler change needed.
- \`insertAttachmentTx\` encrypts filename / content_type / size (decimal-string-encoded) before INSERT.

### β-Revision

Partial: inbound MIME metadata was on the wire over MTAs (β applies on read), but \`local_drafts\` / \`outbox\` filenames are pre-wire if the user cancels send (β does NOT apply, same shape as \`draft_json\` which the ADR already encrypts). Encrypting both halves is the conservative choice.

## Test plan

- [x] All 18 CLI unit tests pass; encryption grep-gate clean.
- [x] New \`TestAttachmentMetadata_EncryptedAtRest\` reads the raw ct bytes via SELECT and asserts distinctive plaintext substrings (\"Tax_Return_2026.pdf\", \"application/dicom\", \"314159\") do NOT appear in the ciphertext, then asserts API round-trip returns the original plaintext, then asserts plaintext columns are physically gone post-migration.