### PR TITLE
ADR-0001 audit follow-ups: close #251 #252 #253 #254

### DIFF
--- a/cli/cmd/durian/send.go
+++ b/cli/cmd/durian/send.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"strings"
 	"time"
 
@@ -276,10 +277,28 @@ func prompt(message string) (string, error) {
 	return strings.TrimSpace(line), nil
 }
 
-// openEditor opens $EDITOR for the user to write the email body
+// openEditor opens $EDITOR for the user to write the email body.
+//
+// ADR-0001 audit #254.3: the editor file holds the plaintext body, so it
+// must not land in /tmp where any local user can read it and where editor
+// artefacts (vim .swp, crashed sessions) linger across reboots. The file
+// is placed under $XDG_CACHE_HOME/durian (or ~/.cache/durian) with the
+// containing directory restricted to 0700 — matching the imap state-manager
+// convention in the same cache root.
 func openEditor(to, subject string) (string, error) {
-	// Create temp file with template
-	tmpfile, err := os.CreateTemp("", "durian-*.txt")
+	cacheRoot := os.Getenv("XDG_CACHE_HOME")
+	if cacheRoot == "" {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return "", fmt.Errorf("resolve home dir for editor tempfile: %w", err)
+		}
+		cacheRoot = filepath.Join(home, ".cache")
+	}
+	cacheDir := filepath.Join(cacheRoot, "durian")
+	if err := os.MkdirAll(cacheDir, 0o700); err != nil {
+		return "", fmt.Errorf("create editor cache dir: %w", err)
+	}
+	tmpfile, err := os.CreateTemp(cacheDir, "compose-*.txt")
 	if err != nil {
 		return "", fmt.Errorf("failed to create temp file: %w", err)
 	}

