### PR TITLE
refactor(go-cli,docs): align CLI flags and reference docs

### DIFF
--- a/cli/cmd/durian/contacts.go
+++ b/cli/cmd/durian/contacts.go
@@ -18,24 +18,29 @@ var contactsCmd = &cobra.Command{
 }
 
 var contactsInitCmd = &cobra.Command{
-	Use:   "init",
-	Short: "Initialize the contacts database",
-	Long:  `Create the contacts database file and schema.`,
-	RunE:  runContactsInit,
+	Use:     "init",
+	Short:   "Initialize the contacts database",
+	Long:    `Create the contacts database file and schema.`,
+	Example: `  durian contacts init`,
+	RunE:    runContactsInit,
 }
 
 var contactsImportCmd = &cobra.Command{
-	Use:   "import",
-	Short: "Import contacts from email store",
-	Long:  "Import email addresses from the local email store (From, To, Cc headers).",
-	RunE:  runContactsImport,
+	Use:     "import",
+	Short:   "Import contacts from email store",
+	Long:    "Import email addresses from the local email store (From, To, Cc headers).",
+	Example: `  durian contacts import`,
+	RunE:    runContactsImport,
 }
 
 var contactsListCmd = &cobra.Command{
 	Use:   "list",
 	Short: "List all contacts",
 	Long:  `List all contacts in the database, ordered by usage.`,
-	RunE:  runContactsList,
+	Example: `  durian contacts list
+  durian contacts list -l 500
+  durian contacts list --json`,
+	RunE: runContactsList,
 }
 
 var contactsSearchCmd = &cobra.Command{
@@ -77,8 +82,8 @@ func init() {
 	contactsCmd.AddCommand(contactsDeleteCmd)
 
 	// Add flags
-	contactsListCmd.Flags().IntVarP(&contactsLimit, "limit", "n", 100, "maximum number of contacts to show")
-	contactsSearchCmd.Flags().IntVarP(&contactsLimit, "limit", "n", 20, "maximum number of results")
+	contactsListCmd.Flags().IntVarP(&contactsLimit, "limit", "l", 100, "maximum number of contacts to show")
+	contactsSearchCmd.Flags().IntVarP(&contactsLimit, "limit", "l", 20, "maximum number of results")
 }
 
 // getDBPath returns the database path from config or default
@@ -220,7 +225,7 @@ func runContactsList(cmd *cobra.Command, args []string) error {
 
 	total, _ := db.Count()
 	if total > contactsLimit {
-		fmt.Printf("\n(showing %d of %d contacts, use -n to show more)\n", contactsLimit, total)
+		fmt.Printf("\n(showing %d of %d contacts, use -l to show more)\n", contactsLimit, total)
 	}
 
 	return nil

--- a/cli/cmd/durian/group.go
+++ b/cli/cmd/durian/group.go
@@ -15,20 +15,30 @@ import (
 var groupCmd = &cobra.Command{
 	Use:   "group",
 	Short: "Manage contact groups",
-	Long:  "Manage contact groups defined in groups.pkl. Edit the file directly to modify.",
+	Long: `Inspect the contact groups defined in groups.pkl
+(~/.config/durian/groups.pkl). Groups bundle email addresses under a
+shared name (e.g. "vip", "investor") so that rules and search queries
+can refer to "group:vip" instead of enumerating every address.
+
+The CLI is read-only — edit groups.pkl to add, remove, or rename groups,
+then run 'durian validate groups' to check the file.`,
 }
 
 var groupListCmd = &cobra.Command{
 	Use:   "list",
 	Short: "List all contact groups",
-	RunE:  runGroupList,
+	Example: `  durian group list
+  durian group list --json`,
+	RunE: runGroupList,
 }
 
 var groupMembersCmd = &cobra.Command{
 	Use:   "members <name>",
 	Short: "List members of a group",
-	Args:  cobra.ExactArgs(1),
-	RunE:  runGroupMembers,
+	Example: `  durian group members vip
+  durian group members investor --json`,
+	Args: cobra.ExactArgs(1),
+	RunE: runGroupMembers,
 }
 
 func init() {

--- a/cli/cmd/durian/master_key.go
+++ b/cli/cmd/durian/master_key.go
@@ -38,9 +38,9 @@ const (
 
 // Flags
 var (
-	masterKeyExportOut     string
-	masterKeyImportSource  string
-	masterKeyImportForce   bool
+	masterKeyExportOut    string
+	masterKeyImportSource string
+	masterKeyImportForce  bool
 )
 
 var masterKeyCmd = &cobra.Command{

--- a/cli/cmd/durian/master_key.go
+++ b/cli/cmd/durian/master_key.go
@@ -38,9 +38,9 @@ const (
 
 // Flags
 var (
-	masterKeyExportOut   string
-	masterKeyImportFrom  string
-	masterKeyImportForce bool
+	masterKeyExportOut     string
+	masterKeyImportSource  string
+	masterKeyImportForce   bool
 )
 
 var masterKeyCmd = &cobra.Command{
@@ -59,7 +59,7 @@ mail can be re-synced from the server.`,
 }
 
 var masterKeyExportCmd = &cobra.Command{
-	Use:   "export --out FILE",
+	Use:   "export --output FILE",
 	Short: "Export the master key to a passphrase-encrypted age file",
 	Long: `Read the master key from the OS keychain, encrypt it with an
 age scrypt passphrase, and write the armored ciphertext to FILE.
@@ -68,12 +68,12 @@ The on-disk format is the same 64-character hex representation that the
 keychain stores, so the file round-trips cleanly with 'master-key import'
 and can also be decrypted manually with the 'age' CLI.
 
-Use --out - to write to stdout.`,
+Use --output - to write to stdout.`,
 	RunE: runMasterKeyExport,
 }
 
 var masterKeyImportCmd = &cobra.Command{
-	Use:   "import --from FILE",
+	Use:   "import --source FILE",
 	Short: "Import a master key from an age file into the OS keychain",
 	Long: `Decrypt an age file produced by 'master-key export' (or any age
 file containing a 64-char hex master key) and store the result in the OS
@@ -90,12 +90,21 @@ func init() {
 	masterKeyCmd.AddCommand(masterKeyExportCmd)
 	masterKeyCmd.AddCommand(masterKeyImportCmd)
 
-	masterKeyExportCmd.Flags().StringVar(&masterKeyExportOut, "out", "", "destination file (or '-' for stdout)")
-	masterKeyExportCmd.MarkFlagRequired("out")
+	masterKeyExportCmd.Flags().StringVarP(&masterKeyExportOut, "output", "o", "", "destination file (or '-' for stdout)")
+	// --out kept as a deprecated alias for one release. Same backing var, so
+	// the import branch in runMasterKeyExport doesn't change.
+	masterKeyExportCmd.Flags().StringVar(&masterKeyExportOut, "out", "", "destination file (deprecated alias for --output)")
+	_ = masterKeyExportCmd.Flags().MarkDeprecated("out", "use --output (or -o) instead")
+	masterKeyExportCmd.MarkFlagsOneRequired("output", "out")
 
-	masterKeyImportCmd.Flags().StringVar(&masterKeyImportFrom, "from", "", "source age file")
+	masterKeyImportCmd.Flags().StringVar(&masterKeyImportSource, "source", "", "source age file")
+	// --from kept as a deprecated alias for one release. The flag name "from"
+	// is reserved for sender semantics (send/draft); using it for a file path
+	// was inconsistent.
+	masterKeyImportCmd.Flags().StringVar(&masterKeyImportSource, "from", "", "source age file (deprecated alias for --source)")
+	_ = masterKeyImportCmd.Flags().MarkDeprecated("from", "use --source instead")
 	masterKeyImportCmd.Flags().BoolVar(&masterKeyImportForce, "force", false, "overwrite an existing keychain entry")
-	masterKeyImportCmd.MarkFlagRequired("from")
+	masterKeyImportCmd.MarkFlagsOneRequired("source", "from")
 }
 
 // bootstrapKeyring loads (or, on first run, generates) the ADR-0001 master
@@ -226,9 +235,9 @@ func runMasterKeyExport(cmd *cobra.Command, args []string) error {
 }
 
 func runMasterKeyImport(cmd *cobra.Command, args []string) error {
-	ct, err := os.ReadFile(masterKeyImportFrom)
+	ct, err := os.ReadFile(masterKeyImportSource)
 	if err != nil {
-		return fmt.Errorf("read %s: %w", masterKeyImportFrom, err)
+		return fmt.Errorf("read %s: %w", masterKeyImportSource, err)
 	}
 
 	pass, err := promptPassword("Passphrase to decrypt the master key: ")
@@ -257,7 +266,7 @@ func runMasterKeyImport(cmd *cobra.Command, args []string) error {
 	}
 
 	fmt.Fprintf(os.Stderr, "Master key imported from %s into keychain (%s/%s)\n",
-		masterKeyImportFrom, keychain.DBKeychainService, keychain.DBAccountMaster)
-	slog.Info("Master key imported", "module", "MASTER-KEY", "from", masterKeyImportFrom, "forced", masterKeyImportForce)
+		masterKeyImportSource, keychain.DBKeychainService, keychain.DBAccountMaster)
+	slog.Info("Master key imported", "module", "MASTER-KEY", "from", masterKeyImportSource, "forced", masterKeyImportForce)
 	return nil
 }

--- a/cli/cmd/durian/rules.go
+++ b/cli/cmd/durian/rules.go
@@ -16,6 +16,16 @@ var rulesApplyDryRun bool
 var rulesCmd = &cobra.Command{
 	Use:   "rules",
 	Short: "Manage filter rules",
+	Long: `Work with the declarative filter rules defined in rules.pkl
+(~/.config/durian/rules.pkl). Each rule matches incoming messages by
+header / body / address / group and adds or removes tags.
+
+Rules are evaluated automatically during 'durian sync' and while
+'durian serve' is running. This subcommand is for backfilling: 'rules
+apply' re-runs the current ruleset against every message in the local
+store, useful after editing rules.pkl.
+
+Validate the file with 'durian validate rules' before applying.`,
 }
 
 var rulesApplyCmd = &cobra.Command{

--- a/cli/cmd/durian/serve.go
+++ b/cli/cmd/durian/serve.go
@@ -36,7 +36,11 @@ var serveCmd = &cobra.Command{
 	Use:   "serve",
 	Short: "Start OpenAPI HTTP server (for GUI integration)",
 	Long:  "Start the HTTP server that provides a RESTful API for the GUI.",
-	Run:   runServe,
+	Example: `  durian serve                     # default port 9723, bearer-token auth
+  durian serve --port 8080         # listen on a non-default port
+  durian serve --debug             # debug-level logging to serve.log
+  durian serve --no-auth           # skip bearer-token check (experimental clients)`,
+	Run: runServe,
 }
 
 func init() {

--- a/cli/cmd/durian/tagsync.go
+++ b/cli/cmd/durian/tagsync.go
@@ -14,20 +14,45 @@ import (
 var tagSyncCmd = &cobra.Command{
 	Use:   "tag-sync",
 	Short: "Manage remote tag synchronization",
+	Long: `Replicate Durian's local tags to a self-hosted tag-sync server so they
+follow you across machines. Configuration lives in config.pkl under
+sync { tag_sync { url; api_key } }.
+
+Incremental push/pull happen automatically during 'durian sync' and while
+'durian serve' is running — this command group is only for the one-shot
+'init' bootstrap that seeds a fresh server from an existing local DB.`,
 }
 
+var tagSyncInitCmd = &cobra.Command{
+	Use:   "init",
+	Short: "Bulk-push all local tags to the sync server (one-shot bootstrap)",
+	Long: `Push every local tag in one batch to the configured tag-sync server.
+
+Run this once after pointing a new machine at the server, or after standing
+up a fresh server, to seed it from an existing local DB. Routine
+incremental sync is handled by 'durian sync' and 'durian serve' — you do
+not need to call 'init' again on the same server.`,
+	Example: `  durian tag-sync init`,
+	RunE:    runTagSyncInit,
+}
+
+// tagSyncPushAllCmd is the previous name for 'init' — kept as a hidden,
+// deprecated alias for one release so existing scripts keep working.
 var tagSyncPushAllCmd = &cobra.Command{
-	Use:   "push-all",
-	Short: "Push all local tags to the sync server (initial sync)",
-	RunE:  runTagSyncPushAll,
+	Use:        "push-all",
+	Short:      "Deprecated alias for 'tag-sync init'",
+	Hidden:     true,
+	Deprecated: "use 'durian tag-sync init' instead",
+	RunE:       runTagSyncInit,
 }
 
 func init() {
+	tagSyncCmd.AddCommand(tagSyncInitCmd)
 	tagSyncCmd.AddCommand(tagSyncPushAllCmd)
 	rootCmd.AddCommand(tagSyncCmd)
 }
 
-func runTagSyncPushAll(cmd *cobra.Command, args []string) error {
+func runTagSyncInit(cmd *cobra.Command, args []string) error {
 	cfg := GetConfig()
 	if cfg == nil {
 		return fmt.Errorf("no configuration loaded")

--- a/docs/content/docs/cli/encryption-at-rest.md
+++ b/docs/content/docs/cli/encryption-at-rest.md
@@ -42,7 +42,7 @@ The first run of any `durian` command that needs the keyring auto-generates the 
 If you ever lose the keychain entry — Mac wipe, Migration Assistant going sideways, fresh OS install — the encrypted DB is unreadable without the master. **Export it once, store the file in your password manager or on a hardware token.**
 
 ```bash
-durian master-key export --out ~/durian-master.age
+durian master-key export --output ~/durian-master.age
 ```
 
 You'll be prompted for a passphrase. The output is an ASCII-armored age file (scrypt recipient), so any standard `age` install can also decrypt it:
@@ -56,7 +56,7 @@ The file content is the 64-character hex of the master. Treat it like a root pas
 Write to stdout if you want to pipe straight into a password manager:
 
 ```bash
-durian master-key export --out - | pbcopy   # macOS clipboard
+durian master-key export --output - | pbcopy   # macOS clipboard
 ```
 
 ## Restore: import an age file into a fresh keychain
@@ -64,7 +64,7 @@ durian master-key export --out - | pbcopy   # macOS clipboard
 On a new machine (or after `security delete-generic-password -s durian-db`), bring the master back before `durian sync`:
 
 ```bash
-durian master-key import --from ~/durian-master.age
+durian master-key import --source ~/durian-master.age
 ```
 
 Passphrase prompt, decrypt, write to the keychain. Refuses to overwrite an existing entry unless you pass `--force` (using `--force` on a populated DB with a different master makes that DB unreadable — the warning is real).

--- a/docs/content/docs/cli/reference.md
+++ b/docs/content/docs/cli/reference.md
@@ -21,6 +21,11 @@ durian sync                          # all accounts, all mailboxes
 durian sync personal                 # one account by alias
 durian sync personal INBOX           # one mailbox
 durian sync --debug                  # verbose logging to stderr
+durian sync --upload-only            # only push local tag/flag changes
+durian sync --download-only          # only fetch from server
+durian sync --no-flags               # skip flag sync (bodies only)
+durian sync --backfill-headers       # refetch headers for existing rows
+durian sync --dry-run                # report what would happen, write nothing
 ```
 
 Bidirectional by default — local tag changes are uploaded as IMAP flags / folder moves, and server-side flag changes are pulled down. The first sync of a large mailbox can take a few minutes; subsequent syncs are incremental.
@@ -33,7 +38,7 @@ The GUI runs `durian serve`, which keeps a long-lived IDLE connection open per a
 durian search "tag:inbox" -l 10
 durian search "from:boss@company.com AND has:attachment:pdf"
 durian search "group:vip AND date:1w.." --json
-durian search count "tag:unread"
+durian count "tag:unread"
 ```
 
 Uses [notmuch-style syntax](../gui/search/) — terms are ANDed by default; `OR`/`NOT` are explicit. `--json` emits machine-readable output for piping into other tools.
@@ -60,27 +65,37 @@ Renders the thread to stdout — useful for piping into `less` or grepping a spe
 ## attachment — list or download
 
 ```bash
-durian attachment <message-id>                          # list parts
-durian attachment <message-id> --part 2 --save ./out/   # download part 2
+durian attachment <message-id>                              # list parts
+durian attachment <message-id> --save 2 --output ./out/     # download part 2 into ./out/
+durian attachment <message-id> --save 2                     # download part 2 into the current dir
 ```
 
-Part IDs come from the `list` output. `--save` writes the original filename into the target directory.
+Part IDs come from the `list` output. `--save <part>` selects the part, `-o, --output <dir>` picks the target directory (defaults to `.`). The original filename is preserved.
 
 ## send — send an email
 
 ```bash
 durian send --to bob@x.com --subject Hi --body "Hello"
 durian send --to bob@x.com --subject Draft       # opens $EDITOR
-durian send --to bob@x.com --subject "PR" --attachment patch.diff
+durian send --to bob@x.com --subject "PR" --attach patch.diff
+durian send --to bob@x.com --subject "Newsletter" --body-file newsletter.html --html
+durian send --to bob@x.com --subject "Re: PR" \
+            --in-reply-to "<orig@host>" --references "<root@host> <orig@host>" \
+            --body "ack"
+durian send --to bob@x.com --subject "huge" --attach video.mov --force
 ```
 
-If `--body` is omitted, your `$EDITOR` opens with a temp file.
+If `--body` is omitted, your `$EDITOR` opens with a temp file. `--body-file`
+reads the body from disk (use with `--html` for HTML mail). `--in-reply-to`
+and `--references` set the threading headers when scripting replies.
+`--force` overrides the per-account attachment-size limit (see
+`max_attachment_size_mb` in `config.pkl`).
 
 ## draft — manage IMAP drafts
 
 ```bash
 durian draft save --to alice@x.com --subject WIP --body "..."
-durian draft save --replace --message-id "<original-id>" ...
+durian draft save --replace "<original-id>" ...
 durian draft delete "<message-id>"
 ```
 
@@ -122,11 +137,14 @@ Credentials live in the macOS Keychain — see [OAuth setup](../auth/oauth/) and
 ## master-key — back up the at-rest encryption key
 
 ```bash
-durian master-key export --out ~/durian-master.age   # passphrase-encrypted age file
-durian master-key export --out -                     # to stdout
-durian master-key import --from ~/durian-master.age  # restore into a fresh keychain
-durian master-key import --from FILE --force         # overwrite an existing entry
+durian master-key export -o ~/durian-master.age        # passphrase-encrypted age file
+durian master-key export --output -                    # to stdout
+durian master-key import --source ~/durian-master.age  # restore into a fresh keychain
+durian master-key import --source FILE --force         # overwrite an existing entry
 ```
+
+The previous `--out` / `--from` flag names are kept as deprecated aliases for one
+release — they still work but print a deprecation warning.
 
 The master encrypts every sensitive column in `email.db` + `contacts.db`. Lose it and the local DB is unrecoverable. See the [Encryption at rest](../encryption-at-rest/) walkthrough.
 
@@ -155,10 +173,13 @@ Groups are defined in `groups.pkl` — edit the file to add or remove members. T
 ## tag-sync — multi-machine tag replication
 
 ```bash
-durian tag-sync push                  # push local tag changes to server
-durian tag-sync pull                  # pull remote changes
-durian tag-sync push-all              # initial sync (all tags)
+durian tag-sync init                  # one-shot bulk push of all local tags
 ```
+
+Incremental `push` / `pull` subcommands are not yet implemented — for now tag changes
+are pushed/pulled automatically as part of every `durian sync` (and continuously while
+`durian serve` is running). `tag-sync init` is the one-time bootstrap to seed a fresh
+sync server from an existing local DB.
 
 Optional. Requires a self-hosted [tag sync server](https://github.com/julion2/durian/tree/main/sync) configured in `config.pkl`:
 


### PR DESCRIPTION
## Summary

Pass over the CLI surface and the Hugo reference docs to fix several wrong examples and tighten flag naming. All flag renames keep the old name as a deprecated alias for one release.

### Doc fixes (`docs/content/docs/cli/reference.md`)
- `search count` → top-level `count`
- `attachment` example: `--part X --save DIR` → `--save <part> --output <dir>`
- `send`: `--attachment` → `--attach`
- `draft save --replace` takes the Message-ID as value (no `--message-id`)
- `tag-sync` block reduced to the one real subcommand with a note that incremental push/pull are not yet implemented
- Examples added for `send --body-file/--html/--in-reply-to/--references/--force`
- Examples added for `sync --no-flags/--backfill-headers/--dry-run`

### CLI ergonomics
- `contacts list/search --limit` shortcut `-n` → `-l` (matches ls/grep/head/tail)
- `master-key export --out` → `-o/--output` (`--out` kept as deprecated alias)
- `master-key import --from` → `--source` (`--from` kept as deprecated alias; the name `--from` is now reserved for sender semantics in send/draft)
- `tag-sync push-all` → `tag-sync init` (`push-all` kept as hidden deprecated alias; frees up `push`/`pull` for future incremental sync)

### Cobra metadata
- Long descriptions for `rules`, `group`, `tag-sync` parent commands
- Example blocks for `serve`, `group list/members`, `contacts init/import/list`, `tag-sync init`

`docs/content/docs/cli/encryption-at-rest.md` updated to match the new master-key flag names.

## Test plan

- [x] `bazel build //cli/cmd/durian` clean
- [x] `bazel test //cli/...` 18/18 pass
- [x] `hugo --destination /tmp/...` renders 47 pages, no errors
- [x] Smoke-tested deprecated aliases: `tag-sync push-all`, `master-key export --out` both emit deprecation warnings and still work
- [x] `contacts list --help` shows `-l, --limit`
- [ ] CI green on this branch