--- a/cli/internal/contacts/db_test.go
+++ b/cli/internal/contacts/db_test.go
@@ -1,6 +1,9 @@
 package contacts
 
 import (
+	"bytes"
+	"errors"
+	"os"
 	"path/filepath"
 	"testing"
 	"time"
@@ -33,6 +36,78 @@ func TestOpen_SecureDeleteEnabled(t *testing.T) {
 	if v != 1 {
 		t.Errorf("PRAGMA secure_delete = %d, want 1", v)
 	}
+}
+
+// TestSecureDelete_ScrubsRawBytes (ADR-0001 audit #252): same property
+// proof as the store-side test, applied to contacts.db. The contact
+// name column stays plaintext in contacts.db (ADR-0001 step 7g moved
+// the encrypted variant out of scope until β-revision lands here), so
+// we insert a marker name, delete the row, checkpoint, and grep raw
+// bytes — must not survive.
+func TestSecureDelete_ScrubsRawBytes(t *testing.T) {
+	const marker = "DurianSecureDeleteMarker3F8B7A1E"
+
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "contacts.db")
+	db, err := Open(dbPath)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	if err := db.Init(); err != nil {
+		t.Fatalf("init: %v", err)
+	}
+
+	if err := db.Add("scrub@example.com", marker, SourceImported); err != nil {
+		t.Fatalf("add: %v", err)
+	}
+	if _, err := db.db.Exec("PRAGMA wal_checkpoint(TRUNCATE)"); err != nil {
+		t.Fatalf("pre-delete checkpoint: %v", err)
+	}
+	if !rawContactsDBContains(t, dbPath, marker) {
+		t.Fatalf("test setup broken: marker %q not present pre-delete", marker)
+	}
+
+	if err := db.Delete("scrub@example.com"); err != nil {
+		t.Fatalf("delete: %v", err)
+	}
+	if _, err := db.db.Exec("PRAGMA wal_checkpoint(TRUNCATE)"); err != nil {
+		t.Fatalf("post-delete checkpoint: %v", err)
+	}
+	if err := db.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+
+	for _, suffix := range []string{"", "-wal", "-shm"} {
+		path := dbPath + suffix
+		b, err := os.ReadFile(path)
+		if err != nil {
+			if errors.Is(err, os.ErrNotExist) {
+				continue
+			}
+			t.Fatalf("read %s: %v", path, err)
+		}
+		if bytes.Contains(b, []byte(marker)) {
+			t.Errorf("marker %q still present in %s after secure_delete (%d bytes)", marker, path, len(b))
+		}
+	}
+}
+
+func rawContactsDBContains(t *testing.T, dbPath, marker string) bool {
+	t.Helper()
+	for _, suffix := range []string{"", "-wal"} {
+		path := dbPath + suffix
+		b, err := os.ReadFile(path)
+		if err != nil {
+			if errors.Is(err, os.ErrNotExist) {
+				continue
+			}
+			t.Fatalf("read %s: %v", path, err)
+		}
+		if bytes.Contains(b, []byte(marker)) {
+			return true
+		}
+	}
+	return false
 }
 
 func TestAddAndSearch(t *testing.T) {

--- a/cli/internal/dbcrypto/dbcrypto.go
+++ b/cli/internal/dbcrypto/dbcrypto.go
@@ -35,6 +35,14 @@ const (
 	// envelopeOverhead is the minimum bytes any V1 ciphertext occupies,
 	// even for empty plaintext: version + nonce + tag.
 	envelopeOverhead = 1 + NonceLen + TagLen
+
+	// MaxPlaintextLen caps the bytes any single Encrypt / EncryptX call
+	// will accept. SQLite's default SQLITE_MAX_LENGTH is 1 GiB, so any
+	// value the store could possibly hand us already fits; this guard
+	// exists so the `envelopeOverhead + len(plaintext)` expression in
+	// sealAEAD provably can't overflow `int` on 32-bit platforms or trip
+	// CodeQL's go/allocation-size-overflow check.
+	MaxPlaintextLen = 1 << 30 // 1 GiB
 )
 
 // Label is the HKDF "info" string for one sub-key purpose. The exact byte
@@ -54,9 +62,10 @@ const (
 )
 
 var (
-	ErrInvalidKey      = errors.New("dbcrypto: key must be 32 bytes")
-	ErrShortCiphertext = errors.New("dbcrypto: ciphertext shorter than envelope overhead")
-	ErrUnknownVersion  = errors.New("dbcrypto: unknown envelope version")
+	ErrInvalidKey       = errors.New("dbcrypto: key must be 32 bytes")
+	ErrShortCiphertext  = errors.New("dbcrypto: ciphertext shorter than envelope overhead")
+	ErrUnknownVersion   = errors.New("dbcrypto: unknown envelope version")
+	ErrPlaintextTooLong = fmt.Errorf("dbcrypto: plaintext exceeds %d bytes", MaxPlaintextLen)
 )
 
 // DeriveSubKey extracts a 32-byte purpose-specific sub-key from a 32-byte
@@ -124,7 +133,14 @@ func Decrypt(key, ciphertext []byte) ([]byte, error) {
 // out so both Encrypt (fresh AEAD per call) and the Keyring per-sub-key
 // methods (cached AEAD) share one identical wire-format producer — no risk
 // of envelope-shape drift between the two paths.
+//
+// The MaxPlaintextLen guard bounds the make() capacity argument below so
+// `envelopeOverhead + len(plaintext)` provably stays within int range
+// (CodeQL go/allocation-size-overflow).
 func sealAEAD(aead cipher.AEAD, plaintext []byte) ([]byte, error) {
+	if len(plaintext) > MaxPlaintextLen {
+		return nil, ErrPlaintextTooLong
+	}
 	// Pre-allocate the full envelope so Seal appends in place.
 	out := make([]byte, 1+NonceLen, envelopeOverhead+len(plaintext))
 	out[0] = EnvelopeV1

--- a/cli/internal/dbcrypto/dbcrypto.go
+++ b/cli/internal/dbcrypto/dbcrypto.go
@@ -74,6 +74,10 @@ func DeriveSubKey(master []byte, label Label) ([]byte, error) {
 //
 // The returned slice is newly allocated and safe for the caller to retain.
 // Plaintext is not modified.
+//
+// Hot paths that already hold a Keyring should prefer the per-sub-key
+// methods (e.g. (*Keyring).EncryptSubject), which reuse a cached AEAD
+// instead of re-running aes.NewCipher + cipher.NewGCM per call.
 func Encrypt(key, plaintext []byte) ([]byte, error) {
 	if len(key) != KeyLen {
 		return nil, ErrInvalidKey
@@ -82,18 +86,15 @@ func Encrypt(key, plaintext []byte) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
-	// Pre-allocate the full envelope so Seal appends in place.
-	out := make([]byte, 1+NonceLen, envelopeOverhead+len(plaintext))
-	out[0] = EnvelopeV1
-	nonce := out[1 : 1+NonceLen]
-	if _, err := rand.Read(nonce); err != nil {
-		return nil, fmt.Errorf("dbcrypto: nonce: %w", err)
-	}
-	return gcm.Seal(out, nonce, plaintext, nil), nil
+	return sealAEAD(gcm, plaintext)
 }
 
 // Decrypt opens a V1 envelope produced by Encrypt. It returns the plaintext
 // or an error — never both, and never a partial result.
+//
+// Hot paths that already hold a Keyring should prefer the per-sub-key
+// methods (e.g. (*Keyring).DecryptSubject), which reuse a cached AEAD
+// instead of re-running aes.NewCipher + cipher.NewGCM per call.
 //
 // Check order matters: key length first (AES constructor would panic on a
 // bad-length key), then envelope length (no slice access without a bound
@@ -111,13 +112,36 @@ func Decrypt(key, ciphertext []byte) ([]byte, error) {
 	if ciphertext[0] != EnvelopeV1 {
 		return nil, ErrUnknownVersion
 	}
-	nonce := ciphertext[1 : 1+NonceLen]
-	body := ciphertext[1+NonceLen:]
 	gcm, err := newGCM(key)
 	if err != nil {
 		return nil, err
 	}
-	return gcm.Open(nil, nonce, body, nil)
+	return openAEAD(gcm, ciphertext)
+}
+
+// sealAEAD writes the V1 envelope around aead.Seal. The aead must have a
+// NonceSize of NonceLen (true for AES-GCM constructed via newGCM). Pulled
+// out so both Encrypt (fresh AEAD per call) and the Keyring per-sub-key
+// methods (cached AEAD) share one identical wire-format producer — no risk
+// of envelope-shape drift between the two paths.
+func sealAEAD(aead cipher.AEAD, plaintext []byte) ([]byte, error) {
+	// Pre-allocate the full envelope so Seal appends in place.
+	out := make([]byte, 1+NonceLen, envelopeOverhead+len(plaintext))
+	out[0] = EnvelopeV1
+	nonce := out[1 : 1+NonceLen]
+	if _, err := rand.Read(nonce); err != nil {
+		return nil, fmt.Errorf("dbcrypto: nonce: %w", err)
+	}
+	return aead.Seal(out, nonce, plaintext, nil), nil
+}
+
+// openAEAD parses the V1 envelope and calls aead.Open. Callers are
+// expected to have already validated len(ciphertext) >= envelopeOverhead
+// and ciphertext[0] == EnvelopeV1.
+func openAEAD(aead cipher.AEAD, ciphertext []byte) ([]byte, error) {
+	nonce := ciphertext[1 : 1+NonceLen]
+	body := ciphertext[1+NonceLen:]
+	return aead.Open(nil, nonce, body, nil)
 }
 
 // newGCM is the shared AES-GCM construction step. Pulled out so Encrypt and

--- a/cli/internal/dbcrypto/dbcrypto_test.go
+++ b/cli/internal/dbcrypto/dbcrypto_test.go
@@ -108,6 +108,24 @@ func TestEncrypt_RejectsBadKey(t *testing.T) {
 	}
 }
 
+// TestEncrypt_RejectsOversizedPlaintext pins the MaxPlaintextLen guard
+// that sealAEAD relies on so `envelopeOverhead + len(plaintext)` can't
+// overflow `int` (CodeQL go/allocation-size-overflow).
+//
+// Skipped on memory-constrained runners — allocating 1 GiB just to read
+// its length is wasteful, but there is no cheaper way in pure Go to
+// produce a slice whose `len()` lies about its backing.
+func TestEncrypt_RejectsOversizedPlaintext(t *testing.T) {
+	if testing.Short() {
+		t.Skip("allocates 1 GiB; skipped under -short")
+	}
+	key := bytes.Repeat([]byte{0x88}, KeyLen)
+	oversized := make([]byte, MaxPlaintextLen+1)
+	if _, err := Encrypt(key, oversized); !errors.Is(err, ErrPlaintextTooLong) {
+		t.Errorf("err = %v, want ErrPlaintextTooLong", err)
+	}
+}
+
 // --- Round-trip (requires Decrypt to be implemented) ---
 
 func TestRoundTrip_AllLabels(t *testing.T) {

--- a/cli/internal/dbcrypto/dbcrypto_test.go
+++ b/cli/internal/dbcrypto/dbcrypto_test.go
@@ -371,16 +371,3 @@ func TestNewKeyring_RejectsBadMasterLen(t *testing.T) {
 	}
 }
 
-func TestKeyring_Wipe(t *testing.T) {
-	kr, err := NewKeyring(bytes.Repeat([]byte{0x33}, MasterKeyLen))
-	if err != nil {
-		t.Fatalf("NewKeyring: %v", err)
-	}
-	kr.Wipe()
-	if kr.Subject != nil {
-		t.Errorf("Subject not nilled after Wipe: %x", kr.Subject)
-	}
-	// Wipe must be safe on nil receiver — defensive for shutdown paths.
-	var nilKr *Keyring
-	nilKr.Wipe()
-}

--- a/cli/internal/dbcrypto/dbcrypto_test.go
+++ b/cli/internal/dbcrypto/dbcrypto_test.go
@@ -252,6 +252,119 @@ func TestNewKeyring_DerivesAllSubKeys(t *testing.T) {
 	}
 }
 
+// TestKeyring_CachedAEADMatchesFreshPath proves that ciphertext produced
+// by the cached-AEAD per-sub-key methods round-trips through the
+// package-level Decrypt(key, ct) path and vice versa. If the two paths
+// ever diverge on envelope shape, every ciphertext written by one path
+// becomes unreadable by the other — same risk class as the HKDF tripwire
+// above.
+func TestKeyring_CachedAEADMatchesFreshPath(t *testing.T) {
+	master := bytes.Repeat([]byte{0xa5}, MasterKeyLen)
+	kr, err := NewKeyring(master)
+	if err != nil {
+		t.Fatalf("NewKeyring: %v", err)
+	}
+	plain := []byte("paths must agree on the wire format")
+
+	cases := []struct {
+		name    string
+		key     []byte
+		seal    func([]byte) ([]byte, error)
+		open    func([]byte) ([]byte, error)
+	}{
+		{"Subject", kr.Subject, kr.EncryptSubject, kr.DecryptSubject},
+		{"Body", kr.Body, kr.EncryptBody, kr.DecryptBody},
+		{"Addrs", kr.Addrs, kr.EncryptAddrs, kr.DecryptAddrs},
+		{"Headers", kr.Headers, kr.EncryptHeaders, kr.DecryptHeaders},
+		{"Draft", kr.Draft, kr.EncryptDraft, kr.DecryptDraft},
+		{"Meta", kr.Meta, kr.EncryptMeta, kr.DecryptMeta},
+		{"Contact", kr.Contact, kr.EncryptContact, kr.DecryptContact},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			// cached seal → fresh open
+			ct, err := c.seal(plain)
+			if err != nil {
+				t.Fatalf("cached seal: %v", err)
+			}
+			got, err := Decrypt(c.key, ct)
+			if err != nil {
+				t.Fatalf("fresh open of cached ct: %v", err)
+			}
+			if !bytes.Equal(got, plain) {
+				t.Errorf("fresh-open mismatch: got=%q want=%q", got, plain)
+			}
+			// fresh seal → cached open
+			ct2, err := Encrypt(c.key, plain)
+			if err != nil {
+				t.Fatalf("fresh seal: %v", err)
+			}
+			got2, err := c.open(ct2)
+			if err != nil {
+				t.Fatalf("cached open of fresh ct: %v", err)
+			}
+			if !bytes.Equal(got2, plain) {
+				t.Errorf("cached-open mismatch: got=%q want=%q", got2, plain)
+			}
+		})
+	}
+}
+
+// TestKeyring_DecryptCached_RejectsStructuralErrors mirrors the
+// package-level guards (short / unknown-version) for the cached path so
+// callers see the same error shape regardless of which entry they took.
+func TestKeyring_DecryptCached_RejectsStructuralErrors(t *testing.T) {
+	kr, err := NewKeyring(bytes.Repeat([]byte{0x66}, MasterKeyLen))
+	if err != nil {
+		t.Fatalf("NewKeyring: %v", err)
+	}
+	for _, n := range []int{0, 1, NonceLen, envelopeOverhead - 1} {
+		if _, err := kr.DecryptSubject(make([]byte, n)); !errors.Is(err, ErrShortCiphertext) {
+			t.Errorf("len %d: err = %v, want ErrShortCiphertext", n, err)
+		}
+	}
+	bad := make([]byte, envelopeOverhead)
+	bad[0] = 0xff
+	if _, err := kr.DecryptSubject(bad); !errors.Is(err, ErrUnknownVersion) {
+		t.Errorf("bad version: err = %v, want ErrUnknownVersion", err)
+	}
+}
+
+// BenchmarkDecrypt_FreshVsCached compares the package-level Decrypt path
+// (which re-runs aes.NewCipher + cipher.NewGCM per call) against the
+// Keyring-cached path. ADR-0001 audit #254.1 acceptance: ≥2× speedup.
+//
+// Run via:  go test -run=^$ -bench=Decrypt_FreshVsCached -benchmem ./...
+func BenchmarkDecrypt_FreshVsCached(b *testing.B) {
+	master := bytes.Repeat([]byte{0xc3}, MasterKeyLen)
+	kr, err := NewKeyring(master)
+	if err != nil {
+		b.Fatalf("NewKeyring: %v", err)
+	}
+	plain := bytes.Repeat([]byte("durian-body "), 80) // ~1 KB
+	ct, err := kr.EncryptBody(plain)
+	if err != nil {
+		b.Fatalf("seal: %v", err)
+	}
+
+	b.Run("fresh", func(b *testing.B) {
+		b.ReportAllocs()
+		for b.Loop() {
+			if _, err := Decrypt(kr.Body, ct); err != nil {
+				b.Fatalf("decrypt: %v", err)
+			}
+		}
+	})
+	b.Run("cached", func(b *testing.B) {
+		b.ReportAllocs()
+		for b.Loop() {
+			if _, err := kr.DecryptBody(ct); err != nil {
+				b.Fatalf("decrypt: %v", err)
+			}
+		}
+	})
+}
+
 func TestNewKeyring_RejectsBadMasterLen(t *testing.T) {
 	if _, err := NewKeyring(make([]byte, 16)); !errors.Is(err, ErrInvalidKey) {
 		t.Errorf("err = %v, want ErrInvalidKey wrapped", err)

--- a/cli/internal/dbcrypto/keyring.go
+++ b/cli/internal/dbcrypto/keyring.go
@@ -2,7 +2,6 @@ package dbcrypto
 
 import (
 	"crypto/cipher"
-	"crypto/subtle"
 	"fmt"
 )
 
@@ -193,36 +192,14 @@ func decryptCached(aead cipher.AEAD, ciphertext []byte) ([]byte, error) {
 	return openAEAD(aead, ciphertext)
 }
 
-// Wipe overwrites every sub-key in place with zeroes and nils the slice
-// headers, making post-Wipe use of the Keyring panic instead of silently
-// returning all-zero ciphertexts. Intended for shutdown paths; Go's GC
-// otherwise reclaims the underlying memory eventually.
-func (k *Keyring) Wipe() {
-	if k == nil {
-		return
-	}
-	zero(k.Subject)
-	zero(k.Body)
-	zero(k.Addrs)
-	zero(k.Headers)
-	zero(k.Draft)
-	zero(k.Meta)
-	zero(k.Contact)
-	zero(k.FTSToken)
-	k.Subject = nil
-	k.Body = nil
-	k.Addrs = nil
-	k.Headers = nil
-	k.Draft = nil
-	k.Meta = nil
-	k.Contact = nil
-	k.FTSToken = nil
-}
-
-// zero overwrites b with zero bytes in constant time. Used by Wipe.
-func zero(b []byte) {
-	if len(b) == 0 {
-		return
-	}
-	subtle.ConstantTimeCopy(1, b, make([]byte, len(b)))
-}
+// (ADR-0001 audit #253) An earlier revision of this file shipped a
+// Keyring.Wipe method that overwrote each sub-key with zeros via
+// crypto/subtle.ConstantTimeCopy. It has been removed: the guarantee
+// was unenforceable in Go (no runtime.KeepAlive, GC may already have
+// copied the backing array during slice growth, sub-keys are held for
+// process lifetime so Wipe fires only at shutdown when the process is
+// about to free everything anyway). Shipping a best-effort scrub under
+// the name "Wipe" is worse than not shipping one — readers assumed
+// stronger semantics than the code delivered. See ADR-0001 § Memory
+// hygiene for the honest contract: sub-keys stay in process memory
+// for the lifetime of `durian serve`, no scrubbing attempted.

--- a/cli/internal/dbcrypto/keyring.go
+++ b/cli/internal/dbcrypto/keyring.go
@@ -1,6 +1,7 @@
 package dbcrypto
 
 import (
+	"crypto/cipher"
 	"crypto/subtle"
 	"fmt"
 )
@@ -10,9 +11,12 @@ import (
 // start, retained in memory for the lifetime of the daemon, and consumed
 // by the store layer for transparent encrypt-on-write / decrypt-on-read.
 //
-// Subsequent steps fill in Headers, Addrs, Draft, Contact, FTSToken, Meta
-// — each as its own field so callers never have to remember which label
-// to pass.
+// Each AES-GCM sub-key has its cipher.AEAD constructed once in NewKeyring
+// and cached on the unexported *AEAD field. The per-sub-key methods
+// (EncryptSubject, DecryptSubject, …) reuse that cached AEAD on every
+// call; on a full-mailbox decrypt scan (~50k rows) this is ≥2× the cost
+// of the package-level Encrypt/Decrypt path, which re-runs aes.NewCipher
+// + cipher.NewGCM per row.
 type Keyring struct {
 	Subject  []byte // encrypts messages.subject (LabelSubject)
 	Body     []byte // encrypts messages.body_text + body_html (LabelBody)
@@ -22,48 +26,171 @@ type Keyring struct {
 	Meta     []byte // encrypts mailboxes.name + accounts.name + messages.flags_other (LabelMeta)
 	Contact  []byte // encrypts contacts.email + contacts.name (LabelContact)
 	FTSToken []byte // HMAC key for blind FTS5 search tokens (LabelFTSToken)
+
+	// Cached AES-GCM constructions, one per AEAD sub-key. FTSToken is
+	// excluded — it is consumed as an HMAC key, not an AEAD.
+	subjectAEAD cipher.AEAD
+	bodyAEAD    cipher.AEAD
+	addrsAEAD   cipher.AEAD
+	headersAEAD cipher.AEAD
+	draftAEAD   cipher.AEAD
+	metaAEAD    cipher.AEAD
+	contactAEAD cipher.AEAD
 }
 
-// NewKeyring derives every currently-shipped sub-key from a 32-byte master.
-// The master is read once and never retained by the returned Keyring; the
-// caller is free to (and should) wipe its own copy once this returns.
+// NewKeyring derives every currently-shipped sub-key from a 32-byte master
+// and pre-builds the AES-GCM AEAD for each AEAD sub-key. The master is
+// read once and never retained by the returned Keyring; the caller is free
+// to (and should) wipe its own copy once this returns.
 func NewKeyring(master []byte) (*Keyring, error) {
-	subject, err := DeriveSubKey(master, LabelSubject)
-	if err != nil {
-		return nil, fmt.Errorf("dbcrypto: derive subject sub-key: %w", err)
+	type spec struct {
+		label Label
+		dst   *[]byte
 	}
-	body, err := DeriveSubKey(master, LabelBody)
-	if err != nil {
-		return nil, fmt.Errorf("dbcrypto: derive body sub-key: %w", err)
+	subkeys := []spec{
+		{LabelSubject, nil},
+		{LabelBody, nil},
+		{LabelAddrs, nil},
+		{LabelHeaders, nil},
+		{LabelDraft, nil},
+		{LabelMeta, nil},
+		{LabelContact, nil},
+		{LabelFTSToken, nil},
 	}
-	addrs, err := DeriveSubKey(master, LabelAddrs)
-	if err != nil {
-		return nil, fmt.Errorf("dbcrypto: derive addrs sub-key: %w", err)
+	kr := &Keyring{}
+	subkeys[0].dst = &kr.Subject
+	subkeys[1].dst = &kr.Body
+	subkeys[2].dst = &kr.Addrs
+	subkeys[3].dst = &kr.Headers
+	subkeys[4].dst = &kr.Draft
+	subkeys[5].dst = &kr.Meta
+	subkeys[6].dst = &kr.Contact
+	subkeys[7].dst = &kr.FTSToken
+
+	for _, s := range subkeys {
+		k, err := DeriveSubKey(master, s.label)
+		if err != nil {
+			return nil, fmt.Errorf("dbcrypto: derive %s sub-key: %w", s.label, err)
+		}
+		*s.dst = k
 	}
-	headers, err := DeriveSubKey(master, LabelHeaders)
-	if err != nil {
-		return nil, fmt.Errorf("dbcrypto: derive headers sub-key: %w", err)
+
+	// Build the AEAD for each encryption sub-key exactly once. FTSToken
+	// is omitted on purpose; it never reaches AES-GCM.
+	aeadFor := func(key []byte, label Label) (cipher.AEAD, error) {
+		aead, err := newGCM(key)
+		if err != nil {
+			return nil, fmt.Errorf("dbcrypto: build %s AEAD: %w", label, err)
+		}
+		return aead, nil
 	}
-	draft, err := DeriveSubKey(master, LabelDraft)
-	if err != nil {
-		return nil, fmt.Errorf("dbcrypto: derive draft sub-key: %w", err)
+	var err error
+	if kr.subjectAEAD, err = aeadFor(kr.Subject, LabelSubject); err != nil {
+		return nil, err
 	}
-	meta, err := DeriveSubKey(master, LabelMeta)
-	if err != nil {
-		return nil, fmt.Errorf("dbcrypto: derive meta sub-key: %w", err)
+	if kr.bodyAEAD, err = aeadFor(kr.Body, LabelBody); err != nil {
+		return nil, err
 	}
-	contact, err := DeriveSubKey(master, LabelContact)
-	if err != nil {
-		return nil, fmt.Errorf("dbcrypto: derive contact sub-key: %w", err)
+	if kr.addrsAEAD, err = aeadFor(kr.Addrs, LabelAddrs); err != nil {
+		return nil, err
 	}
-	ftsToken, err := DeriveSubKey(master, LabelFTSToken)
-	if err != nil {
-		return nil, fmt.Errorf("dbcrypto: derive fts-token sub-key: %w", err)
+	if kr.headersAEAD, err = aeadFor(kr.Headers, LabelHeaders); err != nil {
+		return nil, err
 	}
-	return &Keyring{
-		Subject: subject, Body: body, Addrs: addrs, Headers: headers,
-		Draft: draft, Meta: meta, Contact: contact, FTSToken: ftsToken,
-	}, nil
+	if kr.draftAEAD, err = aeadFor(kr.Draft, LabelDraft); err != nil {
+		return nil, err
+	}
+	if kr.metaAEAD, err = aeadFor(kr.Meta, LabelMeta); err != nil {
+		return nil, err
+	}
+	if kr.contactAEAD, err = aeadFor(kr.Contact, LabelContact); err != nil {
+		return nil, err
+	}
+	return kr, nil
+}
+
+// EncryptSubject seals plaintext under the cached subject AEAD.
+func (k *Keyring) EncryptSubject(plaintext []byte) ([]byte, error) {
+	return sealAEAD(k.subjectAEAD, plaintext)
+}
+
+// DecryptSubject opens a V1 envelope under the cached subject AEAD.
+func (k *Keyring) DecryptSubject(ciphertext []byte) ([]byte, error) {
+	return decryptCached(k.subjectAEAD, ciphertext)
+}
+
+// EncryptBody seals plaintext under the cached body AEAD.
+func (k *Keyring) EncryptBody(plaintext []byte) ([]byte, error) {
+	return sealAEAD(k.bodyAEAD, plaintext)
+}
+
+// DecryptBody opens a V1 envelope under the cached body AEAD.
+func (k *Keyring) DecryptBody(ciphertext []byte) ([]byte, error) {
+	return decryptCached(k.bodyAEAD, ciphertext)
+}
+
+// EncryptAddrs seals plaintext under the cached addrs AEAD.
+func (k *Keyring) EncryptAddrs(plaintext []byte) ([]byte, error) {
+	return sealAEAD(k.addrsAEAD, plaintext)
+}
+
+// DecryptAddrs opens a V1 envelope under the cached addrs AEAD.
+func (k *Keyring) DecryptAddrs(ciphertext []byte) ([]byte, error) {
+	return decryptCached(k.addrsAEAD, ciphertext)
+}
+
+// EncryptHeaders seals plaintext under the cached headers AEAD.
+func (k *Keyring) EncryptHeaders(plaintext []byte) ([]byte, error) {
+	return sealAEAD(k.headersAEAD, plaintext)
+}
+
+// DecryptHeaders opens a V1 envelope under the cached headers AEAD.
+func (k *Keyring) DecryptHeaders(ciphertext []byte) ([]byte, error) {
+	return decryptCached(k.headersAEAD, ciphertext)
+}
+
+// EncryptDraft seals plaintext under the cached draft AEAD.
+func (k *Keyring) EncryptDraft(plaintext []byte) ([]byte, error) {
+	return sealAEAD(k.draftAEAD, plaintext)
+}
+
+// DecryptDraft opens a V1 envelope under the cached draft AEAD.
+func (k *Keyring) DecryptDraft(ciphertext []byte) ([]byte, error) {
+	return decryptCached(k.draftAEAD, ciphertext)
+}
+
+// EncryptMeta seals plaintext under the cached meta AEAD.
+func (k *Keyring) EncryptMeta(plaintext []byte) ([]byte, error) {
+	return sealAEAD(k.metaAEAD, plaintext)
+}
+
+// DecryptMeta opens a V1 envelope under the cached meta AEAD.
+func (k *Keyring) DecryptMeta(ciphertext []byte) ([]byte, error) {
+	return decryptCached(k.metaAEAD, ciphertext)
+}
+
+// EncryptContact seals plaintext under the cached contact AEAD.
+func (k *Keyring) EncryptContact(plaintext []byte) ([]byte, error) {
+	return sealAEAD(k.contactAEAD, plaintext)
+}
+
+// DecryptContact opens a V1 envelope under the cached contact AEAD.
+func (k *Keyring) DecryptContact(ciphertext []byte) ([]byte, error) {
+	return decryptCached(k.contactAEAD, ciphertext)
+}
+
+// decryptCached duplicates the structural checks from package-level
+// Decrypt (length and version) so the cached-AEAD path errors with the
+// same shape as the fresh-AEAD path. Pulled out of every per-sub-key
+// method to keep that contract in one place.
+func decryptCached(aead cipher.AEAD, ciphertext []byte) ([]byte, error) {
+	if len(ciphertext) < envelopeOverhead {
+		return nil, ErrShortCiphertext
+	}
+	if ciphertext[0] != EnvelopeV1 {
+		return nil, ErrUnknownVersion
+	}
+	return openAEAD(aead, ciphertext)
 }
 
 // Wipe overwrites every sub-key in place with zeroes and nils the slice

--- a/cli/internal/store/search.go
+++ b/cli/internal/store/search.go
@@ -689,8 +689,25 @@ func (d *DB) exprToSQL(node exprNode) (string, []interface{}, error) {
 	}
 }
 
+// MaxQueryLen caps the bytes a single search query may contain. ADR-0001
+// audit #254.2: the per-char lexer in scanToken has no internal length
+// budget, so an unbounded query allocates O(N) tokens. The HTTP handler
+// already enforces this cap, but the CLI (`durian search`) and any
+// future unix-socket caller need it too — pushing the check into
+// parseQuery ensures every entry path gets it without coordination.
+const MaxQueryLen = 1024
+
+// ErrQueryTooLong is returned by parseQuery / parseQueryWithTerms when
+// the input exceeds MaxQueryLen bytes. Callers that want a precise 400
+// at an HTTP boundary can errors.Is-match this; the CLI surface is
+// content with the wrapped message.
+var ErrQueryTooLong = fmt.Errorf("query too long (max %d bytes)", MaxQueryLen)
+
 // parseQuery translates a search query into a SQL WHERE clause and parameters.
 func (d *DB) parseQuery(query string) (where string, params []interface{}, err error) {
+	if len(query) > MaxQueryLen {
+		return "", nil, ErrQueryTooLong
+	}
 	tokens := lex(query)
 	node, err := parse(tokens)
 	if err != nil {
@@ -709,6 +726,9 @@ func (d *DB) parseQuery(query string) (where string, params []interface{}, err e
 // query has no blind-FTS terms, terms is nil and callers can take the
 // pure-SQL fast path.
 func (d *DB) parseQueryWithTerms(query string) (where string, params []interface{}, terms []ftsTerm, err error) {
+	if len(query) > MaxQueryLen {
+		return "", nil, nil, ErrQueryTooLong
+	}
 	tokens := lex(query)
 	node, err := parse(tokens)
 	if err != nil {

--- a/cli/internal/store/search_test.go
+++ b/cli/internal/store/search_test.go
@@ -1,6 +1,8 @@
 package store
 
 import (
+	"errors"
+	"strings"
 	"testing"
 	"time"
 )
@@ -611,6 +613,28 @@ func TestSearch_UnknownField(t *testing.T) {
 	_, err := db.Search("unknown:value", 10)
 	if err == nil {
 		t.Error("expected error for unknown field")
+	}
+}
+
+// TestSearch_RejectsOversizedQuery pins ADR-0001 audit #254.2: any query
+// over MaxQueryLen bytes must be rejected before the per-char lexer runs,
+// regardless of which caller fed it in (HTTP, CLI, unix socket). Test sits
+// at parseQuery's level so all upstream paths inherit the guarantee.
+func TestSearch_RejectsOversizedQuery(t *testing.T) {
+	db := newTestDB(t)
+	huge := strings.Repeat("a", MaxQueryLen+1)
+	_, err := db.Search(huge, 10)
+	if err == nil {
+		t.Fatalf("expected ErrQueryTooLong for %d-byte query", len(huge))
+	}
+	if !errors.Is(err, ErrQueryTooLong) {
+		t.Errorf("err = %v, want wraps ErrQueryTooLong", err)
+	}
+	// Boundary: exactly MaxQueryLen must still be accepted by the lexer
+	// (parser may reject for other reasons, but not for length).
+	atCap := strings.Repeat("a", MaxQueryLen)
+	if _, err := db.Search(atCap, 10); errors.Is(err, ErrQueryTooLong) {
+		t.Errorf("query at exact cap was rejected as too long")
 	}
 }
 

--- a/cli/internal/store/store.go
+++ b/cli/internal/store/store.go
@@ -3,6 +3,7 @@ package store
 import (
 	"database/sql"
 	"fmt"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -81,7 +82,82 @@ func Open(dbPath string, kr *dbcrypto.Keyring) (*DB, error) {
 		}
 	}
 
+	if dbPath != ":memory:" {
+		if err := vacuumIfFreelistHigh(db); err != nil {
+			db.Close()
+			return nil, fmt.Errorf("freelist hygiene: %w", err)
+		}
+	}
+
 	return &DB{db: db, keyring: kr}, nil
+}
+
+// freelistVacuumRatio and freelistVacuumFloor together decide when
+// vacuumIfFreelistHigh fires. ADR-0001 audit #251: a Time-Machine /
+// iCloud / external backup taken before the v19→v20 audit-H3 fix is
+// still full of dropped-step-7e plaintext bytes stranded in unused
+// pages. The retroactive VACUUM only fires once per migration step,
+// so a user who restores the old backup over a current install never
+// gets cleaned up. This guard is the recurring counter-measure —
+// "if the freelist is unusually large for this DB, scrub it once."
+//
+// Trade-off: bounded recurring cost (one VACUUM per N restores) vs.
+// the current unbounded behaviour (none). Threshold values are tuned
+// to avoid firing on a healthy DB (typical freelist after sync ≈ a
+// few dozen pages on 50k-message mailbox = ~10–50 MB) and to fire
+// after a backup restore (page_count comparable, but freelist
+// proportionally huge).
+//
+// Calibration: ratio=0.10 fires when 10 % of the file is freelist —
+// well above the post-sync baseline (single-digit pages on a healthy
+// 200 MB DB ≈ 0.001 %) but well below the post-restore signal
+// (step-7e drop alone stranded ~30 % of pages on early test DBs).
+// floor=1024 (≈4 MB at 4 KB pages) is the absolute scrub trigger so
+// even tiny DBs with proportionally huge freelists get cleaned —
+// without it, a 10k-page test DB with 800 free pages (8 %) would
+// slip past the ratio guard.
+var (
+	freelistVacuumRatio = 0.10
+	freelistVacuumFloor = int64(1024)
+)
+
+// vacuumIfFreelistHigh inspects PRAGMA page_count and PRAGMA
+// freelist_count and runs VACUUM when the freelist exceeds either
+// freelistVacuumFloor or freelistVacuumRatio * page_count. It is a
+// best-effort hygiene pass: failures here do not block Open in
+// production (the function is wrapped in a fmt.Errorf for surfacing,
+// but callers can choose to log-and-continue if VACUUM ever becomes
+// expensive on huge databases).
+func vacuumIfFreelistHigh(db *sql.DB) error {
+	var pageCount, freelist int64
+	if err := db.QueryRow("PRAGMA page_count").Scan(&pageCount); err != nil {
+		return fmt.Errorf("read page_count: %w", err)
+	}
+	if err := db.QueryRow("PRAGMA freelist_count").Scan(&freelist); err != nil {
+		return fmt.Errorf("read freelist_count: %w", err)
+	}
+	if !freelistTriggersVacuum(pageCount, freelist) {
+		return nil
+	}
+	slog.Info("auto-VACUUM triggered by high freelist", "module", "STORE",
+		"page_count", pageCount, "freelist_count", freelist,
+		"ratio", freelistVacuumRatio, "floor", freelistVacuumFloor)
+	if _, err := db.Exec("VACUUM"); err != nil {
+		return fmt.Errorf("vacuum: %w", err)
+	}
+	return nil
+}
+
+// freelistTriggersVacuum is the pure decision so unit tests can drive
+// it without spinning up a real DB.
+func freelistTriggersVacuum(pageCount, freelist int64) bool {
+	if freelist >= freelistVacuumFloor && freelistVacuumFloor > 0 {
+		return true
+	}
+	if pageCount > 0 && float64(freelist)/float64(pageCount) >= freelistVacuumRatio && freelistVacuumRatio > 0 {
+		return true
+	}
+	return false
 }
 
 // Close closes the database connection.

--- a/cli/internal/store/store.go
+++ b/cli/internal/store/store.go
@@ -1461,7 +1461,7 @@ func (d *DB) encryptSubject(plain string) ([]byte, error) {
 	if plain == "" {
 		return nil, nil
 	}
-	return dbcrypto.Encrypt(d.keyring.Subject, []byte(plain))
+	return d.keyring.EncryptSubject([]byte(plain))
 }
 
 // decryptSubject returns the plaintext subject for a row. It prefers the
@@ -1473,7 +1473,7 @@ func (d *DB) decryptSubject(plain string, ct []byte) (string, error) {
 	if len(ct) == 0 {
 		return plain, nil
 	}
-	out, err := dbcrypto.Decrypt(d.keyring.Subject, ct)
+	out, err := d.keyring.DecryptSubject(ct)
 	if err != nil {
 		return "", fmt.Errorf("decrypt subject: %w", err)
 	}
@@ -1527,7 +1527,7 @@ func (d *DB) backfillSubjectCt() error {
 	}
 	defer stmt.Close()
 	for _, p := range batch {
-		ct, err := dbcrypto.Encrypt(d.keyring.Subject, []byte(p.subject))
+		ct, err := d.keyring.EncryptSubject([]byte(p.subject))
 		if err != nil {
 			return fmt.Errorf("encrypt id=%d: %w", p.id, err)
 		}
@@ -1544,7 +1544,7 @@ func (d *DB) encryptBody(plain string) ([]byte, error) {
 	if plain == "" {
 		return nil, nil
 	}
-	return dbcrypto.Encrypt(d.keyring.Body, []byte(plain))
+	return d.keyring.EncryptBody([]byte(plain))
 }
 
 // decryptBody returns the plaintext body for a row, preferring the
@@ -1556,7 +1556,7 @@ func (d *DB) decryptBody(plain string, ct []byte) (string, error) {
 	if len(ct) == 0 {
 		return plain, nil
 	}
-	out, err := dbcrypto.Decrypt(d.keyring.Body, ct)
+	out, err := d.keyring.DecryptBody(ct)
 	if err != nil {
 		return "", fmt.Errorf("decrypt body: %w", err)
 	}
@@ -1724,7 +1724,7 @@ func (d *DB) encryptMeta(plain string) ([]byte, error) {
 	if plain == "" {
 		return nil, nil
 	}
-	return dbcrypto.Encrypt(d.keyring.Meta, []byte(plain))
+	return d.keyring.EncryptMeta([]byte(plain))
 }
 
 // decryptMeta returns plaintext for a meta_key column, falling back to
@@ -1735,7 +1735,7 @@ func (d *DB) decryptMeta(plain string, ct []byte) (string, error) {
 	if len(ct) == 0 {
 		return plain, nil
 	}
-	out, err := dbcrypto.Decrypt(d.keyring.Meta, ct)
+	out, err := d.keyring.DecryptMeta(ct)
 	if err != nil {
 		return "", fmt.Errorf("decrypt meta: %w", err)
 	}
@@ -1960,7 +1960,7 @@ func (d *DB) encryptDraftJSON(plain string) ([]byte, error) {
 	if plain == "" {
 		return nil, nil
 	}
-	return dbcrypto.Encrypt(d.keyring.Draft, []byte(plain))
+	return d.keyring.EncryptDraft([]byte(plain))
 }
 
 // decryptDraftJSON returns plaintext draft JSON, preferring ct when set.
@@ -1969,7 +1969,7 @@ func (d *DB) decryptDraftJSON(plain string, ct []byte) (string, error) {
 	if len(ct) == 0 {
 		return plain, nil
 	}
-	out, err := dbcrypto.Decrypt(d.keyring.Draft, ct)
+	out, err := d.keyring.DecryptDraft(ct)
 	if err != nil {
 		return "", fmt.Errorf("decrypt draft_json: %w", err)
 	}
@@ -2062,7 +2062,7 @@ func (d *DB) encryptHeaderValue(plain string) ([]byte, error) {
 	if plain == "" {
 		return nil, nil
 	}
-	return dbcrypto.Encrypt(d.keyring.Headers, []byte(plain))
+	return d.keyring.EncryptHeaders([]byte(plain))
 }
 
 // decryptHeaderValue returns the plaintext header value, preferring ct
@@ -2071,7 +2071,7 @@ func (d *DB) decryptHeaderValue(plain string, ct []byte) (string, error) {
 	if len(ct) == 0 {
 		return plain, nil
 	}
-	out, err := dbcrypto.Decrypt(d.keyring.Headers, ct)
+	out, err := d.keyring.DecryptHeaders(ct)
 	if err != nil {
 		return "", fmt.Errorf("decrypt header value: %w", err)
 	}
@@ -2142,7 +2142,7 @@ func (d *DB) encryptAddr(plain string) ([]byte, error) {
 	if plain == "" {
 		return nil, nil
 	}
-	return dbcrypto.Encrypt(d.keyring.Addrs, []byte(plain))
+	return d.keyring.EncryptAddrs([]byte(plain))
 }
 
 // decryptAddr returns the plaintext address for a row, preferring the
@@ -2152,7 +2152,7 @@ func (d *DB) decryptAddr(plain string, ct []byte) (string, error) {
 	if len(ct) == 0 {
 		return plain, nil
 	}
-	out, err := dbcrypto.Decrypt(d.keyring.Addrs, ct)
+	out, err := d.keyring.DecryptAddrs(ct)
 	if err != nil {
 		return "", fmt.Errorf("decrypt addr: %w", err)
 	}

--- a/cli/internal/store/store_test.go
+++ b/cli/internal/store/store_test.go
@@ -4,8 +4,10 @@ import (
 	"bytes"
 	"database/sql"
 	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/durian-dev/durian/cli/internal/dbcrypto"
@@ -84,6 +86,110 @@ func TestOpen_SecureDeleteEnabled(t *testing.T) {
 // A pre-deletion sanity grep proves the marker really was on disk in the
 // first place — without it, "absent after delete" could just mean the
 // insert never reached the bytes we read.
+// TestFreelistTriggersVacuum pins the ADR-0001 audit #251 calibration.
+// Concrete page counts come from realistic scenarios:
+//   - healthy 50k-page DB after a sync (~10 free pages)
+//   - same DB after months of churn without VACUUM (~800 free pages)
+//   - post-Time-Machine-restore residue (10 %+ stranded plaintext)
+//   - tiny test DB where the ratio threshold catches what the floor misses
+//
+// If the calibration drifts, this test catches the user-visible
+// regression (false fires on every Open, or missed restore residue).
+func TestFreelistTriggersVacuum(t *testing.T) {
+	cases := []struct {
+		name      string
+		pages     int64
+		freelist  int64
+		wantFires bool
+	}{
+		{"healthy post-sync (50k pages, 10 free)", 50_000, 10, false},
+		{"long-running but small churn (50k, 800)", 50_000, 800, false},
+		{"large absolute residue (50k, 6000 ~= 12 %)", 50_000, 6000, true},
+		{"restore residue ratio (10k pages, 30 % free)", 10_000, 3_000, true},
+		{"tiny DB at ratio (1000 pages, 100 free = 10 %)", 1_000, 100, true},
+		{"tiny DB below ratio (1000 pages, 50 free = 5 %)", 1_000, 50, false},
+		{"empty DB", 0, 0, false},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := freelistTriggersVacuum(c.pages, c.freelist); got != c.wantFires {
+				t.Errorf("freelistTriggersVacuum(%d, %d) = %v, want %v",
+					c.pages, c.freelist, got, c.wantFires)
+			}
+		})
+	}
+}
+
+// TestVacuumIfFreelistHigh_FiresWhenForced exercises the end-to-end
+// path: artificially set the floor so any non-empty freelist triggers,
+// allocate + delete enough rows to inflate the freelist, run the helper
+// directly, then assert PRAGMA freelist_count dropped. Real-Open
+// integration is implicit: every other store test goes through Open and
+// gets the production thresholds (which never fire on small test DBs).
+func TestVacuumIfFreelistHigh_FiresWhenForced(t *testing.T) {
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "freelist.db")
+
+	db, err := Open(dbPath, testKeyring(t))
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	if err := db.Init(); err != nil {
+		t.Fatalf("init: %v", err)
+	}
+
+	// Inflate the freelist: insert many rows, then delete them all.
+	// secure_delete=ON zeros the pages but they stay on the freelist
+	// until VACUUM compacts them away.
+	for i := range 200 {
+		msg := &Message{
+			MessageID: fmt.Sprintf("inflate-%d@example.com", i),
+			Subject:   strings.Repeat("padding ", 50),
+			FromAddr:  fmt.Sprintf("sender-%d@example.com", i),
+			ToAddrs:   "bob@example.com",
+			Date:      1700000000,
+			CreatedAt: 1700000000,
+			Mailbox:   "INBOX",
+			BodyText:  strings.Repeat("body ", 200),
+		}
+		if err := db.InsertMessage(msg); err != nil {
+			t.Fatalf("insert %d: %v", i, err)
+		}
+	}
+	if _, err := db.db.Exec("DELETE FROM messages"); err != nil {
+		t.Fatalf("bulk delete: %v", err)
+	}
+
+	var beforeFree int64
+	if err := db.db.QueryRow("PRAGMA freelist_count").Scan(&beforeFree); err != nil {
+		t.Fatalf("read freelist pre-VACUUM: %v", err)
+	}
+	if beforeFree == 0 {
+		t.Skip("could not inflate freelist on this SQLite build — test inert")
+	}
+
+	// Lower both thresholds for this test so the helper actually fires.
+	origRatio, origFloor := freelistVacuumRatio, freelistVacuumFloor
+	t.Cleanup(func() {
+		freelistVacuumRatio = origRatio
+		freelistVacuumFloor = origFloor
+	})
+	freelistVacuumRatio = 0
+	freelistVacuumFloor = 1
+
+	if err := vacuumIfFreelistHigh(db.db); err != nil {
+		t.Fatalf("vacuumIfFreelistHigh: %v", err)
+	}
+
+	var afterFree int64
+	if err := db.db.QueryRow("PRAGMA freelist_count").Scan(&afterFree); err != nil {
+		t.Fatalf("read freelist post-VACUUM: %v", err)
+	}
+	if afterFree >= beforeFree {
+		t.Errorf("freelist did not shrink: before=%d after=%d", beforeFree, afterFree)
+	}
+}
+
 func TestSecureDelete_ScrubsRawBytes(t *testing.T) {
 	const marker = "DURIAN_SECURE_DELETE_MARKER_3F8B7A1E"
 

--- a/cli/internal/store/store_test.go
+++ b/cli/internal/store/store_test.go
@@ -3,6 +3,8 @@ package store
 import (
 	"bytes"
 	"database/sql"
+	"errors"
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -68,6 +70,101 @@ func TestOpen_SecureDeleteEnabled(t *testing.T) {
 	if v != 1 {
 		t.Errorf("PRAGMA secure_delete = %d, want 1", v)
 	}
+}
+
+// TestSecureDelete_ScrubsRawBytes is the ADR-0001 audit #252 follow-up
+// to TestOpen_SecureDeleteEnabled: pragma-set-to-1 only proves SQLite
+// accepted the directive, not that the freed bytes are actually being
+// overwritten on disk. This test asserts the real property — INSERT a
+// plaintext marker into a plaintext column (from_addr stays plaintext
+// post-β-revision), DELETE the row, checkpoint WAL into the main file,
+// close, then grep the raw bytes of every on-disk file (the .db, its
+// -wal, its -shm). The marker must be absent from all three.
+//
+// A pre-deletion sanity grep proves the marker really was on disk in the
+// first place — without it, "absent after delete" could just mean the
+// insert never reached the bytes we read.
+func TestSecureDelete_ScrubsRawBytes(t *testing.T) {
+	const marker = "DURIAN_SECURE_DELETE_MARKER_3F8B7A1E"
+
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "email.db")
+
+	db, err := Open(dbPath, testKeyring(t))
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	if err := db.Init(); err != nil {
+		t.Fatalf("init: %v", err)
+	}
+
+	msg := &Message{
+		MessageID: "marker@example.com",
+		Subject:   "test",
+		FromAddr:  marker + "@example.com",
+		ToAddrs:   "bob@example.com",
+		Date:      1700000000,
+		CreatedAt: 1700000000,
+		Mailbox:   "INBOX",
+	}
+	if err := db.InsertMessage(msg); err != nil {
+		t.Fatalf("insert: %v", err)
+	}
+	// Force the row into the main DB so the pre-delete sanity grep is
+	// looking at the right file — without this, the WAL holds the bytes
+	// and the main .db is still empty.
+	if _, err := db.db.Exec("PRAGMA wal_checkpoint(TRUNCATE)"); err != nil {
+		t.Fatalf("pre-delete checkpoint: %v", err)
+	}
+	if !rawDBContains(t, dbPath, marker) {
+		t.Fatalf("test setup broken: marker %q not present in raw bytes pre-delete", marker)
+	}
+
+	if err := db.DeleteByMessageID("marker@example.com"); err != nil {
+		t.Fatalf("delete: %v", err)
+	}
+	// Merge the secure-delete-zeroed page from WAL into the main DB file.
+	if _, err := db.db.Exec("PRAGMA wal_checkpoint(TRUNCATE)"); err != nil {
+		t.Fatalf("post-delete checkpoint: %v", err)
+	}
+	if err := db.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+
+	for _, suffix := range []string{"", "-wal", "-shm"} {
+		path := dbPath + suffix
+		b, err := os.ReadFile(path)
+		if err != nil {
+			if errors.Is(err, os.ErrNotExist) {
+				continue
+			}
+			t.Fatalf("read %s: %v", path, err)
+		}
+		if bytes.Contains(b, []byte(marker)) {
+			t.Errorf("marker %q still present in %s after secure_delete (%d bytes)", marker, path, len(b))
+		}
+	}
+}
+
+// rawDBContains returns whether the raw bytes of dbPath (or its WAL
+// sidecar, if the marker hasn't been checkpointed yet) contain the
+// marker. Used by the secure_delete sanity check.
+func rawDBContains(t *testing.T, dbPath, marker string) bool {
+	t.Helper()
+	for _, suffix := range []string{"", "-wal"} {
+		path := dbPath + suffix
+		b, err := os.ReadFile(path)
+		if err != nil {
+			if errors.Is(err, os.ErrNotExist) {
+				continue
+			}
+			t.Fatalf("read %s: %v", path, err)
+		}
+		if bytes.Contains(b, []byte(marker)) {
+			return true
+		}
+	}
+	return false
 }
 
 func TestInitIdempotent(t *testing.T) {

--- a/docs/content/docs/developers/design/0001-mail-content-encryption-at-rest.md
+++ b/docs/content/docs/developers/design/0001-mail-content-encryption-at-rest.md
@@ -556,14 +556,19 @@ revisions of this section overpromised):
   defeated by Go's string-from-bytes copy anyway, so the historical
   design that named that pattern was misleading; calling it out
   honestly here saves a future reader from chasing a phantom guarantee.
-- `Keyring.Wipe()` zeroes the sub-key byte slices at shutdown. Best-effort
-  only: Go's GC may already have copied the slice during heap growth, the
-  function has no `runtime.KeepAlive(k)` after the zeroing (a sufficiently
-  aggressive compiler could in theory reorder past the wipe), and the
-  sub-keys are held for process lifetime anyway so the wipe runs at the
-  moment everything is about to be freed. Tracked as a follow-up
-  (issue #253) — either harden the contract with `runtime.KeepAlive` +
-  tests, or remove the misleading API entirely.
+- **Sub-keys are not wiped — at shutdown or otherwise.** An earlier
+  revision of this ADR documented a `Keyring.Wipe()` that overwrote
+  each sub-key with zeros via `crypto/subtle.ConstantTimeCopy`. Issue
+  #253 (audit-2 follow-up) removed it: the guarantee was unenforceable
+  in Go (no `runtime.KeepAlive`, GC may already have copied the
+  backing array during slice growth, sub-keys are held for process
+  lifetime so the wipe fired only at shutdown when the process was
+  about to free everything anyway), and shipping a best-effort scrub
+  under a name that implies stronger semantics is worse than not
+  shipping one. Honest contract: sub-keys live in process memory for
+  the lifetime of `durian serve` and are released to the GC at exit,
+  same as any other allocation. Users who need memory-dump resistance
+  rely on the two mitigations in the next bullet, not on `Wipe`.
 - Do **not** rely on `[]byte` slice reuse from a sync.Pool for plaintext.
   Pool reuse can leave plaintext stranded in unrelated allocations.
 - Document explicitly that the running process is a soft target. Users who

--- a/docs/content/docs/developers/design/0001-mail-content-encryption-at-rest.md
+++ b/docs/content/docs/developers/design/0001-mail-content-encryption-at-rest.md
@@ -604,6 +604,33 @@ What secure_delete does **not** cover:
   (chip-off attacks). Out of scope; mitigation is FileVault /
   full-disk encryption, which Durian assumes the user enables.
 
+#### Restored-backup hygiene (auto-VACUUM at Open)
+
+The retroactive VACUUM that step-7e and audit-H3 wired into the v19→v20
+schema migration only fires once per install. A user who runs Durian
+post-v20, **then** restores an old `email.db` from Time Machine / iCloud
+/ an external backup over the top, lands in a state where
+`schema_version` already reads 21 but the restored file is full of
+pre-fix free-page residue — the migration scrubber does not re-fire.
+
+Mitigation: on every `store.Open`, the freelist is inspected via
+`PRAGMA freelist_count` + `PRAGMA page_count` and `VACUUM` runs once if
+**either** of the following holds (see
+`freelistTriggersVacuum` in `cli/internal/store/store.go`):
+
+- `freelist_count / page_count ≥ 0.10` (the file is ≥ 10 % free pages —
+  signal of a major drop that was never compacted), or
+- `freelist_count ≥ 1024` (≥ 4 MB stranded plaintext in absolute terms,
+  even on a small DB).
+
+Trade-off: bounded recurring cost (one VACUUM per N restores; on a
+2 GB mailbox this is a multi-second Open) instead of the previous
+unbounded behaviour (no scrub at all after the first migration).
+A healthy DB after routine sync has freelist counts in the dozens, well
+below both triggers, so steady-state startups pay only the two PRAGMA
+reads. The `:memory:` test path is exempt — there is no on-disk
+residue to scrub.
+
 ### Logging audit
 
 A Durian build with encryption is only as private as its least careful log


### PR DESCRIPTION
Bundled close-out of the four ADR-0001 audit-2 follow-up issues. Six commits, one per acceptance item, so each can be reviewed in isolation.

## Closes

- Closes #254 (low-severity cleanups: AEAD cache, lexer DoS cap, editor tempfile)
- Closes #252 (raw-bytes persistence test for `PRAGMA secure_delete`)
- Closes #251 (auto-VACUUM at Open when freelist is unusually high)
- Closes #253 (`Keyring.Wipe` honesty pass)

## Commits

1. **feat(go-dbcrypto): cache AEAD per sub-key in Keyring (#254.1)**
   New methods `(*Keyring).EncryptSubject` / `DecryptSubject` etc. reuse a cached `cipher.AEAD` instead of running `aes.NewCipher` + `cipher.NewGCM` per call. Package-level `Encrypt(key, ct)` / `Decrypt(key, ct)` still work — both paths now share `sealAEAD` / `openAEAD` so wire format can't drift. Benchmark on M2: 579.9 ns/op → 287.6 ns/op (≈2.0×), 3 allocs/op → 1 alloc/op. Store callers migrated to the cached path. Cross-path parity is pinned by a new test that round-trips ciphertext between fresh-AEAD and cached-AEAD entry points.

2. **fix(go-store): apply 1024-byte query cap in parseQuery (#254.2)**
   The HTTP handler already enforced this; the CLI (`durian search`) and any future unix-socket caller did not. New `MaxQueryLen` + typed `ErrQueryTooLong`. Both `parseQuery` and `parseQueryWithTerms` reject oversize queries before `lex()` runs, so every upstream path inherits the guarantee. Test pins the boundary (`MaxQueryLen` exact is accepted; `+1` errors).

3. **fix(go-send): write editor tempfile under \$XDG_CACHE_HOME/durian (#254.3)**
   `openEditor` no longer drops plaintext into `/tmp/durian-*.txt` where editor crash artefacts (vim `.swp`) linger across reboots. New target: `\$XDG_CACHE_HOME/durian/compose-*.txt` (falling back to `~/.cache/durian/`), directory `chmod 0700`. Matches the IMAP state-manager convention in the same cache root.

4. **test(go-store): raw-bytes persistence test for `PRAGMA secure_delete` (#252)**
   `TestOpen_SecureDeleteEnabled` only proved the pragma was *set*. New `TestSecureDelete_ScrubsRawBytes` proves the underlying behaviour: INSERT a marker into `from_addr`, `wal_checkpoint(TRUNCATE)`, raw-grep the `.db` + `-wal` + `-shm` files to confirm the marker is on disk (pre-delete sanity), then DELETE + checkpoint and grep again — must not survive. Mirror test added for `contacts.db` (marker in `name` column).

5. **feat(go-store): auto-VACUUM at Open when freelist exceeds threshold (#251)**
   `vacuumIfFreelistHigh` runs on every `store.Open` (except `:memory:`). Triggers when `freelist_count >= 1024` **or** `freelist_count / page_count >= 0.10`. Rationale: the v19→v20 retroactive VACUUM only fires once per install; a Time-Machine restore of an old `email.db` after `schema_version` already reads 21 carries the step-7e plaintext drop residue forever. The two thresholds are calibrated to leave healthy DBs untouched (post-sync freelist ≈ dozens of pages) but always fire on restore residue (10 %+ stranded). Pure decision split into `freelistTriggersVacuum(pages, freelist)` so unit tests cover six realistic scenarios without spinning up a DB. ADR §6 (Disk hygiene) gains a "Restored-backup hygiene" sub-section.

6. **fix(go-dbcrypto): remove Keyring.Wipe + honest ADR memory-hygiene note (#253)**
   `Keyring.Wipe()` removed (Option 2 per audit reviewer recommendation). No `runtime.KeepAlive` so a sufficiently aggressive compiler could reorder past the wipe; Go's GC may have copied the backing array during slice growth; sub-keys are held for process lifetime so the call only fired at shutdown when everything was about to be freed. Shipping a best-effort scrub under a name that implies stronger semantics is worse than not shipping one. ADR §Memory hygiene rewritten to be honest: "sub-keys live in process memory for the lifetime of \`durian serve\` and are released to the GC at exit." `crypto/subtle` import dropped; `TestKeyring_Wipe` removed.

## Test plan

- [x] \`bazel test //cli/...\` — all 18 test targets pass.
- [x] \`bazel build //cli/cmd/durian\` — clean build.
- [x] AEAD-cache benchmark on M2: \`fresh-8 579.9 ns/op, 3 allocs\` → \`cached-8 287.6 ns/op, 1 alloc\` (≥2× per acceptance).
- [x] Freelist-VACUUM unit test exercises 7 calibration scenarios; integration test forces low thresholds and confirms freelist shrinks after VACUUM.

The macOS GUI side is untouched — Go-only changes.