### PR TITLE
chore(swift): swiftformat -w macos/ + enable CI lint gate

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -95,6 +95,11 @@ jobs:
           key: bazel-gui-${{ hashFiles('MODULE.bazel', 'gui/BUILD.bazel') }}
           restore-keys: bazel-gui-
 
+      - name: Check SwiftFormat
+        run: |
+          brew install swiftformat
+          swiftformat --lint macos/
+
       - name: Test
         run: bazel test //macos:all --build_tests_only --test_output=errors
 

--- a/.swiftformat
+++ b/.swiftformat
@@ -2,28 +2,23 @@
 # observed style (4-space indent, no hard line length, `// MARK:`
 # sections, Foundation/SwiftUI-first imports per CLAUDE.md).
 #
-# Conservative rule set: catches the trailing-whitespace and stale
-# import-order drift that the reviewer flagged, without forcing churn
-# on the existing 200+ Swift files.
+# `--rules` is an allowlist: ONLY the rules below run. SwiftFormat's
+# default rule set is otherwise large (~50 rules) and includes
+# semantic style migrations (andOperator, hoistPatternLet,
+# unusedArguments) that would churn existing files without
+# discriminating real improvements from cosmetic.
 
 --swiftversion 5.10
 --indent 4
 --maxwidth none
---trimwhitespace always
 --linebreaks lf
 --commas inline
---self remove
---header ignore
 
-# Enabled rules — conservative, all observably present in the codebase
---enable trailingSpace
---enable redundantSelf
---enable sortImports
---enable redundantParens
---enable redundantReturn
---enable wrapMultilineStatementBraces
-
-# Disabled — opinionated, would churn existing files for no gain
---disable redundantType
---disable blankLinesAtStartOfScope
---disable redundantInternal
+# Allowlist — narrowly chosen for "obvious safe cleanup":
+#   trailingSpace  — drop end-of-line whitespace (the reviewer's main flag)
+#   sortImports    — alphabetize import blocks per CLAUDE.md style
+#   redundantSelf  — remove `self.` where unambiguous
+#   redundantParens — drop unneeded parens in conditions / returns
+#   redundantReturn — drop `return` from single-expression closures
+#   wrapMultilineStatementBraces — opening brace on its own line for long ifs
+--rules trailingSpace,sortImports,redundantSelf,redundantParens,redundantReturn,wrapMultilineStatementBraces

--- a/macos/durian/ContentView.swift
+++ b/macos/durian/ContentView.swift
@@ -5,8 +5,8 @@
 //  Created by Julian Schenker on 15.09.25.
 //
 
-import SwiftUI
 import Combine
+import SwiftUI
 
 // MARK: - Popup Navigation Notifications
 
@@ -56,7 +56,7 @@ struct ContentView: View {
     var body: some View {
         ZStack {
             emailView
-            
+
             if showSearchPopup {
                 searchPopupOverlay
             }
@@ -98,7 +98,7 @@ struct ContentView: View {
     }
 
     // MARK: - Search Popup Overlay
-    
+
     @ViewBuilder
     private var searchPopupOverlay: some View {
         ZStack {
@@ -138,7 +138,7 @@ struct ContentView: View {
         }
         .ignoresSafeArea()
     }
-    
+
     // MARK: - Tag Picker Overlay
 
     @ViewBuilder
@@ -247,7 +247,7 @@ struct ContentView: View {
     }
 
     // MARK: - Email View
-    
+
     @ViewBuilder
     private var emailView: some View {
         NavigationSplitView {
@@ -270,7 +270,7 @@ struct ContentView: View {
                     }
                     .padding(.vertical, 4)
                 }
-                
+
                 if !displayEmails.isEmpty {
                     emailListView
                 } else if !isSearchMode && accountManager.isLoadingEmails {
@@ -296,44 +296,44 @@ struct ContentView: View {
                     }
                     .help("New Message (Cmd+N)")
                     .keyboardShortcut("n", modifiers: .command)
-                    
+
                     Button(action: { replyToSelected() }) {
                         Image(systemName: "arrowshape.turn.up.left")
                     }
                     .help("Reply (R)")
                     .disabled(markedEmails.isEmpty || !selectedEmailHasBody)
-                    
+
                     Button(action: { replyAllToSelected() }) {
                         Image(systemName: "arrowshape.turn.up.left.2")
                     }
                     .help("Reply All (Shift+R)")
                     .disabled(markedEmails.isEmpty || !selectedEmailHasBody)
-                    
+
                     Button(action: { forwardSelected() }) {
                         Image(systemName: "arrowshape.turn.up.right")
                     }
                     .help("Forward (F)")
                     .disabled(markedEmails.isEmpty || !selectedEmailHasBody)
-                    
+
                     Button(action: deleteSelectedEmails) {
                         Image(systemName: "trash")
                     }
                     .help("Delete")
                     .disabled(markedEmails.isEmpty)
-                    
+
                     Button(action: togglePin) {
                         Image(systemName: selectedEmailIsPinned ? "pin.fill" : "pin")
                     }
                     .help(selectedEmailIsPinned ? "Unpin (S)" : "Pin (S)")
                     .disabled(markedEmails.isEmpty)
-                    
+
                     Button(action: toggleRead) {
                         Image(systemName: selectedEmailIsRead ? "envelope.open" : "envelope.badge")
                     }
                     .help(selectedEmailIsRead ? "Mark Unread (U)" : "Mark Read (U)")
                     .disabled(markedEmails.isEmpty)
                 }
-                
+
                 // Right: Search & Sync
                 ToolbarItemGroup(placement: .automatic) {
                     Button(action: { showSearchPopup = true }) {
@@ -341,7 +341,7 @@ struct ContentView: View {
                     }
                     .keyboardShortcut("/", modifiers: .command)
                     .help("Search (Cmd+/)")
-                    
+
                     Button(action: {
                         Task {
                             await syncManager.quickSync()
@@ -367,7 +367,8 @@ struct ContentView: View {
             // Detail View - always show cursor email, with badge if multi-selected
             if let emailId = cursorEmailId,
                let email = accountManager.mailMessages.first(where: { $0.id == emailId })
-                            ?? searchResults.first(where: { $0.id == emailId }) {
+                            ?? searchResults.first(where: { $0.id == emailId })
+            {
                 ZStack(alignment: .bottomTrailing) {
                     EmailDetailView(
                         email: email,
@@ -393,7 +394,7 @@ struct ContentView: View {
                         isThreadFocused: isThreadFocused
                     )
                     .id(email.id)  // Force new View instance on email change to reset @State
-                    
+
                     // Selection badge when multiple emails marked
                     if markedEmails.count > 1 {
                         HStack(spacing: 4) {
@@ -494,7 +495,7 @@ struct ContentView: View {
             return .ignored
         }
     }
-    
+
     /// Number of thread messages for the currently focused email
     var currentThreadMessageCount: Int {
         guard let emailId = cursorEmailId,
@@ -634,7 +635,7 @@ struct ContentView: View {
     }
 
     // MARK: - Helper Methods
-    
+
     private func handleEmailSelection(_ emailId: String) {
         detailMode = .emailDetail(emailId: emailId)
 
@@ -678,12 +679,13 @@ struct ContentView: View {
             }
         }
     }
-    
+
     // MARK: - Toolbar Helpers
-    
+
     private var selectedEmailIsPinned: Bool {
         guard let emailId = markedEmails.first,
-              let email = displayEmails.first(where: { $0.id == emailId }) else {
+              let email = displayEmails.first(where: { $0.id == emailId }) else
+        {
             return false
         }
         return email.isPinned
@@ -691,7 +693,8 @@ struct ContentView: View {
 
     private var selectedEmailIsRead: Bool {
         guard let emailId = markedEmails.first,
-              let email = displayEmails.first(where: { $0.id == emailId }) else {
+              let email = displayEmails.first(where: { $0.id == emailId }) else
+        {
             return true
         }
         return email.isRead
@@ -699,7 +702,8 @@ struct ContentView: View {
 
     private var selectedEmailHasBody: Bool {
         guard let emailId = markedEmails.first,
-              let email = displayEmails.first(where: { $0.id == emailId }) else {
+              let email = displayEmails.first(where: { $0.id == emailId }) else
+        {
             return false
         }
         if case .loaded = email.bodyState {
@@ -712,7 +716,7 @@ struct ContentView: View {
         guard let emailId = markedEmails.first else { return nil }
         return displayEmails.first(where: { $0.id == emailId })
     }
-    
+
     private func deleteSelectedEmails() {
         guard !markedEmails.isEmpty else { return }
         let ids = markedEmails
@@ -751,9 +755,9 @@ struct ContentView: View {
             }
         }
     }
-    
+
     // MARK: - Compose
-    
+
     func openNewCompose() {
         guard defaultFromAccount != nil else {
             BannerManager.shared.showWarning(title: "No Account", message: "Configure an email account to use this action.")
@@ -762,15 +766,16 @@ struct ContentView: View {
         let draftId = DraftService.shared.createDraft(from: defaultFromAccount)
         openWindow(value: draftId)
     }
-    
+
     // MARK: - Reply/Forward Actions
-    
+
     /// Get default from-account based on current profile
     private var defaultFromAccount: String? {
         // Get first account from current profile
         if let profile = profileManager.currentProfile,
            let accountName = profile.accounts.first,
-           accountName != "*" {
+           accountName != "*"
+        {
             // Find matching account by name
             return ConfigManager.shared.getAccounts()
                 .first(where: { $0.name.caseInsensitiveCompare(accountName) == .orderedSame })?.email
@@ -778,11 +783,12 @@ struct ContentView: View {
         // Fallback to first configured account
         return ConfigManager.shared.getAccounts().first?.email
     }
-    
+
     func replyToSelected() {
         guard let email = selectedEmail,
               case .loaded = email.bodyState,
-              let fromAccount = defaultFromAccount else {
+              let fromAccount = defaultFromAccount else
+        {
             Log.warning("COMPOSE", "replyToSelected guard failed — selected=\(selectedEmail != nil), bodyState=\(String(describing: selectedEmail?.bodyState)), fromAccount=\(defaultFromAccount ?? "nil")")
             if defaultFromAccount == nil {
                 BannerManager.shared.showWarning(title: "No Account", message: "Configure an email account to use this action.")
@@ -801,7 +807,8 @@ struct ContentView: View {
     func replyAllToSelected() {
         guard let email = selectedEmail,
               case .loaded = email.bodyState,
-              let fromAccount = defaultFromAccount else {
+              let fromAccount = defaultFromAccount else
+        {
             Log.warning("COMPOSE", "replyAllToSelected guard failed — selected=\(selectedEmail != nil), bodyState=\(String(describing: selectedEmail?.bodyState)), fromAccount=\(defaultFromAccount ?? "nil")")
             if defaultFromAccount == nil {
                 BannerManager.shared.showWarning(title: "No Account", message: "Configure an email account to use this action.")
@@ -824,11 +831,12 @@ struct ContentView: View {
         guard let response = await backend.fetchOriginalBody(messageId: targetId) else { return nil }
         return (body: response.body, html: response.html)
     }
-    
+
     func forwardSelected() {
         guard let email = selectedEmail,
               case .loaded = email.bodyState,
-              let fromAccount = defaultFromAccount else {
+              let fromAccount = defaultFromAccount else
+        {
             Log.warning("COMPOSE", "forwardSelected guard failed — selected=\(selectedEmail != nil), bodyState=\(String(describing: selectedEmail?.bodyState)), fromAccount=\(defaultFromAccount ?? "nil")")
             if defaultFromAccount == nil {
                 BannerManager.shared.showWarning(title: "No Account", message: "Configure an email account to use this action.")
@@ -863,9 +871,9 @@ struct ContentView: View {
         let draftId = DraftService.shared.createDraft(with: draft)
         openWindow(value: draftId)
     }
-    
+
     // MARK: - Navigation Helpers
-    
+
     /// Advance cursor and selection to the given email, or clear if nil.
     func advanceCursor(to emailId: String?) {
         if let emailId = emailId {
@@ -901,13 +909,13 @@ struct ContentView: View {
         let unpinned = displayEmails.filter { !$0.isPinned }.sorted { $0.timestamp > $1.timestamp }
         return (pinned + unpinned).map { $0.id }
     }
-    
+
     /// Get current email index in sorted list (based on cursor position)
     func currentEmailIndex() -> Int? {
         guard let currentId = cursorEmailId else { return nil }
         return sortedEmailIds.firstIndex(of: currentId)
     }
-    
+
     /// Navigate to email at specific index (clamped to valid range)
     /// Updates cursor position and handles visual mode selection
     func navigateToEmail(at index: Int) {
@@ -917,16 +925,17 @@ struct ContentView: View {
 
         // Always update cursor position
         cursorEmailId = targetId
-        
+
         switch keymapHandler.engine.visualModeType {
         case .none:
             // Normal navigation: selection follows cursor
             markedEmails = [targetId]
-            
+
         case .line:
             // Line mode: selection = all emails from anchor to cursor
             if let anchor = visualModeAnchor,
-               let anchorIndex = sortedEmailIds.firstIndex(of: anchor) {
+               let anchorIndex = sortedEmailIds.firstIndex(of: anchor)
+            {
                 let start = min(anchorIndex, clampedIndex)
                 let end = max(anchorIndex, clampedIndex)
                 markedEmails = Set(sortedEmailIds[start...end])
@@ -934,13 +943,13 @@ struct ContentView: View {
                 // No anchor yet, just add cursor to selection
                 markedEmails.insert(targetId)
             }
-            
+
         case .toggle:
             // Toggle mode: selection stays unchanged, only cursor moves
             break
         }
     }
-    
+
     /// Get range of email IDs between two indices
     private func emailsInRange(from: Int, to: Int) -> Set<String> {
         let start = min(from, to)

--- a/macos/durian/DurianApp.swift
+++ b/macos/durian/DurianApp.swift
@@ -83,7 +83,7 @@ struct DurianApp: App {
             }
         }
     }
-    
+
     var body: some Scene {
         WindowGroup {
             ContentView()
@@ -102,21 +102,21 @@ struct DurianApp: App {
                 }
                 .keyboardShortcut(",", modifiers: .command)
             }
-            
+
             CommandGroup(after: .newItem) {
                 Button("Reload Keymaps") {
                     KeymapsManager.shared.reloadKeymaps()
                 }
                 .keyboardShortcut("k", modifiers: [.command, .shift])
-                
+
                 Button("Reload Config") {
                     SettingsManager.shared.reloadSettings()
                     ProfileManager.shared.loadProfiles()
                 }
                 .keyboardShortcut("c", modifiers: [.command, .shift])
-                
+
                 Divider()
-                
+
                 Button("Full Sync") {
                     Task {
                         await SyncManager.shared.fullSync()
@@ -124,7 +124,7 @@ struct DurianApp: App {
                 }
                 .keyboardShortcut("r", modifiers: [.command, .shift])
             }
-            
+
             // Profile Menu
             CommandMenu("Profiles") {
                 ForEach(Array(profileManager.profiles.enumerated()), id: \.element.id) { index, profile in
@@ -144,7 +144,7 @@ struct DurianApp: App {
                 }
             }
         }
-        
+
         // Compose Window - supports multiple windows via UUID
         WindowGroup("New Message", for: UUID.self) { $draftId in
             if let draftId = draftId {
@@ -153,11 +153,12 @@ struct DurianApp: App {
         }
         .defaultSize(width: 650, height: 550)
     }
-    
+
     private func showAbout() {
         Task {
             if let backend = accountManager.emailBackend,
-               let info = await backend.fetchVersion() {
+               let info = await backend.fetchVersion()
+            {
                 cliVersion = "\(info.version) (\(info.commit))"
             }
             await MainActor.run {

--- a/macos/durian/Keymaps/KeyBuffer.swift
+++ b/macos/durian/Keymaps/KeyBuffer.swift
@@ -10,38 +10,38 @@ import Foundation
 /// Collects key presses for sequence matching with automatic timeout
 @MainActor
 class KeyBuffer: ObservableObject {
-    
+
     // MARK: - Configuration
-    
+
     /// Timeout in seconds before buffer is cleared (from config)
     private var timeout: TimeInterval {
         KeymapsManager.shared.keymaps.globalSettings.sequenceTimeout
     }
-    
+
     // MARK: - State
-    
+
     /// Current buffer of key events
     private var buffer: [KeyEvent] = []
-    
+
     /// Timeout task
     private var timeoutTask: Task<Void, Never>?
-    
+
     /// Callback when timeout expires
     var onTimeout: (() -> Void)?
-    
+
     // MARK: - Published
-    
+
     /// Current buffer as string for display
     @Published private(set) var displayString: String = ""
-    
+
     // MARK: - Init
-    
+
     init() {
         // Timeout is now read from KeymapsManager.shared.keymaps.globalSettings.sequenceTimeout
     }
-    
+
     // MARK: - Public API
-    
+
     /// Append a key event to the buffer
     func append(_ event: KeyEvent) {
         buffer.append(event)
@@ -52,31 +52,31 @@ class KeyBuffer: ObservableObject {
     func startTimeout() {
         resetTimeout()
     }
-    
+
     /// Append a simple key (no modifiers)
     func append(key: String) {
         append(KeyEvent(key: key))
     }
-    
+
     /// Clear the buffer
     func clear() {
         buffer.removeAll()
         displayString = ""
         cancelTimeout()
     }
-    
+
     /// Get buffer contents as normalized string for matching
     /// e.g., ["5", "j"] → "5j", ["g", "g"] → "gg"
     var asString: String {
         buffer.map { $0.normalized }.joined()
     }
-    
+
     /// Get just the count prefix if present
     /// e.g., "5j" → 5, "12gg" → 12, "gg" → nil
     var countPrefix: Int? {
         let str = asString
         var digits = ""
-        
+
         for char in str {
             if char.isNumber {
                 digits.append(char)
@@ -84,47 +84,47 @@ class KeyBuffer: ObservableObject {
                 break
             }
         }
-        
+
         return digits.isEmpty ? nil : Int(digits)
     }
-    
+
     /// Get sequence without count prefix
     /// e.g., "5j" → "j", "12gg" → "gg", "gg" → "gg"
     var sequenceWithoutCount: String {
         let str = asString
         return String(str.drop(while: { $0.isNumber }))
     }
-    
+
     /// Check if buffer is empty
     var isEmpty: Bool {
         buffer.isEmpty
     }
-    
+
     /// Number of keys in buffer
     var count: Int {
         buffer.count
     }
-    
+
     /// Check if buffer contains only digits (waiting for action)
     var isCountOnly: Bool {
         !asString.isEmpty && asString.allSatisfy { $0.isNumber }
     }
-    
+
     // MARK: - Private
-    
+
     private func updateDisplayString() {
         displayString = asString
     }
-    
+
     private func resetTimeout() {
         cancelTimeout()
-        
+
         timeoutTask = Task { [weak self] in
             do {
                 try await Task.sleep(nanoseconds: UInt64(self?.timeout ?? 0.5) * 1_000_000_000)
-                
+
                 guard !Task.isCancelled else { return }
-                
+
                 await MainActor.run {
                     self?.handleTimeout()
                 }
@@ -133,12 +133,12 @@ class KeyBuffer: ObservableObject {
             }
         }
     }
-    
+
     private func cancelTimeout() {
         timeoutTask?.cancel()
         timeoutTask = nil
     }
-    
+
     private func handleTimeout() {
         clear()
         onTimeout?()

--- a/macos/durian/Keymaps/KeySequenceEngine.swift
+++ b/macos/durian/Keymaps/KeySequenceEngine.swift
@@ -5,9 +5,9 @@
 //  Main engine for handling key sequences with count support
 //
 
-import Foundation
 import AppKit
 import Combine
+import Foundation
 
 /// Visual mode types for multi-selection
 enum VisualModeType: Equatable {
@@ -20,16 +20,16 @@ enum VisualModeType: Equatable {
 /// Handles: single keys (j, k), counts (5j, 12k), sequences (gg, dd)
 @MainActor
 class KeySequenceEngine: ObservableObject {
-    
+
     // MARK: - Singleton
-    
+
     static let shared = KeySequenceEngine()
-    
+
     // MARK: - Dependencies
-    
+
     private let buffer = KeyBuffer()
     private let matcher = SequenceMatcher.shared
-    
+
     // MARK: - State
 
     /// Registered action handlers, scoped by context
@@ -52,20 +52,20 @@ class KeySequenceEngine: ObservableObject {
 
     /// Convenience: whether any visual mode is active
     var isVisualMode: Bool { visualModeType != .none }
-    
+
     // MARK: - Init
-    
+
     private init() {
         setupBufferTimeout()
     }
-    
+
     private func setupBufferTimeout() {
         buffer.onTimeout = { [weak self] in
             self?.currentSequence = ""
             self?.isWaitingForMore = false
         }
     }
-    
+
     // MARK: - Public API
 
     /// Switch the active keymap context (clears buffer on change)
@@ -87,25 +87,26 @@ class KeySequenceEngine: ObservableObject {
         }
         actionHandlers[context]?[action] = handler
     }
-    
+
     /// Process a key event
     /// - Parameter event: The NSEvent key event
     /// - Returns: true if event was consumed, false to pass through
     func handleKeyEvent(_ event: NSEvent) -> Bool {
         let key = event.charactersIgnoringModifiers ?? ""
         let modifiers = getModifiers(from: event)
-        
+
         // Skip if key is empty
         guard !key.isEmpty else {
             return false
         }
-        
+
         // Skip pure modifier keys
-        if key.isEmpty || event.keyCode == 55 || event.keyCode == 54 || 
-           event.keyCode == 56 || event.keyCode == 58 || event.keyCode == 59 {
+        if key.isEmpty || event.keyCode == 55 || event.keyCode == 54 ||
+           event.keyCode == 56 || event.keyCode == 58 || event.keyCode == 59
+        {
             return false
         }
-        
+
         // Escape always clears buffer, exits visual mode, and dispatches handler
         if event.keyCode == 53 { // Escape
             if !buffer.isEmpty {
@@ -148,17 +149,17 @@ class KeySequenceEngine: ObservableObject {
             // Other Cmd/Ctrl combos pass through
             return false
         }
-        
+
         return processKey(key: key, modifiers: modifiers)
     }
-    
+
     /// Clear the buffer manually
     func clearBuffer() {
         buffer.clear()
         currentSequence = ""
         isWaitingForMore = false
     }
-    
+
     /// Enter visual mode for multi-selection
     /// - Parameter type: The type of visual mode (.line or .toggle)
     func enterVisualMode(_ type: VisualModeType = .line) {
@@ -166,15 +167,15 @@ class KeySequenceEngine: ObservableObject {
         visualModeType = type
         Log.debug("KEYSEQ", "Entered visual mode: \(type)")
     }
-    
+
     /// Exit visual mode
     func exitVisualMode() {
         visualModeType = .none
         Log.debug("KEYSEQ", "Exited visual mode")
     }
-    
+
     // MARK: - Private
-    
+
     private func processKey(key: String, modifiers: Set<KeyModifier>) -> Bool {
         let keyEvent = KeyEvent(key: key, modifiers: modifiers)
 
@@ -213,10 +214,10 @@ class KeySequenceEngine: ObservableObject {
         guard let handler = actionHandlers[activeContext]?[action] else { return }
         Task { await handler(count) }
     }
-    
+
     private func getModifiers(from event: NSEvent) -> Set<KeyModifier> {
         var modifiers: Set<KeyModifier> = []
-        
+
         if event.modifierFlags.contains(.command) {
             modifiers.insert(.cmd)
         }
@@ -229,7 +230,7 @@ class KeySequenceEngine: ObservableObject {
         if event.modifierFlags.contains(.shift) {
             modifiers.insert(.shift)
         }
-        
+
         return modifiers
     }
 }

--- a/macos/durian/Keymaps/KeymapHandler.swift
+++ b/macos/durian/Keymaps/KeymapHandler.swift
@@ -5,23 +5,23 @@
 //  Handles keyboard events and delegates to KeySequenceEngine
 //
 
+import AppKit
+import Combine
 import Foundation
 import SwiftUI
-import Combine
-import AppKit
 import WebKit
 
 @MainActor
 class KeymapHandler: ObservableObject {
     static let shared = KeymapHandler()
-    
+
     // MARK: - Dependencies
-    
+
     private var keymapsManager = KeymapsManager.shared
     private let sequenceEngine = KeySequenceEngine.shared
-    
+
     // MARK: - State
-    
+
     private var cancellables = Set<AnyCancellable>()
     private var keyEventMonitor: Any?
     private var isAppInForeground = false
@@ -29,26 +29,26 @@ class KeymapHandler: ObservableObject {
     /// When true, space key is passed through for attachment QuickLook preview.
     var attachmentSelected = false
     var composeActive = false
-    
+
     // Legacy action handlers (for keymaps.pkl defined shortcuts with modifiers)
     private var legacyActionHandlers: [String: () async -> Void] = [:]
-    
+
     // MARK: - Published (proxy from sequence engine)
-    
+
     @Published private(set) var currentSequence: String = ""
     @Published private(set) var isWaitingForMore: Bool = false
-    
+
     /// Public access to the sequence engine (for visual mode state, etc.)
     var engine: KeySequenceEngine { sequenceEngine }
-    
+
     // MARK: - Init
-    
+
     private init() {
         setupForegroundDetection()
         setupKeymapObserver()
         setupSequenceEngineBindings()
     }
-    
+
     deinit {
         // Note: Can't call MainActor methods in deinit
         // The event monitor will be cleaned up when the app terminates
@@ -56,7 +56,7 @@ class KeymapHandler: ObservableObject {
             NSEvent.removeMonitor(monitor)
         }
     }
-    
+
     // MARK: - Public API
 
     /// Register a handler for a KeymapAction in a specific context (goes through sequence engine)
@@ -70,26 +70,26 @@ class KeymapHandler: ObservableObject {
         sequenceEngine.registerSimpleHandler(for: action, context: context, handler: handler)
         Log.debug("KEYMAPS", "Simple handler registered for action: \(action.rawValue) in context: \(context.rawValue)")
     }
-    
+
     /// Register a legacy handler for keymaps.pkl defined shortcuts (Cmd+r, etc.)
     func registerLegacyHandler(for action: String, handler: @escaping () async -> Void) {
         legacyActionHandlers[action] = handler
         Log.debug("KEYMAPS", "Legacy handler registered for action: \(action)")
     }
-    
+
     func startKeyEventMonitoring() {
         stopKeyEventMonitoring()
-        
+
         keyEventMonitor = NSEvent.addLocalMonitorForEvents(matching: .keyDown) { [weak self] event in
             if self?.handleKeyEvent(event) == true {
                 return nil // Consume event
             }
             return event // Pass through
         }
-        
+
         Log.debug("KEYMAPS", "Key event monitoring started")
     }
-    
+
     func stopKeyEventMonitoring() {
         if let monitor = keyEventMonitor {
             NSEvent.removeMonitor(monitor)
@@ -97,14 +97,14 @@ class KeymapHandler: ObservableObject {
             Log.debug("KEYMAPS", "Key event monitoring stopped")
         }
     }
-    
+
     /// Clear the sequence buffer
     func clearSequence() {
         sequenceEngine.clearBuffer()
     }
-    
+
     // MARK: - Private Methods
-    
+
     private func setupForegroundDetection() {
         NotificationCenter.default.addObserver(
             forName: NSApplication.didBecomeActiveNotification,
@@ -131,7 +131,7 @@ class KeymapHandler: ObservableObject {
             }
         }
     }
-    
+
     private func setupKeymapObserver() {
         keymapsManager.$keymaps
             .sink { _ in
@@ -139,18 +139,18 @@ class KeymapHandler: ObservableObject {
             }
             .store(in: &cancellables)
     }
-    
+
     private func setupSequenceEngineBindings() {
         // Bind sequence engine state to this handler for UI
         sequenceEngine.$currentSequence
             .receive(on: DispatchQueue.main)
             .assign(to: &$currentSequence)
-        
+
         sequenceEngine.$isWaitingForMore
             .receive(on: DispatchQueue.main)
             .assign(to: &$isWaitingForMore)
     }
-    
+
     private func handleKeyEvent(_ event: NSEvent) -> Bool {
         let isPopupContext = sequenceEngine.activeContext == .search || sequenceEngine.activeContext == .tagPicker
 
@@ -169,7 +169,8 @@ class KeymapHandler: ObservableObject {
         }
 
         guard isAppInForeground,
-              keymapsManager.keymaps.globalSettings.keymapsEnabled else {
+              keymapsManager.keymaps.globalSettings.keymapsEnabled else
+        {
             return false
         }
 
@@ -181,22 +182,22 @@ class KeymapHandler: ObservableObject {
         // Then delegate to sequence engine
         return sequenceEngine.handleKeyEvent(event)
     }
-    
+
     /// Handle keymaps.pkl defined shortcuts with modifiers
     private func handleLegacyKeymap(_ event: NSEvent) -> Bool {
         let key = event.charactersIgnoringModifiers?.lowercased() ?? ""
         let modifiers = getModifiers(from: event)
-        
+
         // Only handle if there are modifiers (except pure shift)
         guard !modifiers.isEmpty && modifiers != ["shift"] else {
             return false
         }
-        
+
         // Check keymaps.pkl entries
         for keymapEntry in keymapsManager.keymaps.keymaps {
             // Legacy entries require modifiers
             guard !keymapEntry.modifiers.isEmpty else { continue } // Skip no-modifier entries
-            
+
             if keymapEntry.key.lowercased() == key && Set(keymapEntry.modifiers) == Set(modifiers) {
                 if let handler = legacyActionHandlers[keymapEntry.action] {
                     Task {
@@ -206,13 +207,13 @@ class KeymapHandler: ObservableObject {
                 }
             }
         }
-        
+
         return false
     }
-    
+
     private func getModifiers(from event: NSEvent) -> [String] {
         var modifiers: [String] = []
-        
+
         if event.modifierFlags.contains(.command) {
             modifiers.append("cmd")
         }
@@ -225,10 +226,10 @@ class KeymapHandler: ObservableObject {
         if event.modifierFlags.contains(.shift) {
             modifiers.append("shift")
         }
-        
+
         return modifiers
     }
-    
+
     /// Check if a text input field is currently focused
     /// This prevents vim keymaps from interfering with typing in search, compose, etc.
     private func isTextInputFocused() -> Bool {
@@ -248,7 +249,8 @@ class KeymapHandler: ObservableObject {
 
         // Directly editable NSTextField
         if let textField = responder as? NSTextField,
-           textField.isEditable {
+           textField.isEditable
+        {
             return true
         }
 

--- a/macos/durian/Keymaps/KeymapTypes.swift
+++ b/macos/durian/Keymaps/KeymapTypes.swift
@@ -88,24 +88,24 @@ struct KeyEvent: Equatable {
     let key: String
     let modifiers: Set<KeyModifier>
     let timestamp: Date
-    
+
     init(key: String, modifiers: Set<KeyModifier> = [], timestamp: Date = Date()) {
         self.key = key
         self.modifiers = modifiers
         self.timestamp = timestamp
     }
-    
+
     /// String representation for matching (e.g., "shift+g" or "j")
     var normalized: String {
         if modifiers.isEmpty {
             return key.lowercased()
         }
-        
+
         // Special case: Shift+letter becomes uppercase
         if modifiers == [.shift] && key.count == 1 && key.first?.isLetter == true {
             return key.uppercased()
         }
-        
+
         let modStr = modifiers.sorted(by: { $0.rawValue < $1.rawValue })
             .map { $0.rawValue }
             .joined(separator: "+")
@@ -121,7 +121,7 @@ enum KeyModifier: String, Comparable {
     case ctrl = "ctrl"
     case option = "option"
     case shift = "shift"
-    
+
     static func < (lhs: KeyModifier, rhs: KeyModifier) -> Bool {
         lhs.rawValue < rhs.rawValue
     }
@@ -133,13 +133,13 @@ enum KeyModifier: String, Comparable {
 enum SequenceMatchResult: Equatable {
     /// No match found - clear buffer
     case noMatch
-    
+
     /// Partial match - waiting for more keys (e.g., "g" waiting for "g")
     case partial
-    
+
     /// Full match found
     case match(action: KeymapAction, count: Int)
-    
+
     static func == (lhs: SequenceMatchResult, rhs: SequenceMatchResult) -> Bool {
         switch (lhs, rhs) {
         case (.noMatch, .noMatch):

--- a/macos/durian/Keymaps/KeymapsManager.swift
+++ b/macos/durian/Keymaps/KeymapsManager.swift
@@ -1,6 +1,6 @@
+import Combine
 import Foundation
 import SwiftUI
-import Combine
 
 // MARK: - Notifications
 
@@ -10,10 +10,10 @@ extension Notification.Name {
 
 class KeymapsManager: ObservableObject {
     static let shared = KeymapsManager()
-    
+
     @Published var keymaps: KeymapConfig = KeymapConfig()
     private var cancellables = Set<AnyCancellable>()
-    
+
     private init() {
         loadKeymapsBlocking()
     }
@@ -41,10 +41,10 @@ class KeymapsManager: ObservableObject {
 
         NotificationCenter.default.post(name: .keymapsDidChange, object: nil)
     }
-    
+
     /// Returns the default keymaps array
     private func getDefaultKeymaps() -> [KeymapEntry] {
-        return [
+        [
             // Navigation
             KeymapEntry(action: "next_email", key: "j", supportsCount: true),
             KeymapEntry(action: "prev_email", key: "k", supportsCount: true),
@@ -147,9 +147,9 @@ class KeymapsManager: ObservableObject {
         FileManager.default.durianConfigURL().appendingPathComponent("keymaps.pkl")
     }
 
-    
+
     // MARK: - Public API
-    
+
     func setKeymap(for action: String, key: String, modifiers: [String] = []) {
         if let index = keymaps.keymaps.firstIndex(where: { $0.action == action }) {
             keymaps.keymaps[index].key = key
@@ -157,13 +157,13 @@ class KeymapsManager: ObservableObject {
             Log.debug("KEYMAPS", "Set \(action) = \(formatKeymap(key: key, modifiers: modifiers))")
         }
     }
-    
+
     func getKeymap(for action: String) -> KeymapEntry? {
-        return keymaps.keymaps.first(where: { $0.action == action })
+        keymaps.keymaps.first(where: { $0.action == action })
     }
 
     func getKeymapsForAction(_ action: String) -> [KeymapEntry] {
-        return keymaps.keymaps.filter { $0.action == action }
+        keymaps.keymaps.filter { $0.action == action }
     }
 
     func isKeymapPressed(key: String, modifiers: [String], for action: String) -> Bool {
@@ -174,18 +174,18 @@ class KeymapsManager: ObservableObject {
         let matchingKeymaps = keymaps.keymaps.filter {
             $0.action == action
         }
-        
+
         return matchingKeymaps.contains { keymap in
-            keymap.key.lowercased() == key.lowercased() && 
+            keymap.key.lowercased() == key.lowercased() &&
             Set(keymap.modifiers) == Set(modifiers)
         }
     }
-    
+
     private func formatKeymap(key: String, modifiers: [String]) -> String {
         let modString = modifiers.isEmpty ? "" : modifiers.joined(separator: "+") + "+"
         return modString + key
     }
-    
+
     // Public method to manually reload keymaps
     func reloadKeymaps() {
         Log.info("KEYMAPS", "Manual keymaps reload requested")
@@ -196,12 +196,12 @@ class KeymapsManager: ObservableObject {
 struct KeymapConfig: Codable {
     var keymaps: [KeymapEntry]
     var globalSettings: KeymapGlobalSettings
-    
+
     init() {
-        self.keymaps = []
-        self.globalSettings = KeymapGlobalSettings()
+        keymaps = []
+        globalSettings = KeymapGlobalSettings()
     }
-    
+
     enum CodingKeys: String, CodingKey {
         case keymaps
         case globalSettings = "global_settings"

--- a/macos/durian/Keymaps/SequenceMatcher.swift
+++ b/macos/durian/Keymaps/SequenceMatcher.swift
@@ -9,11 +9,11 @@ import Foundation
 
 /// Matches key buffer contents against defined sequences
 class SequenceMatcher {
-    
+
     // MARK: - Singleton
-    
+
     static let shared = SequenceMatcher()
-    
+
     // MARK: - Dynamic Sequence Storage
 
     /// All defined key sequences (loaded from config), grouped by context
@@ -30,12 +30,12 @@ class SequenceMatcher {
 
     /// Per-context tag_op tags lookup: sequence → tags string (e.g. "+todo -inbox")
     private var contextTagOps: [KeymapContext: [String: String]] = [:]
-    
+
     // MARK: - Init
-    
+
     private init() {
         reloadFromConfig()
-        
+
         // Observe config changes
         NotificationCenter.default.addObserver(
             self,
@@ -44,17 +44,17 @@ class SequenceMatcher {
             object: nil
         )
     }
-    
+
     deinit {
         NotificationCenter.default.removeObserver(self)
     }
-    
+
     // MARK: - Config Loading
-    
+
     @objc private func configDidChange() {
         reloadFromConfig()
     }
-    
+
     /// Reload sequences from KeymapsManager config
     func reloadFromConfig() {
         let keymapEntries = KeymapsManager.shared.keymaps.keymaps
@@ -125,7 +125,7 @@ class SequenceMatcher {
         let totalSeqs = contextSequenceLookup.values.reduce(0) { $0 + $1.count }
         Log.debug("SEQMATCH", "Loaded \(totalSeqs) sequences across \(contextSequenceLookup.count) contexts")
     }
-    
+
     // MARK: - Public API
 
     /// Match buffer contents against known sequences in the given context
@@ -168,7 +168,7 @@ class SequenceMatcher {
 
         return .noMatch
     }
-    
+
     /// Get tags for a tag_op sequence in a given context
     func tagOpTags(for sequence: String, context: KeymapContext) -> String? {
         contextTagOps[context]?[sequence]
@@ -178,26 +178,26 @@ class SequenceMatcher {
     func sequences(for action: KeymapAction) -> [String] {
         sequences.filter { $0.action == action }.map { $0.sequence }
     }
-    
+
     /// Get all defined sequences (for help display)
     var allSequences: [SequenceDefinition] {
         sequences
     }
-    
+
     /// Check if an action supports count prefix in a given context
     func supportsCount(_ action: KeymapAction, context: KeymapContext = .list) -> Bool {
         contextCountSupported[context]?.contains(action) ?? false
     }
-    
+
     // MARK: - Private
-    
+
     /// Parse count prefix from buffer
     /// e.g., "5j" → (5, "j"), "12gg" → (12, "gg"), "gg" → (nil, "gg")
     func parseCountAndSequence(_ buffer: String) -> (count: Int?, sequence: String) {
         var digits = ""
         var rest = ""
         var foundNonDigit = false
-        
+
         for char in buffer {
             if char.isNumber && !foundNonDigit {
                 digits.append(char)
@@ -206,7 +206,7 @@ class SequenceMatcher {
                 rest.append(char)
             }
         }
-        
+
         let count = digits.isEmpty ? nil : Int(digits)
         return (count, rest)
     }

--- a/macos/durian/Managers/AccountManager.swift
+++ b/macos/durian/Managers/AccountManager.swift
@@ -5,14 +5,14 @@
 //  Manages email backend for email access
 //
 
-import Foundation
-import Combine
 import AppKit
+import Combine
+import Foundation
 
 @MainActor
 class AccountManager: ObservableObject {
     static let shared = AccountManager()
-    
+
     // MARK: - Email Backend Properties
     @Published var emailBackend: EmailBackend?
     @Published var mailMessages: [MailMessage] = []    // Messages
@@ -27,9 +27,9 @@ class AccountManager: ObservableObject {
 
     /// Unread thread counts per folder name (for sidebar badges)
     @Published var folderUnreadCounts: [String: Int] = [:]
-    
+
     private var cancellables = Set<AnyCancellable>()
-    
+
     /// Folders from current profile config
     var mailFolders: [MailFolder] {
         let profile = ProfileManager.shared.currentProfile
@@ -42,17 +42,17 @@ class AccountManager: ObservableObject {
             return MailFolder(name: folder.name.lowercased(), displayName: folder.name, icon: folder.icon)
         }
     }
-    
+
     private init() {
         setupEmailBackend()
     }
-    
+
     // MARK: - Backend Setup
-    
+
     private func setupEmailBackend() {
         Log.debug("BACKEND", "AccountManager: Setting up email backend")
         emailBackend = EmailBackend()
-        
+
         // Subscribe to backend changes — debounced to avoid cascade storms
         emailBackend?.objectWillChange
             .debounce(for: .milliseconds(50), scheduler: DispatchQueue.main)
@@ -75,7 +75,7 @@ class AccountManager: ObservableObject {
             loadingProgress = backend.loadingProgress
         }
     }
-    
+
     // MARK: - Folder Unread Counts & Dock Badge
 
     /// Refresh unread counts for all sidebar folders and update dock badge.
@@ -101,7 +101,7 @@ class AccountManager: ObservableObject {
     }
 
     // MARK: - Connection
-    
+
     func connectToAllAccounts() async {
         Log.debug("BACKEND", "AccountManager: Connecting to email backend...")
         guard let backend = emailBackend else {
@@ -112,7 +112,7 @@ class AccountManager: ObservableObject {
         syncFromBackend()
         await selectTag(resolvedFolder())
     }
-    
+
     // MARK: - Folder/Tag Selection
 
     /// Returns `selectedFolder` if it exists in the current profile,
@@ -135,20 +135,20 @@ class AccountManager: ObservableObject {
         syncFromBackend()
         await refreshFolderCounts()
     }
-    
+
     // MARK: - Profile Switching
-    
+
     /// Switch to a different profile and reload the current tag/folder
     func switchProfile(_ profile: Profile) async {
         // Update ProfileManager
         ProfileManager.shared.currentProfile = profile
         Log.info("BACKEND", "Switched to profile '\(profile.name)'")
-        
+
         await selectTag(resolvedFolder())
     }
-    
+
     // MARK: - Email Operations
-    
+
     @discardableResult func fetchEmailBody(id: String) async -> MailMessage? {
         guard let backend = emailBackend else { return nil }
         let standalone = await backend.fetchEmailBody(id: id)
@@ -159,7 +159,7 @@ class AccountManager: ObservableObject {
     func prefetchAroundCursor(cursorId: String) {
         emailBackend?.prefetchAroundCursor(cursorId: cursorId)
     }
-    
+
     func markAsRead(id: String) async {
         guard let backend = emailBackend else { return }
         do {
@@ -335,7 +335,7 @@ class AccountManager: ObservableObject {
         }
         syncFromBackend()
     }
-    
+
     // MARK: - Notification Navigation
 
     /// Select an email by thread ID (called when user clicks a notification)
@@ -349,21 +349,21 @@ class AccountManager: ObservableObject {
     }
 
     // MARK: - Full Reload
-    
+
     func reloadEmail() async {
         guard let backend = emailBackend else { return }
-        
+
         isLoadingEmails = true
-        
+
         // Quick sync via SyncManager
         let success = await SyncManager.shared.quickSync()
-        
+
         if !success {
             loadingProgress = SyncManager.shared.syncState.statusText
             isLoadingEmails = false
             return
         }
-        
+
         // Reload from backend
         loadingProgress = "Loading..."
         Log.debug("BACKEND", "Reloading from backend")

--- a/macos/durian/Managers/AttachmentCacheManager.swift
+++ b/macos/durian/Managers/AttachmentCacheManager.swift
@@ -21,7 +21,8 @@ class AttachmentCacheManager: ObservableObject {
     private var failedKeys: Set<String> = []
 
     init(cacheDir: URL? = nil,
-         settingsProvider: @escaping () -> AttachmentCacheSettings = { SettingsManager.shared.attachmentCacheSettings }) {
+         settingsProvider: @escaping () -> AttachmentCacheSettings = { SettingsManager.shared.attachmentCacheSettings })
+    {
         let resolvedDir: URL
         if let cacheDir {
             resolvedDir = cacheDir
@@ -30,7 +31,7 @@ class AttachmentCacheManager: ObservableObject {
             resolvedDir = caches.appendingPathComponent("org.js-lab.durian/attachments", isDirectory: true)
         }
         self.cacheDir = resolvedDir
-        self.indexFile = resolvedDir.appendingPathComponent(".cache-index.json")
+        indexFile = resolvedDir.appendingPathComponent(".cache-index.json")
         self.settingsProvider = settingsProvider
         try? fileManager.createDirectory(at: resolvedDir, withIntermediateDirectories: true)
         loadIndex()

--- a/macos/durian/Managers/AvatarManager.swift
+++ b/macos/durian/Managers/AvatarManager.swift
@@ -5,23 +5,23 @@
 //  Manages avatar loading from Gravatar and Brandfetch with caching
 //
 
-import Foundation
 import AppKit
 import CryptoKit
+import Foundation
 
 @MainActor
 class AvatarManager: ObservableObject {
     static let shared = AvatarManager()
-    
+
     // Memory Cache
     private var imageCache = NSCache<NSString, NSImage>()
-    
+
     // Failed lookups - don't retry for 24h
     private var failedLookups: [String: Date] = [:]
-    
+
     // Brandfetch token for company logos
     private let brandfetchToken = "1idWonATCJFIseiVHIH"
-    
+
     // Personal domains → Gravatar (company domains → Brandfetch)
     private let personalDomains: Set<String> = [
         // Google
@@ -44,14 +44,14 @@ class AvatarManager: ObservableObject {
         "posteo.de", "mailbox.org",
         "tutanota.com", "tutanota.de", "tuta.io"
     ]
-    
+
     private init() {
         imageCache.countLimit = 200
         imageCache.totalCostLimit = 50 * 1024 * 1024 // 50MB
     }
-    
+
     // MARK: - Public API
-    
+
     /// Load avatar for email address or name
     /// - Parameters:
     ///   - email: Full email string (can be "Name <email>" format) or just a name
@@ -69,43 +69,46 @@ class AvatarManager: ObservableObject {
             // Split by comma first (primary separator)
             let byComma = email.components(separatedBy: ",").first?
                 .trimmingCharacters(in: .whitespaces) ?? email
-            
+
             // Check for "|" without leading space (author separator)
             if let pipeRange = byComma.range(of: "|"),
                pipeRange.lowerBound > byComma.startIndex,
-               byComma[byComma.index(before: pipeRange.lowerBound)] != " " {
+               byComma[byComma.index(before: pipeRange.lowerBound)] != " "
+            {
                 firstAuthor = String(byComma[..<pipeRange.lowerBound])
                     .trimmingCharacters(in: .whitespaces)
             } else {
                 firstAuthor = byComma
             }
         }
-        
+
         // Extract clean email from "Name <email>" format
         let cleanEmail = extractEmail(from: firstAuthor).lowercased()
         let cacheKey = cleanEmail as NSString
-        
+
         // Check memory cache
         if let cached = imageCache.object(forKey: cacheKey) {
             return cached
         }
-        
+
         // Check if recently failed (don't retry for 24h)
         if let failedDate = failedLookups[cleanEmail],
-           Date().timeIntervalSince(failedDate) < 86400 {
+           Date().timeIntervalSince(failedDate) < 86400
+        {
             return nil
         }
-        
+
         // Extract domain - either from email or guess from name
         var domain: String?
         var emailForGravatar = cleanEmail  // Track actual email for Gravatar lookup
-        
+
         if cleanEmail.contains("@") {
             domain = extractDomain(from: cleanEmail)
         } else {
             // No email address (list view) - try contacts DB lookup first
             if let contact = await ContactsManager.shared.findByExactName(cleanEmail),
-               !contact.email.isEmpty {
+               !contact.email.isEmpty
+            {
                 // Found contact! Use their email for avatar lookup
                 emailForGravatar = contact.email.lowercased()
                 domain = extractDomain(from: contact.email)
@@ -115,11 +118,11 @@ class AvatarManager: ObservableObject {
                 domain = guessDomainFromName(cleanEmail)
             }
         }
-        
+
         guard let domain = domain else {
             return nil
         }
-        
+
         // Try appropriate source based on domain type
         let image: NSImage?
         if personalDomains.contains(domain) {
@@ -129,25 +132,25 @@ class AvatarManager: ObservableObject {
             // Company email → try Brandfetch
             image = await fetchBrandfetch(domain: domain)
         }
-        
+
         // Cache result
         if let image = image {
             imageCache.setObject(image, forKey: cacheKey)
         } else {
             failedLookups[cleanEmail] = Date()
         }
-        
+
         return image
     }
-    
+
     /// Clear all caches
     func clearCache() {
         imageCache.removeAllObjects()
         failedLookups.removeAll()
     }
-    
+
     // MARK: - Private Methods
-    
+
     /// Extract email address from "Name <email>" format
     private func extractEmail(from string: String) -> String {
         if let start = string.range(of: "<"), let end = string.range(of: ">") {
@@ -156,30 +159,31 @@ class AvatarManager: ObservableObject {
         }
         return string.trimmingCharacters(in: .whitespaces)
     }
-    
+
     /// Extract domain from email address
     private func extractDomain(from email: String) -> String? {
         guard let atIndex = email.firstIndex(of: "@") else { return nil }
         return String(email[email.index(after: atIndex)...]).lowercased()
     }
-    
+
     /// Guess domain from a company/brand name (for list view where we only have author name)
     /// Only returns domain if name already looks like a domain (e.g. "Amazon.de")
     /// Returns nil for regular names to avoid false matches
     private func guessDomainFromName(_ name: String) -> String? {
         let cleanName = name.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
-        
+
         // Must look like a domain: no spaces, has dot, no @, minimum length
         guard !cleanName.contains(" "),
               !cleanName.contains("@"),
               cleanName.contains("."),
-              cleanName.count >= 4 else {  // minimum "a.de"
+              cleanName.count >= 4 else
+        {  // minimum "a.de"
             return nil
         }
-        
+
         return cleanName
     }
-    
+
     /// Fetch avatar from Gravatar
     /// Uses MD5 hash of email, returns 404 if no account exists
     private func fetchGravatar(email: String, size: Int) async -> NSImage? {
@@ -187,14 +191,14 @@ class AvatarManager: ObservableObject {
         let hash = Insecure.MD5.hash(data: Data(email.utf8))
             .map { String(format: "%02x", $0) }
             .joined()
-        
+
         // d=404 returns 404 if no Gravatar exists (instead of default image)
         let urlString = "https://gravatar.com/avatar/\(hash)?d=404&s=\(size)"
         guard let url = URL(string: urlString) else { return nil }
-        
+
         return await fetchImage(from: url)
     }
-    
+
     /// Known Brandfetch placeholder image MD5 hashes.
     /// Brandfetch returns 200 + a generic placeholder for domains without a real logo,
     /// so we reject responses matching these hashes to avoid showing the same generic icon everywhere.
@@ -215,20 +219,21 @@ class AvatarManager: ObservableObject {
 
         return await fetchImage(request: request, rejectPlaceholders: true)
     }
-    
+
     /// Generic image fetcher with error handling (URL version)
     private func fetchImage(from url: URL, rejectPlaceholders: Bool = false) async -> NSImage? {
         let request = URLRequest(url: url)
         return await fetchImage(request: request, rejectPlaceholders: rejectPlaceholders)
     }
-    
+
     /// Generic image fetcher with error handling (Request version)
     private func fetchImage(request: URLRequest, rejectPlaceholders: Bool = false) async -> NSImage? {
         do {
             let (data, response) = try await URLSession.shared.data(for: request)
 
             guard let httpResponse = response as? HTTPURLResponse,
-                  httpResponse.statusCode == 200 else {
+                  httpResponse.statusCode == 200 else
+            {
                 return nil
             }
 
@@ -244,7 +249,8 @@ class AvatarManager: ObservableObject {
 
             // Verify we got image data, not HTML error page
             guard let image = NSImage(data: data),
-                  image.isValid else {
+                  image.isValid else
+            {
                 return nil
             }
 

--- a/macos/durian/Managers/ConfigManager.swift
+++ b/macos/durian/Managers/ConfigManager.swift
@@ -97,18 +97,18 @@ struct AppConfig: Codable {
     let settings: AppSettings
     let sync: SyncSettings
     let signatures: [String: String]
-    
+
     init(accounts: [MailAccount], settings: AppSettings = AppSettings(), sync: SyncSettings = SyncSettings(), signatures: [String: String] = [:]) {
         self.accounts = accounts
         self.settings = settings
         self.sync = sync
         self.signatures = signatures
     }
-    
+
     enum CodingKeys: String, CodingKey {
         case accounts, settings, sync, signatures
     }
-    
+
     init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         accounts = try container.decodeIfPresent([MailAccount].self, forKey: .accounts) ?? []
@@ -149,7 +149,7 @@ class ConfigManager {
 
     /// Test-only initializer: inject config directly, skip file loading
     init(config: AppConfig) {
-        self._config = config
+        _config = config
     }
 
     /// Synchronous load via pkl CLI subprocess.
@@ -174,36 +174,36 @@ class ConfigManager {
     private func getConfigURL() -> URL {
         FileManager.default.durianConfigURL().appendingPathComponent("config.pkl")
     }
-    
+
     // MARK: - Public API
-    
+
     func getAccounts() -> [MailAccount] {
-        return config?.accounts ?? []
+        config?.accounts ?? []
     }
-    
+
     func getSettings() -> AppSettings {
-        return config?.settings ?? AppSettings()
+        config?.settings ?? AppSettings()
     }
-    
+
     func getSignatures() -> [String: String] {
-        return config?.signatures ?? [:]
+        config?.signatures ?? [:]
     }
-    
+
     func getSyncSettings() -> SyncSettings {
-        return config?.sync ?? SyncSettings()
+        config?.sync ?? SyncSettings()
     }
-    
+
     /// Reload config from disk (call after editing config.pkl)
     func reloadConfig() {
         Log.info("CONFIG", "Reloading config...")
         loadConfigBlocking()
     }
-    
+
     func updateSettings(_ newSettings: AppSettings) {
-        guard let currentConfig = self.config else { return }
+        guard let currentConfig = config else { return }
 
         let updatedConfig = AppConfig(accounts: currentConfig.accounts, settings: newSettings, sync: currentConfig.sync, signatures: currentConfig.signatures)
-        self.config = updatedConfig
+        config = updatedConfig
         // Settings are now managed in config.pkl — edit the file directly
     }
 }

--- a/macos/durian/Managers/ContactsManager.swift
+++ b/macos/durian/Managers/ContactsManager.swift
@@ -36,17 +36,18 @@ struct Contact: Identifiable, Hashable {
 
     /// Convert from API response to domain model
     init(from response: ContactResponse) {
-        self.id = response.id
-        self.email = response.email
-        self.name = response.name
-        self.usageCount = response.usage_count
-        self.source = response.source
-        self.lastUsed = Self.parseDate(response.last_used)
-        self.createdAt = Self.parseDate(response.created_at) ?? Date()
+        id = response.id
+        email = response.email
+        name = response.name
+        usageCount = response.usage_count
+        source = response.source
+        lastUsed = Self.parseDate(response.last_used)
+        createdAt = Self.parseDate(response.created_at) ?? Date()
     }
 
     init(id: String, email: String, name: String?, lastUsed: Date? = nil,
-         usageCount: Int, source: String, createdAt: Date) {
+         usageCount: Int, source: String, createdAt: Date)
+    {
         self.id = id
         self.email = email
         self.name = name

--- a/macos/durian/Managers/DraftService.swift
+++ b/macos/durian/Managers/DraftService.swift
@@ -5,8 +5,8 @@
 //  Manages email drafts with IMAP synchronization
 //
 
-import SwiftUI
 import Combine
+import SwiftUI
 
 /// Response from durian draft save command
 struct DraftSaveResponse: Decodable {
@@ -29,7 +29,7 @@ enum DraftError: Error, LocalizedError {
     case deleteFailed(String)
     case loadFailed(String)
     case cliError(String)
-    
+
     var errorDescription: String? {
         switch self {
         case .noAccountConfigured:
@@ -50,21 +50,21 @@ enum DraftError: Error, LocalizedError {
 @MainActor
 class DraftService: ObservableObject {
     static let shared = DraftService()
-    
+
     /// Active drafts indexed by window UUID
     @Published var activeDrafts: [UUID: EmailDraft] = [:]
-    
+
     /// Drafts currently being saved (to show progress)
     @Published var savingDrafts: Set<UUID> = []
-    
+
     private let durianPath: String
-    
+
     private init() {
         durianPath = FileManager.default.resolveDurianPath() ?? "\(NSHomeDirectory())/.local/bin/durian"
     }
-    
+
     // MARK: - Draft Lifecycle
-    
+
     /// Create a new draft and return its UUID
     func createDraft(from account: String? = nil) -> UUID {
         let id = UUID()
@@ -74,7 +74,7 @@ class DraftService: ObservableObject {
         Log.debug("DRAFT", "Created new draft \(id)")
         return id
     }
-    
+
     /// Create a draft from an existing EmailDraft (for reply/forward)
     func createDraft(with draft: EmailDraft) -> UUID {
         let id = draft.id
@@ -82,17 +82,17 @@ class DraftService: ObservableObject {
         Log.debug("DRAFT", "Created draft from template \(id)")
         return id
     }
-    
+
     /// Get a draft by its UUID
     func getDraft(id: UUID) -> EmailDraft? {
-        return activeDrafts[id]
+        activeDrafts[id]
     }
-    
+
     /// Update a draft (called on every change in the compose view)
     func updateDraft(id: UUID, draft: EmailDraft) {
         activeDrafts[id] = draft
     }
-    
+
     /// Discard a draft without saving to IMAP
     func discard(id: UUID) {
         activeDrafts.removeValue(forKey: id)
@@ -108,16 +108,16 @@ class DraftService: ObservableObject {
         Log.debug("DRAFT", "Cloned draft \(id) → \(newId)")
         return newId
     }
-    
+
     // MARK: - IMAP Operations
-    
+
     /// Save a draft to IMAP (called on window close)
     /// Returns the new Message-ID if successful
     func saveToServer(id: UUID) async throws -> String {
         guard let draft = activeDrafts[id] else {
             throw DraftError.saveFailed("Draft not found")
         }
-        
+
         // Discard drafts where the user hasn't typed any content
         // (signatures and quoted content don't count)
         if !draft.hasUserContent {
@@ -126,16 +126,17 @@ class DraftService: ObservableObject {
             Log.debug("DRAFT", "Discarded draft with no user content \(id)")
             return ""
         }
-        
+
         // Get account
-        guard let account = ConfigManager.shared.getAccounts().first(where: { $0.email == draft.from }) 
-              ?? ConfigManager.shared.getAccounts().first else {
+        guard let account = ConfigManager.shared.getAccounts().first(where: { $0.email == draft.from })
+              ?? ConfigManager.shared.getAccounts().first else
+        {
             throw DraftError.noAccountConfigured
         }
-        
+
         savingDrafts.insert(id)
         defer { savingDrafts.remove(id) }
-        
+
         // Build command arguments
         var args = [
             "draft", "save",
@@ -144,7 +145,7 @@ class DraftService: ObservableObject {
             "--subject", draft.subject,
             "--body", draft.body
         ]
-        
+
         // Add recipients
         if !draft.to.isEmpty {
             args += ["--to", draft.to.joined(separator: ",")]
@@ -155,7 +156,7 @@ class DraftService: ObservableObject {
         if !draft.bcc.isEmpty {
             args += ["--bcc", draft.bcc.joined(separator: ",")]
         }
-        
+
         // Reply threading headers
         if let inReplyTo = draft.inReplyTo, !inReplyTo.isEmpty {
             args += ["--in-reply-to", inReplyTo]
@@ -168,77 +169,80 @@ class DraftService: ObservableObject {
         if let messageId = draft.messageId, !messageId.isEmpty {
             args += ["--replace", messageId]
         }
-        
+
         // HTML flag
         if draft.isHTML {
             args.append("--html")
         }
-        
+
         // Note: Attachments would need to be saved to temp files first
         // For now, we skip attachments in IMAP drafts (they're stored locally)
-        
+
         // Execute CLI command
         let result = try await executeCLI(args: args)
-        
+
         // Parse response
         guard let data = result.data(using: .utf8) else {
             throw DraftError.cliError("Invalid response")
         }
-        
+
         let response = try JSONDecoder().decode(DraftSaveResponse.self, from: data)
-        
+
         if !response.ok {
             throw DraftError.saveFailed(response.error ?? "Unknown error")
         }
-        
+
         // Update draft with new message ID
         var updatedDraft = draft
         updatedDraft.messageId = response.message_id
         activeDrafts[id] = updatedDraft
-        
+
         Log.info("DRAFT", "Saved to IMAP - Message-ID: \(response.message_id ?? "unknown")")
-        
+
         return response.message_id ?? ""
     }
-    
+
     /// Delete a draft from IMAP after sending
     func deleteAfterSend(id: UUID) async {
         guard let draft = activeDrafts[id],
               let messageId = draft.messageId,
-              !messageId.isEmpty else {
+              !messageId.isEmpty else
+        {
             // No server-side draft to delete
             activeDrafts.removeValue(forKey: id)
             return
         }
-        
+
         // Get account
         guard let account = ConfigManager.shared.getAccounts().first(where: { $0.email == draft.from })
-              ?? ConfigManager.shared.getAccounts().first else {
+              ?? ConfigManager.shared.getAccounts().first else
+        {
             activeDrafts.removeValue(forKey: id)
             return
         }
-        
+
         do {
             let args = [
                 "draft", "delete",
                 "--account", account.email,
                 messageId
             ]
-            
+
             let result = try await executeCLI(args: args)
-            
+
             if let data = result.data(using: .utf8),
                let response = try? JSONDecoder().decode(DraftDeleteResponse.self, from: data),
-               response.ok {
+               response.ok
+            {
                 Log.info("DRAFT", "Deleted from IMAP - \(messageId)")
             }
         } catch {
             Log.error("DRAFT", "Failed to delete from IMAP - \(error)")
         }
-        
+
         activeDrafts.removeValue(forKey: id)
     }
-    
+
     /// Load a draft from backend for editing
     /// Returns the UUID of the new draft window
     func loadFromBackend(messageId: String) async throws -> UUID {
@@ -249,34 +253,34 @@ class DraftService: ObservableObject {
         activeDrafts[id] = draft
         return id
     }
-    
+
     // MARK: - CLI Execution
-    
+
     private func executeCLI(args: [String]) async throws -> String {
-        return try await withCheckedThrowingContinuation { continuation in
+        try await withCheckedThrowingContinuation { continuation in
             DispatchQueue.global(qos: .userInitiated).async {
                 let process = Process()
                 process.executableURL = URL(fileURLWithPath: self.durianPath)
                 process.arguments = args
-                
+
                 // Set PATH for durian CLI
                 var environment = ProcessInfo.processInfo.environment
                 let homebrewPaths = "/opt/homebrew/bin:/opt/homebrew/sbin:/usr/local/bin"
                 environment["PATH"] = homebrewPaths + ":" + (environment["PATH"] ?? "")
                 process.environment = environment
-                
+
                 let stdout = Pipe()
                 let stderr = Pipe()
                 process.standardOutput = stdout
                 process.standardError = stderr
-                
+
                 do {
                     try process.run()
                     process.waitUntilExit()
-                    
+
                     let outputData = stdout.fileHandleForReading.readDataToEndOfFile()
                     let output = String(data: outputData, encoding: .utf8) ?? ""
-                    
+
                     if process.terminationStatus != 0 {
                         let errorData = stderr.fileHandleForReading.readDataToEndOfFile()
                         let errorOutput = String(data: errorData, encoding: .utf8) ?? "Unknown error"

--- a/macos/durian/Managers/EmailSendingManager.swift
+++ b/macos/durian/Managers/EmailSendingManager.swift
@@ -5,8 +5,8 @@
 //  Manages email sending via the outbox HTTP API
 //
 
-import Foundation
 import Combine
+import Foundation
 
 @MainActor
 class EmailSendingManager: ObservableObject {
@@ -322,7 +322,8 @@ class EmailSendingManager: ObservableObject {
 
         if let startIdx = trimmed.lastIndex(of: "<"),
            let endIdx = trimmed.lastIndex(of: ">"),
-           startIdx < endIdx {
+           startIdx < endIdx
+        {
             let start = trimmed.index(after: startIdx)
             return String(trimmed[start..<endIdx]).trimmingCharacters(in: .whitespaces)
         }

--- a/macos/durian/Managers/NetworkMonitor.swift
+++ b/macos/durian/Managers/NetworkMonitor.swift
@@ -11,7 +11,7 @@ import Network
 @MainActor
 class NetworkMonitor: ObservableObject {
     static let shared = NetworkMonitor()
-    
+
     @Published private(set) var isConnected: Bool = true
     @Published private(set) var showReconnectedBanner: Bool = false
 
@@ -27,13 +27,13 @@ class NetworkMonitor: ObservableObject {
                 let nowConnected = (path.status == .satisfied)
 
                 // Skip if state hasn't changed
-                guard nowConnected != self.isConnected else { return }
+                guard nowConnected != isConnected else { return }
 
                 // Debounce: NWPathMonitor fires rapidly during WiFi transitions.
                 // Wait 2s before committing the state change — if it flaps back,
                 // the previous task is cancelled and no update is published.
-                self.debounceTask?.cancel()
-                self.debounceTask = Task { @MainActor in
+                debounceTask?.cancel()
+                debounceTask = Task { @MainActor in
                     try? await Task.sleep(nanoseconds: 2_000_000_000)
                     guard !Task.isCancelled else { return }
 

--- a/macos/durian/Managers/OutboxManager.swift
+++ b/macos/durian/Managers/OutboxManager.swift
@@ -5,8 +5,8 @@
 //  Tracks outbox state (pending count) for badge display.
 //
 
-import Foundation
 import Combine
+import Foundation
 
 @MainActor
 class OutboxManager: ObservableObject {
@@ -17,12 +17,12 @@ class OutboxManager: ObservableObject {
     private let backendProvider: () -> (any OutboxBackend)?
 
     private init() {
-        self.backendProvider = { AccountManager.shared.emailBackend }
+        backendProvider = { AccountManager.shared.emailBackend }
     }
 
     /// Test-only initializer for dependency injection
     init(backend: @escaping () -> (any OutboxBackend)?) {
-        self.backendProvider = backend
+        backendProvider = backend
     }
 
     /// Refresh the pending count from the server.

--- a/macos/durian/Managers/ProfileManager.swift
+++ b/macos/durian/Managers/ProfileManager.swift
@@ -26,19 +26,19 @@ struct Profile: Identifiable, Equatable, Hashable {
     let isDefault: Bool
     let color: String?  // Hex color string, e.g. "#3B82F6"
     let folders: [FolderConfig]  // Folders with custom queries
-    
+
     var isAll: Bool { accounts.contains("*") }
-    
+
     /// Convert hex color string to SwiftUI Color
     var swiftUIColor: Color {
         guard let hex = color else { return .brown }  // Fallback: Brown
         return Color(hex: hex)
     }
-    
+
     static func == (lhs: Profile, rhs: Profile) -> Bool {
         lhs.name == rhs.name && lhs.accounts == rhs.accounts
     }
-    
+
     func hash(into hasher: inout Hasher) {
         hasher.combine(name)
         hasher.combine(accounts)
@@ -49,7 +49,7 @@ struct Profile: Identifiable, Equatable, Hashable {
 
 struct ProfilesConfig: Decodable {
     let profiles: [ProfileEntry]
-    
+
     struct ProfileEntry: Decodable {
         let name: String
         let accounts: [String]
@@ -57,7 +57,7 @@ struct ProfilesConfig: Decodable {
         var color: String?
         var folders: [FolderEntry]?
     }
-    
+
     struct FolderEntry: Decodable {
         let name: String
         var icon: String?
@@ -70,15 +70,15 @@ struct ProfilesConfig: Decodable {
 @MainActor
 class ProfileManager: ObservableObject {
     static let shared = ProfileManager()
-    
+
     @Published var profiles: [Profile] = []
     @Published var currentProfile: Profile?
-    
+
     /// Default folders when none are defined in config
     static let defaultFolders: [FolderConfig] = [
         FolderConfig(name: "Inbox", icon: "tray", query: "tag:inbox", isSection: false)
     ]
-    
+
     init() {
         loadProfiles()
     }
@@ -135,7 +135,7 @@ class ProfileManager: ObservableObject {
             Log.debug("PROFILE", "Current profile has \(profile.folders.count) folders")
         }
     }
-    
+
     /// Resolved app-wide accent color following the precedence:
     ///   1. currentProfile.color (per-profile override)
     ///   2. settings.accent_color (app-wide default in [settings])
@@ -157,7 +157,7 @@ class ProfileManager: ObservableObject {
         guard let profile = currentProfile else {
             return "tag:inbox"
         }
-        
+
         // Find folder query from config
         let baseQuery: String
         if let folder = profile.folders.first(where: { $0.name.lowercased() == folderName.lowercased() }) {
@@ -166,14 +166,14 @@ class ProfileManager: ObservableObject {
             // Fallback: simple tag query
             baseQuery = "tag:\(folderName.lowercased())"
         }
-        
+
         // Add profile path filter (except for "All" profile)
         return buildQueryWithProfileFilter(baseQuery: baseQuery)
     }
-    
+
     /// Add profile path filter to an arbitrary query (e.g. from the search popup)
     func applyProfileFilter(to query: String) -> String {
-        return buildQueryWithProfileFilter(baseQuery: query)
+        buildQueryWithProfileFilter(baseQuery: query)
     }
 
     /// Add profile path filter to a base query
@@ -181,11 +181,11 @@ class ProfileManager: ObservableObject {
         guard let profile = currentProfile, !profile.isAll else {
             return baseQuery
         }
-        
+
         // Build path filter: (path:work/** OR path:personal/**)
         let pathFilters = profile.accounts.map { "path:\($0)/**" }
         let pathQuery = pathFilters.joined(separator: " OR ")
-        
+
         let query = "(\(baseQuery)) AND (\(pathQuery))"
         Log.debug("PROFILE", "Built query: \(query)")
         return query

--- a/macos/durian/Managers/SearchManager.swift
+++ b/macos/durian/Managers/SearchManager.swift
@@ -20,14 +20,14 @@ class SearchManager: ObservableObject {
     private let profileFilterProvider: (String) -> String
 
     init() {
-        self.backendProvider = { AccountManager.shared.emailBackend }
-        self.profileFilterProvider = { ProfileManager.shared.applyProfileFilter(to: $0) }
+        backendProvider = { AccountManager.shared.emailBackend }
+        profileFilterProvider = { ProfileManager.shared.applyProfileFilter(to: $0) }
     }
 
     /// Test-only initializer for dependency injection
     init(backend: @escaping () -> (any SearchBackend)?, profileFilter: @escaping (String) -> String) {
-        self.backendProvider = backend
-        self.profileFilterProvider = profileFilter
+        backendProvider = backend
+        profileFilterProvider = profileFilter
     }
 
     /// Search emails with debounce

--- a/macos/durian/Managers/SettingsManager.swift
+++ b/macos/durian/Managers/SettingsManager.swift
@@ -1,21 +1,21 @@
-import Foundation
 import Combine
+import Foundation
 
 class SettingsManager: ObservableObject {
     static let shared = SettingsManager()
-    
+
     @Published var settings: AppSettings = AppSettings()
     private var cancellables = Set<AnyCancellable>()
-    
+
     private init() {
         loadSettings()
         setupAutoSave()
     }
-    
+
     private func loadSettings() {
         settings = ConfigManager.shared.getSettings()
     }
-    
+
     private func setupAutoSave() {
         // Auto-save when settings change
         $settings
@@ -26,28 +26,28 @@ class SettingsManager: ObservableObject {
             }
             .store(in: &cancellables)
     }
-    
+
     private func saveSettings() {
         ConfigManager.shared.updateSettings(settings)
     }
-    
+
     // MARK: - Sync Settings (read from [sync] section)
-    
+
     /// Sync settings are read-only from config.pkl [sync] section
     var syncSettings: SyncSettings {
         ConfigManager.shared.getSyncSettings()
     }
-    
+
     /// Whether GUI auto-sync is enabled
     var guiAutoSync: Bool {
         syncSettings.guiAutoSync
     }
-    
+
     /// Quick sync interval in seconds
     var autoFetchInterval: TimeInterval {
         syncSettings.autoFetchInterval
     }
-    
+
     /// Full sync interval in seconds
     var fullSyncInterval: TimeInterval {
         syncSettings.fullSyncInterval
@@ -57,21 +57,21 @@ class SettingsManager: ObservableObject {
     var attachmentCacheSettings: AttachmentCacheSettings {
         syncSettings.attachmentCache
     }
-    
+
     // MARK: - Public API
-    
+
     func resetToDefaults() {
         settings = AppSettings()
         Log.info("SETTINGS", "Reset to defaults")
     }
-    
+
     @MainActor
     func reloadSettings() {
         ConfigManager.shared.reloadConfig()
         settings = ConfigManager.shared.getSettings()
         Log.info("SETTINGS", "Reloaded from config file")
         Log.info("SETTINGS", "Sync - guiAutoSync=\(guiAutoSync), autoFetchInterval=\(autoFetchInterval)s, fullSyncInterval=\(fullSyncInterval)s")
-        
+
         // Restart sync timers with new settings
         SyncManager.shared.restartTimers()
     }

--- a/macos/durian/Managers/SyncManager.swift
+++ b/macos/durian/Managers/SyncManager.swift
@@ -5,8 +5,8 @@
 //  Manages email synchronization via durian CLI
 //
 
-import Foundation
 import Combine
+import Foundation
 import SwiftUI
 import UserNotifications
 
@@ -17,7 +17,7 @@ enum SyncState: Equatable {
     case syncing           // Rotating icon - sync in progress
     case success           // Green - sync completed
     case failed(String)    // Red - sync failed
-    
+
     var color: Color {
         switch self {
         case .idle: return .secondary
@@ -26,14 +26,14 @@ enum SyncState: Equatable {
         case .failed: return .red
         }
     }
-    
+
     var shouldNotify: Bool {
         switch self {
         case .failed: return true
         default: return false
         }
     }
-    
+
     var statusText: String {
         switch self {
         case .idle: return ""
@@ -49,11 +49,11 @@ enum SyncState: Equatable {
 @MainActor
 class SyncManager: ObservableObject {
     static let shared = SyncManager()
-    
+
     // MARK: - Published State
     @Published var syncState: SyncState = .idle
     @Published var lastSyncTime: Date?
-    
+
     // MARK: - Sync Lock (prevents multiple concurrent syncs)
     private var syncLock = false
 
@@ -68,26 +68,26 @@ class SyncManager: ObservableObject {
 
     /// True if a sync is currently in progress
     var isSyncing: Bool { syncLock }
-    
+
     // MARK: - Paths
     private let durianPath: String
-    
+
     // MARK: - Timers
     private var quickSyncTimer: Timer?
     private var fullSyncTimer: Timer?
     private var cancellables = Set<AnyCancellable>()
-    
+
     private init() {
         // Initial path resolution, will be refreshed in runDurianSync if needed
         durianPath = FileManager.default.resolveDurianPath() ?? ""
     }
-    
+
     // MARK: - Setup (call on app start)
-    
+
     func setup() {
         Log.debug("SYNC", "Setting up SyncManager...")
         Log.debug("SYNC", "Config - guiAutoSync=\(SettingsManager.shared.guiAutoSync), autoFetchInterval=\(SettingsManager.shared.autoFetchInterval)s, fullSyncInterval=\(SettingsManager.shared.fullSyncInterval)s")
-        
+
         // Start timers based on config (if online)
         if NetworkMonitor.shared.isConnected {
             startQuickSyncTimer()
@@ -95,7 +95,7 @@ class SyncManager: ObservableObject {
         } else {
             Log.debug("SYNC", "Offline at startup, timers not started")
         }
-        
+
         // Start SSE event stream for real-time new-mail notifications
         let stream = EventStreamClient()
         stream.onNewMail = { [weak self] event in
@@ -144,12 +144,12 @@ class SyncManager: ObservableObject {
                 }
             }
             .store(in: &cancellables)
-        
+
         Log.info("SYNC", "Setup complete")
     }
-    
+
     // MARK: - Timer Management
-    
+
     func startQuickSyncTimer() {
         guard SettingsManager.shared.guiAutoSync else {
             Log.debug("SYNC", "GUI auto-sync disabled, not starting quick sync timer")
@@ -159,10 +159,10 @@ class SyncManager: ObservableObject {
             Log.debug("SYNC", "Offline, not starting quick sync timer")
             return
         }
-        
+
         let interval = SettingsManager.shared.autoFetchInterval
         Log.debug("SYNC", "Starting quick sync timer with interval \(interval)s")
-        
+
         quickSyncTimer?.invalidate()
         quickSyncTimer = Timer.scheduledTimer(withTimeInterval: interval, repeats: true) { [weak self] _ in
             Task { @MainActor in
@@ -179,7 +179,7 @@ class SyncManager: ObservableObject {
             }
         }
     }
-    
+
     func startFullSyncTimer() {
         guard SettingsManager.shared.guiAutoSync else {
             Log.debug("SYNC", "GUI auto-sync disabled, not starting full sync timer")
@@ -189,10 +189,10 @@ class SyncManager: ObservableObject {
             Log.debug("SYNC", "Offline, not starting full sync timer")
             return
         }
-        
+
         let interval = SettingsManager.shared.fullSyncInterval
         Log.debug("SYNC", "Starting full sync timer with interval \(interval)s (\(interval/3600)h)")
-        
+
         fullSyncTimer?.invalidate()
         fullSyncTimer = Timer.scheduledTimer(withTimeInterval: interval, repeats: true) { [weak self] _ in
             Task { @MainActor in
@@ -209,7 +209,7 @@ class SyncManager: ObservableObject {
             }
         }
     }
-    
+
     func stopTimers() {
         Log.debug("SYNC", "Stopping all sync timers")
         quickSyncTimer?.invalidate()
@@ -217,7 +217,7 @@ class SyncManager: ObservableObject {
         fullSyncTimer?.invalidate()
         fullSyncTimer = nil
     }
-    
+
     func restartTimers() {
         Log.debug("SYNC", "Restarting timers with new settings")
         stopTimers()
@@ -226,7 +226,7 @@ class SyncManager: ObservableObject {
             startFullSyncTimer()
         }
     }
-    
+
     // MARK: - Failure Suppression
 
     /// Show banner only after 3+ consecutive failures
@@ -246,7 +246,7 @@ class SyncManager: ObservableObject {
     }
 
     // MARK: - Quick Sync (Cmd+R)
-    
+
     /// Quick sync - syncs current profile's INBOX only
     @discardableResult
     func quickSync() async -> Bool {
@@ -254,10 +254,10 @@ class SyncManager: ObservableObject {
             Log.debug("SYNC", "Quick sync - already syncing, skipping")
             return false
         }
-        
+
         syncLock = true
         defer { syncLock = false }
-        
+
         // Get current profile for targeted sync
         guard let currentProfile = ProfileManager.shared.currentProfile else {
             Log.debug("SYNC", "Quick sync - no current profile, skipping")
@@ -271,7 +271,8 @@ class SyncManager: ObservableObject {
         let accountName: String?
         if !currentProfile.isAll && currentProfile.accounts.count == 1,
            let profileAccount = currentProfile.accounts.first,
-           knownAccountNames.contains(profileAccount.lowercased()) {
+           knownAccountNames.contains(profileAccount.lowercased())
+        {
             accountName = profileAccount
         } else {
             accountName = nil
@@ -280,7 +281,7 @@ class SyncManager: ObservableObject {
         syncState = .syncing
 
         let success = await runDurianSync(account: accountName, mailbox: "INBOX", timeout: 60)
-        
+
         if success {
             Log.info("SYNC", "Quick sync completed successfully")
             recordSyncSuccess()
@@ -311,9 +312,9 @@ class SyncManager: ObservableObject {
 
         return success
     }
-    
+
     // MARK: - Full Sync (Cmd+Shift+R or timer)
-    
+
     /// Full sync - syncs all accounts with longer timeout
     @discardableResult
     func fullSync() async -> Bool {
@@ -321,15 +322,15 @@ class SyncManager: ObservableObject {
             Log.debug("SYNC", "Full sync - already syncing, skipping")
             return false
         }
-        
+
         syncLock = true
         defer { syncLock = false }
-        
+
         Log.debug("SYNC", "Full sync starting (all accounts)")
         // No UI feedback for full sync (runs in background)
-        
+
         let success = await runDurianSync(account: nil, mailbox: nil, timeout: 300)
-        
+
         if success {
             Log.info("SYNC", "Full sync completed successfully")
             recordSyncSuccess()
@@ -346,12 +347,12 @@ class SyncManager: ObservableObject {
                 showFailureBannerIfThresholdMet(title: "Full Sync Failed", message: "Background sync encountered an error.")
             }
         }
-        
+
         return success
     }
-    
+
     // MARK: - Core Sync Logic
-    
+
     /// Run durian sync with optional account and mailbox targeting
     /// - Parameters:
     ///   - account: Specific account name to sync (nil = all accounts)
@@ -363,7 +364,7 @@ class SyncManager: ObservableObject {
             BannerManager.shared.showCritical(title: "Durian CLI Not Found", message: "Install durian to sync emails.")
             return false
         }
-        
+
         // Build command args: sync [account] [mailbox]
         var args = ["sync"]
         if let account = account {
@@ -372,10 +373,10 @@ class SyncManager: ObservableObject {
                 args.append(mailbox)
             }
         }
-        
+
         Log.debug("SYNC", "Running \(resolvedPath) \(args.joined(separator: " ")) (timeout: \(Int(timeout))s)")
         let result = await runCommand(resolvedPath, args: args, timeout: timeout)
-        
+
         if result.success {
             Log.debug("SYNC", "durian sync completed successfully")
             if let output = result.output, !output.isEmpty {
@@ -387,10 +388,10 @@ class SyncManager: ObservableObject {
                 Log.error("SYNC", "Error: \(error)")
             }
         }
-        
+
         return result.success
     }
-    
+
     /// Reload the email list after sync to show new messages
     private func reloadEmailList() async {
         guard let backend = AccountManager.shared.emailBackend else { return }
@@ -427,7 +428,8 @@ class SyncManager: ObservableObject {
         }
         // Per-account notification filter
         if let account = ConfigManager.shared.getAccounts().first(where: { $0.email == event.account }),
-           let notify = account.notifications, !notify {
+           let notify = account.notifications, !notify
+        {
             Log.debug("NOTIFY", "Notifications disabled for account \(event.account), skipping")
             return
         }
@@ -474,7 +476,7 @@ class SyncManager: ObservableObject {
             center.add(request)
         }
     }
-    
+
     // MARK: - Outbox Update Handler
 
     /// Handle an outbox_update SSE event — show banners for sent/failed status.
@@ -509,13 +511,13 @@ class SyncManager: ObservableObject {
     }
 
     // MARK: - Command Execution
-    
+
     private struct CommandResult {
         let success: Bool
         let output: String?
         let error: String?
     }
-    
+
     /// Run a command directly with timeout
     private func runCommand(_ path: String, args: [String], timeout: TimeInterval) async -> CommandResult {
         await withCheckedContinuation { continuation in
@@ -523,7 +525,7 @@ class SyncManager: ObservableObject {
                 let process = Process()
                 process.executableURL = URL(fileURLWithPath: path)
                 process.arguments = args
-                
+
                 // Set up environment with Homebrew paths
                 var env = ProcessInfo.processInfo.environment
                 let homebrewPaths = "/opt/homebrew/bin:/opt/homebrew/sbin:/usr/local/bin"
@@ -533,12 +535,12 @@ class SyncManager: ObservableObject {
                     env["PATH"] = "\(homebrewPaths):/usr/bin:/bin:/usr/sbin:/sbin"
                 }
                 process.environment = env
-                
+
                 let outputPipe = Pipe()
                 let errorPipe = Pipe()
                 process.standardOutput = outputPipe
                 process.standardError = errorPipe
-                
+
                 // Set up timeout
                 var didTimeout = false
                 let timeoutWorkItem = DispatchWorkItem {
@@ -549,14 +551,14 @@ class SyncManager: ObservableObject {
                     }
                 }
                 DispatchQueue.global().asyncAfter(deadline: .now() + timeout, execute: timeoutWorkItem)
-                
+
                 do {
                     try process.run()
                     process.waitUntilExit()
-                    
+
                     // Cancel timeout timer if process completed
                     timeoutWorkItem.cancel()
-                    
+
                     if didTimeout {
                         continuation.resume(returning: CommandResult(
                             success: false,
@@ -565,13 +567,13 @@ class SyncManager: ObservableObject {
                         ))
                         return
                     }
-                    
+
                     let outputData = outputPipe.fileHandleForReading.readDataToEndOfFile()
                     let errorData = errorPipe.fileHandleForReading.readDataToEndOfFile()
-                    
+
                     let output = String(data: outputData, encoding: .utf8)
                     let error = String(data: errorData, encoding: .utf8)
-                    
+
                     let success = process.terminationStatus == 0
                     continuation.resume(returning: CommandResult(success: success, output: output, error: error))
                 } catch {

--- a/macos/durian/Models/AttachmentModels.swift
+++ b/macos/durian/Models/AttachmentModels.swift
@@ -15,7 +15,7 @@ struct IncomingAttachmentMetadata: Identifiable, Codable, Hashable {
     let sizeBytes: Int64
     let disposition: AttachmentDisposition
     let contentId: String?
-    
+
     init(id: UUID = UUID(), section: String, filename: String, mimeType: String, sizeBytes: Int64, disposition: AttachmentDisposition = .attachment, contentId: String? = nil) {
         self.id = id
         self.section = section
@@ -25,11 +25,11 @@ struct IncomingAttachmentMetadata: Identifiable, Codable, Hashable {
         self.disposition = disposition
         self.contentId = contentId
     }
-    
+
     var sizeFormatted: String {
         ByteCountFormatter.string(fromByteCount: sizeBytes, countStyle: .file)
     }
-    
+
     var icon: String {
         if mimeType.hasPrefix("image/") {
             return "photo"
@@ -51,9 +51,9 @@ struct IncomingAttachmentMetadata: Identifiable, Codable, Hashable {
             return "doc"
         }
     }
-    
+
     var isInlineImage: Bool {
-        return disposition == .inline && mimeType.hasPrefix("image/")
+        disposition == .inline && mimeType.hasPrefix("image/")
     }
 }
 
@@ -90,7 +90,7 @@ enum AttachmentError: Error, LocalizedError {
     case circuitBreakerOpen
     case downloadTimeout
     case corruptedData
-    
+
     var errorDescription: String? {
         switch self {
         case .failedToExtract:

--- a/macos/durian/Models/EmailComposition.swift
+++ b/macos/durian/Models/EmailComposition.swift
@@ -77,8 +77,8 @@ struct EmailDraft: Identifiable, Codable, Equatable {
         self.quotedIsHTML = quotedIsHTML
         self.htmlSignature = htmlSignature
         self.htmlBody = htmlBody
-        self.createdAt = Date()
-        self.modifiedAt = Date()
+        createdAt = Date()
+        modifiedAt = Date()
     }
 
     mutating func updateModifiedDate() {
@@ -86,11 +86,11 @@ struct EmailDraft: Identifiable, Codable, Equatable {
     }
 
     var hasRecipients: Bool {
-        return !to.isEmpty || !cc.isEmpty || !bcc.isEmpty
+        !to.isEmpty || !cc.isEmpty || !bcc.isEmpty
     }
 
     var isValid: Bool {
-        return hasRecipients && !subject.isEmpty
+        hasRecipients && !subject.isEmpty
     }
 
     /// Whether the user has typed any actual content (excludes signature, quoted content).
@@ -109,7 +109,7 @@ struct EmailDraft: Identifiable, Codable, Equatable {
     }
 
     var hasAttachments: Bool {
-        return !attachments.isEmpty
+        !attachments.isEmpty
     }
 
     var totalAttachmentSize: Int64 {
@@ -191,7 +191,8 @@ enum EmailHelper {
         // Standard format: "Name <email>"
         if let start = trimmed.firstIndex(of: "<"),
            let end = trimmed.firstIndex(of: ">"),
-           start < end {
+           start < end
+        {
             let email = String(trimmed[trimmed.index(after: start)..<end])
             if email.contains("@") {
                 return email.trimmingCharacters(in: .whitespaces)
@@ -209,6 +210,6 @@ enum EmailHelper {
 
     /// Validate all recipients and return list of invalid emails
     static func validateRecipients(_ recipients: [String]) -> [String] {
-        return recipients.filter { !isValidEmail($0) }
+        recipients.filter { !isValidEmail($0) }
     }
 }

--- a/macos/durian/Models/EmailDraftFactory.swift
+++ b/macos/durian/Models/EmailDraftFactory.swift
@@ -34,7 +34,7 @@ extension EmailDraft {
     /// Returns the message ID of the message that should be quoted in a reply.
     /// Used to lazy-load the original (unstripped) body before creating the draft.
     static func replyTargetMessageId(for message: MailMessage, fromAccount: String) -> String? {
-        return findReplyTarget(message: message, fromAccount: fromAccount).bodySourceId
+        findReplyTarget(message: message, fromAccount: fromAccount).bodySourceId
     }
 
     /// Create a reply draft from a mail message
@@ -45,7 +45,8 @@ extension EmailDraft {
     ///     When provided, used for quoting instead of the stripped thread body.
     /// - Returns: A new EmailDraft configured as a reply
     static func createReply(from message: MailMessage, fromAccount: String,
-                            originalBody: (body: String, html: String?)? = nil) -> EmailDraft {
+                            originalBody: (body: String, html: String?)? = nil) -> EmailDraft
+    {
         let target = findReplyTarget(message: message, fromAccount: fromAccount)
 
         // Fallback if target.from has no email (e.g. cache restored without headers)
@@ -100,7 +101,8 @@ extension EmailDraft {
     ///   - fromAccount: The email address to send from
     /// - Returns: A new EmailDraft configured as a reply-all
     static func createReplyAll(from message: MailMessage, fromAccount: String,
-                               originalBody: (body: String, html: String?)? = nil) -> EmailDraft {
+                               originalBody: (body: String, html: String?)? = nil) -> EmailDraft
+    {
         var draft = createReply(from: message, fromAccount: fromAccount, originalBody: originalBody)
         let target = findReplyTarget(message: message, fromAccount: fromAccount)
 
@@ -324,7 +326,8 @@ extension EmailDraft {
         // Standard format: "Name <email>"
         if let start = trimmed.firstIndex(of: "<"),
            let end = trimmed.firstIndex(of: ">"),
-           start < end {
+           start < end
+        {
             let email = String(trimmed[trimmed.index(after: start)..<end])
             // Validate it looks like an email
             if email.contains("@") {
@@ -404,7 +407,7 @@ extension EmailDraft {
 
     /// Quote body HTML for reply (preserves formatting)
     private static func quoteBodyHTML(_ html: String, from: String, date: String) -> String {
-        return """
+        """
         <div style="color: #555;">
         <p style="font-size: 12px; color: #888; margin-bottom: 8px;">On \(escapeHTML(date)), \(escapeHTML(from)) wrote:</p>
         <div style="border-left: 2px solid #ccc; padding-left: 10px; margin-left: 5px;">
@@ -420,7 +423,7 @@ extension EmailDraft {
     private static func buildForwardThread(_ messages: [ThreadMessage]) -> String {
         // Thread messages arrive newest-first from API; keep that order
         // in forwards so the most recent reply is at the top.
-        return messages.map { msg in
+        messages.map { msg in
             var part = "---------- Forwarded message ----------\n"
             part += "From: \(msg.from)\n"
             if let to = msg.to { part += "To: \(to)\n" }
@@ -495,7 +498,7 @@ extension EmailDraft {
 
     /// Escape HTML special characters
     private static func escapeHTML(_ string: String) -> String {
-        return string
+        string
             .replacingOccurrences(of: "&", with: "&amp;")
             .replacingOccurrences(of: "<", with: "&lt;")
             .replacingOccurrences(of: ">", with: "&gt;")

--- a/macos/durian/Models/Mail.swift
+++ b/macos/durian/Models/Mail.swift
@@ -51,7 +51,7 @@ enum EmailBodyState: Equatable, Hashable {
     case loading
     case loaded(body: String, attributedBody: NSAttributedString?)
     case failed(message: String)
-    
+
     var displayBody: String {
         switch self {
         case .notLoaded:
@@ -64,7 +64,7 @@ enum EmailBodyState: Equatable, Hashable {
             return "Failed to load: \(message)"
         }
     }
-    
+
     var attributedBody: NSAttributedString? {
         switch self {
         case .loaded(_, let attributed):
@@ -73,7 +73,7 @@ enum EmailBodyState: Equatable, Hashable {
             return nil
         }
     }
-    
+
     func hash(into hasher: inout Hasher) {
         switch self {
         case .notLoaded:
@@ -88,7 +88,7 @@ enum EmailBodyState: Equatable, Hashable {
             hasher.combine(message)
         }
     }
-    
+
     static func == (lhs: EmailBodyState, rhs: EmailBodyState) -> Bool {
         switch (lhs, rhs) {
         case (.notLoaded, .notLoaded), (.loading, .loading):
@@ -115,82 +115,82 @@ struct MailFolder: Identifiable, Hashable {
     let isSpecial: Bool  // true for inbox, sent, drafts, trash
     let specialType: SpecialFolderType?
     let isSection: Bool  // true for section headers (no query, not clickable)
-    
+
     enum SpecialFolderType: String {
         case inbox, sent, drafts, trash, archive, junk
     }
-    
+
     /// Create a section header (non-clickable divider in sidebar)
     init(section title: String) {
-        self.id = "section:\(title)"
-        self.name = title
-        self.displayName = title
-        self.icon = nil
-        self.accountId = "default"
-        self.isSpecial = false
-        self.specialType = nil
-        self.isSection = true
+        id = "section:\(title)"
+        name = title
+        displayName = title
+        icon = nil
+        accountId = "default"
+        isSpecial = false
+        specialType = nil
+        isSection = true
     }
 
     /// Create for tag-based folder
     init(tag: String, icon: String) {
-        self.id = "tag:\(tag)"
-        self.name = tag
-        self.displayName = tag.capitalized
+        id = "tag:\(tag)"
+        name = tag
+        displayName = tag.capitalized
         self.icon = icon
-        self.accountId = "default"
-        self.isSection = false
+        accountId = "default"
+        isSection = false
 
         switch tag {
         case "inbox":
-            self.isSpecial = true
-            self.specialType = .inbox
+            isSpecial = true
+            specialType = .inbox
         case "sent":
-            self.isSpecial = true
-            self.specialType = .sent
+            isSpecial = true
+            specialType = .sent
         case "draft", "drafts":
-            self.isSpecial = true
-            self.specialType = .drafts
+            isSpecial = true
+            specialType = .drafts
         case "deleted", "trash":
-            self.isSpecial = true
-            self.specialType = .trash
+            isSpecial = true
+            specialType = .trash
         case "archive":
-            self.isSpecial = true
-            self.specialType = .archive
+            isSpecial = true
+            specialType = .archive
         default:
-            self.isSpecial = false
-            self.specialType = nil
+            isSpecial = false
+            specialType = nil
         }
     }
-    
+
     /// Create from profile folder config (name, displayName, icon)
     init(name: String, displayName: String, icon: String?) {
-        self.id = "folder:\(name)"
+        id = "folder:\(name)"
         self.name = name
         self.displayName = displayName
         self.icon = icon
-        self.accountId = "default"
-        self.isSection = false
+        accountId = "default"
+        isSection = false
 
         switch name.lowercased() {
         case "inbox":
-            self.isSpecial = true
-            self.specialType = .inbox
+            isSpecial = true
+            specialType = .inbox
         case "sent":
-            self.isSpecial = true
-            self.specialType = .sent
+            isSpecial = true
+            specialType = .sent
         case "draft", "drafts":
-            self.isSpecial = true
-            self.specialType = .drafts
+            isSpecial = true
+            specialType = .drafts
         case "deleted", "trash":
-            self.isSpecial = true
-            self.specialType = .trash
+            isSpecial = true
+            specialType = .trash
         case "archive":
-            self.isSpecial = true
-            self.specialType = .archive
+            isSpecial = true
+            specialType = .archive
         default:
-            self.isSpecial = false
-            self.specialType = nil
+            isSpecial = false
+            specialType = nil
         }
     }
 }
@@ -213,10 +213,10 @@ struct MailMessage: Identifiable, Hashable {
     var hasAttachment: Bool
     var bodyState: EmailBodyState
     var incomingAttachments: [IncomingAttachmentMetadata]
-    
+
     // Thread messages (loaded from CLI show command)
     var threadMessages: [ThreadMessage]?
-    
+
     // Preview text from search enrichment (separate from bodyState cache)
     var previewText: String?
 
@@ -225,32 +225,32 @@ struct MailMessage: Identifiable, Hashable {
     var messageId: String?
     var inReplyTo: String?
     var references: String?
-    
+
     /// Create from search result
     init(threadId: String, subject: String, from: String, to: String? = nil, date: String, timestamp: Int, tags: String) {
-        self.id = threadId
+        id = threadId
         self.subject = subject
         self.from = from
         self.to = to
-        self.cc = nil
+        cc = nil
         self.date = date
         self.timestamp = timestamp
         self.tags = tags
-        self.body = nil
-        self.htmlBody = nil
-        self.attributedBody = nil
+        body = nil
+        htmlBody = nil
+        attributedBody = nil
         let tagSet = Set(tags.split(separator: ","))
-        self.isRead = !tagSet.contains("unread")
-        self.isPinned = tagSet.contains("flagged")
-        self.hasAttachment = tagSet.contains("attachment")
-        self.bodyState = .notLoaded
-        self.incomingAttachments = []
-        self.threadMessages = nil
-        self.messageId = nil
-        self.inReplyTo = nil
-        self.references = nil
+        isRead = !tagSet.contains("unread")
+        isPinned = tagSet.contains("flagged")
+        hasAttachment = tagSet.contains("attachment")
+        bodyState = .notLoaded
+        incomingAttachments = []
+        threadMessages = nil
+        messageId = nil
+        inReplyTo = nil
+        references = nil
     }
-    
+
     var isDraft: Bool {
         guard let tags = tags else { return false }
         return tags.split(separator: ",").contains("draft")
@@ -278,7 +278,7 @@ struct MailMessage: Identifiable, Hashable {
             return nil
         }
     }
-    
+
     // Hashable
     func hash(into hasher: inout Hasher) {
         hasher.combine(id)

--- a/macos/durian/Network/EmailBackend.swift
+++ b/macos/durian/Network/EmailBackend.swift
@@ -6,9 +6,9 @@
 //  Email backend using durian CLI HTTP server
 //
 
-import Foundation
-import Combine
 import AppKit
+import Combine
+import Foundation
 
 // MARK: - JSON Models (unchanged, but DurianRequest is no longer needed)
 
@@ -132,7 +132,7 @@ class EmailBackend: ObservableObject, SearchBackend, OutboxBackend {
     // Internal state
     private var currentFolder = "inbox"
     private var currentQuery = "tag:inbox"
-    
+
     // Cancellation support for prefetch and active search
     private var prefetchTask: Task<Void, Never>?
     private var searchTask: Task<Void, Never>?
@@ -275,7 +275,7 @@ class EmailBackend: ObservableObject, SearchBackend, OutboxBackend {
     }
 
     // MARK: - Folder/Tag Selection (unchanged)
-    
+
     func selectFolder(_ name: String) async {
         shouldCancelPrefetch = true
         prefetchTask?.cancel()
@@ -295,7 +295,7 @@ class EmailBackend: ObservableObject, SearchBackend, OutboxBackend {
     // MARK: - Generic HTTP Request Function
 
     private func request<T: Decodable>(endpoint: String, method: String = "GET") async -> T? {
-        return await performRequest(endpoint: endpoint, method: method, bodyData: nil)
+        await performRequest(endpoint: endpoint, method: method, bodyData: nil)
     }
 
     private func request<T: Decodable>(endpoint: String, method: String = "GET", body: some Encodable) async -> T? {
@@ -382,7 +382,8 @@ class EmailBackend: ObservableObject, SearchBackend, OutboxBackend {
 
         guard let thread = response?.thread else {
             if let index = emails.firstIndex(where: { $0.id == id }) {
-                 if isPrefetch && (shouldCancelPrefetch || Task.isCancelled) {
+                 if isPrefetch && (shouldCancelPrefetch || Task.isCancelled)
+                {
                     emails[index].bodyState = .notLoaded
                     Log.debug("BACKEND", "Prefetch cancelled for \(id)")
                 } else {
@@ -416,7 +417,7 @@ class EmailBackend: ObservableObject, SearchBackend, OutboxBackend {
         Log.info("BACKEND", "Loaded thread \(id) with \(thread.messages.count) messages (standalone)")
         return mail
     }
-    
+
     /// Shared search pipeline: build URL, request, parse results, apply enrichment.
     /// Returns nil on request failure, empty array on no results.
     private func performSearch(query: String, limit: Int, enrich: Int = 50) async -> [MailMessage]? {
@@ -595,7 +596,8 @@ class EmailBackend: ObservableObject, SearchBackend, OutboxBackend {
         let filename: String
         if let disposition = httpResponse.value(forHTTPHeaderField: "Content-Disposition"),
            let range = disposition.range(of: "filename=\""),
-           let endRange = disposition[range.upperBound...].range(of: "\"") {
+           let endRange = disposition[range.upperBound...].range(of: "\"")
+        {
             filename = String(disposition[range.upperBound..<endRange.lowerBound])
         } else {
             filename = "attachment"
@@ -687,7 +689,7 @@ class EmailBackend: ObservableObject, SearchBackend, OutboxBackend {
 
     // MARK: - Unchanged methods (markAsRead, togglePin, etc.)
     // These methods use `tag` internally and don't need to be changed.
-    
+
     func markAsRead(id: String) async throws {
         try await tag(query: "thread:\(id)", tags: "-unread")
         if let index = emails.firstIndex(where: { $0.id == id }) {
@@ -735,7 +737,7 @@ class EmailBackend: ObservableObject, SearchBackend, OutboxBackend {
 
     func modifyTags(id: String, add: [String], remove: [String]) async throws {
         let ops = add.map { "+\($0)" } + remove.map { "-\($0)" }
-        try await self.tag(query: "thread:\(id)", tags: ops.joined(separator: " "))
+        try await tag(query: "thread:\(id)", tags: ops.joined(separator: " "))
         await reload()
     }
 
@@ -744,7 +746,7 @@ class EmailBackend: ObservableObject, SearchBackend, OutboxBackend {
         emails.removeAll { $0.id == id }
         await reload()
     }
-    
+
     func reload() async {
         currentQuery = ProfileManager.shared.buildQuery(folderName: currentFolder)
         await search(currentQuery)
@@ -796,7 +798,7 @@ class EmailBackend: ObservableObject, SearchBackend, OutboxBackend {
     }
 
     // MARK: - Unchanged Caching and Prefetching Logic
-    
+
     private func cacheThread(id: String, messages: [ThreadMessage]) {
         threadCache[id] = CachedThread(messages: messages, timestamp: Date())
         if threadCache.count > maxCacheSize {
@@ -810,7 +812,7 @@ class EmailBackend: ObservableObject, SearchBackend, OutboxBackend {
             Log.debug("BACKEND", "Cache cleanup: removed \(keysToRemove.count) old entries")
         }
     }
-    
+
     private func restoreCachedThreads() {
         var restoredCount = 0
         for (index, email) in emails.enumerated() {
@@ -859,7 +861,7 @@ class EmailBackend: ObservableObject, SearchBackend, OutboxBackend {
             Log.debug("BACKEND", "Restored \(restoredCount) threads from cache")
         }
     }
-    
+
     private func prefetchInitialBodiesInternal(count: Int = 5) async {
         let emailsToFetch = emails.prefix(count).filter { email in
             if case .notLoaded = email.bodyState { return true }
@@ -896,11 +898,11 @@ class EmailBackend: ObservableObject, SearchBackend, OutboxBackend {
             try? await Task.sleep(for: .milliseconds(200))
             guard !Task.isCancelled, let self else { return }
 
-            guard let cursorIndex = self.emails.firstIndex(where: { $0.id == cursorId }) else {
+            guard let cursorIndex = emails.firstIndex(where: { $0.id == cursorId }) else {
                 return
             }
 
-            let toFetch = self.selectEmailsAroundCursor(
+            let toFetch = selectEmailsAroundCursor(
                 cursorIndex: cursorIndex,
                 before: before,
                 after: after

--- a/macos/durian/Network/MailBackendProtocol.swift
+++ b/macos/durian/Network/MailBackendProtocol.swift
@@ -5,8 +5,8 @@
 //  Abstract protocol for mail backends
 //
 
-import Foundation
 import Combine
+import Foundation
 
 // MARK: - Mail Backend Protocol
 

--- a/macos/durian/Utilities/AddressUtils.swift
+++ b/macos/durian/Utilities/AddressUtils.swift
@@ -66,7 +66,8 @@ enum AddressUtils {
     private static func stripOuterQuotes(_ s: String) -> String {
         var r = s
         if (r.hasPrefix("\"") && r.hasSuffix("\"")) ||
-           (r.hasPrefix("'") && r.hasSuffix("'")) {
+           (r.hasPrefix("'") && r.hasSuffix("'"))
+        {
             r = String(r.dropFirst().dropLast())
         }
         return r.trimmingCharacters(in: .whitespaces)

--- a/macos/durian/Utilities/ColorExtensions.swift
+++ b/macos/durian/Utilities/ColorExtensions.swift
@@ -5,8 +5,8 @@
 //  Design system colors from Figma + hex initializer
 //
 
-import SwiftUI
 import AppKit
+import SwiftUI
 
 // MARK: - Hex Initializer
 

--- a/macos/durian/Utilities/FileManager+Extensions.swift
+++ b/macos/durian/Utilities/FileManager+Extensions.swift
@@ -12,24 +12,24 @@ extension FileManager {
 
     func resolveDurianPath() -> String? {
         // 1. Check ~/.local/bin/durian
-        let homeURL = self.homeDirectoryForCurrentUser
+        let homeURL = homeDirectoryForCurrentUser
         let localBinURL = homeURL.appendingPathComponent(".local/bin/durian")
-        if self.fileExists(atPath: localBinURL.path) {
+        if fileExists(atPath: localBinURL.path) {
             return localBinURL.path
         }
-        
+
         // 2. Check standard Homebrew path
         let brewPath = "/opt/homebrew/bin/durian"
-        if self.fileExists(atPath: brewPath) {
+        if fileExists(atPath: brewPath) {
             return brewPath
         }
-        
+
         // 3. Fallback to /usr/local/bin
         let usrLocalPath = "/usr/local/bin/durian"
-        if self.fileExists(atPath: usrLocalPath) {
+        if fileExists(atPath: usrLocalPath) {
             return usrLocalPath
         }
-        
+
         return nil
     }
 }

--- a/macos/durian/Utilities/KeychainHelper.swift
+++ b/macos/durian/Utilities/KeychainHelper.swift
@@ -17,13 +17,14 @@ struct KeychainHelper {
             kSecReturnData as String: true,
             kSecMatchLimit as String: kSecMatchLimitOne
         ]
-        
+
         var result: AnyObject?
         let status = SecItemCopyMatching(query as CFDictionary, &result)
-        
+
         if status == errSecSuccess,
            let data = result as? Data,
-           let password = String(data: data, encoding: .utf8) {
+           let password = String(data: data, encoding: .utf8)
+        {
             return password
         } else {
             Log.error("KEYCHAIN", "Failed to retrieve password from keychain for \(account): \(status)")

--- a/macos/durian/Utilities/QuickLookPreview.swift
+++ b/macos/durian/Utilities/QuickLookPreview.swift
@@ -5,58 +5,58 @@
 //  QuickLook preview support for email attachments
 //
 
-import Foundation
 import AppKit
+import Foundation
 import Quartz
 
 class QuickLookPreviewController: NSObject, QLPreviewPanelDataSource, QLPreviewPanelDelegate {
     var attachments: [EmailAttachment] = []
     var currentIndex: Int = 0
     private var tempURLs: [URL] = []
-    
+
     override init() {
         super.init()
     }
-    
+
     deinit {
         cleanupTempFiles()
     }
-    
+
     func showPreview(for attachments: [EmailAttachment], startingAt index: Int) {
         Log.debug("QUICKLOOK", "showPreview called with \(attachments.count) attachments, index: \(index)")
-        
+
         self.attachments = attachments
-        self.currentIndex = index
-        
+        currentIndex = index
+
         cleanupTempFiles()
         tempURLs = createTempFiles()
-        
+
         Log.debug("QUICKLOOK", "Created \(tempURLs.count) temp files")
-        
+
         guard let panel = QLPreviewPanel.shared() else {
             Log.error("QUICKLOOK", "Failed to get shared preview panel")
             return
         }
-        
+
         Log.debug("QUICKLOOK", "Got preview panel, setting datasource and delegate")
-        
+
         panel.dataSource = self
         panel.delegate = self
         panel.currentPreviewItemIndex = index
-        
+
         Log.debug("QUICKLOOK", "Making panel key and ordering front")
         panel.makeKeyAndOrderFront(nil)
-        
+
         Log.debug("QUICKLOOK", "Panel shown, isVisible: \(panel.isVisible)")
     }
-    
+
     private func createTempFiles() -> [URL] {
         let tempDir = FileManager.default.temporaryDirectory
         var urls: [URL] = []
-        
+
         for attachment in attachments {
             let tempURL = tempDir.appendingPathComponent(attachment.filename)
-            
+
             do {
                 try attachment.data.write(to: tempURL)
                 urls.append(tempURL)
@@ -65,28 +65,28 @@ class QuickLookPreviewController: NSObject, QLPreviewPanelDataSource, QLPreviewP
                 Log.error("QUICKLOOK", "Failed to write temp file: \(error)")
             }
         }
-        
+
         return urls
     }
-    
+
     private func cleanupTempFiles() {
         for url in tempURLs {
             try? FileManager.default.removeItem(at: url)
         }
         tempURLs.removeAll()
     }
-    
+
     func numberOfPreviewItems(in panel: QLPreviewPanel!) -> Int {
-        return attachments.count
+        attachments.count
     }
-    
+
     func previewPanel(_ panel: QLPreviewPanel!, previewItemAt index: Int) -> QLPreviewItem! {
         guard index >= 0 && index < tempURLs.count else {
             return nil
         }
         return tempURLs[index] as QLPreviewItem
     }
-    
+
     func previewPanel(_ panel: QLPreviewPanel!, handle event: NSEvent!) -> Bool {
         if event.type == .keyDown {
             if event.keyCode == 53 {
@@ -101,14 +101,14 @@ class QuickLookPreviewController: NSObject, QLPreviewPanelDataSource, QLPreviewP
 class QuickLookManager {
     static let shared = QuickLookManager()
     private var controller: QuickLookPreviewController?
-    
+
     private init() {}
-    
+
     func showPreview(for attachments: [EmailAttachment], startingAt index: Int) {
         controller = QuickLookPreviewController()
         controller?.showPreview(for: attachments, startingAt: index)
     }
-    
+
     func closePreview() {
         QLPreviewPanel.shared()?.close()
         controller = nil

--- a/macos/durian/Utilities/ScrollViewFinder.swift
+++ b/macos/durian/Utilities/ScrollViewFinder.swift
@@ -13,7 +13,7 @@ struct ScrollViewFinder: NSViewRepresentable {
     func makeNSView(context: Context) -> NSView {
         let view = NSView()
         DispatchQueue.main.async {
-            self.scrollView = view.enclosingScrollView
+            scrollView = view.enclosingScrollView
         }
         return view
     }
@@ -21,7 +21,7 @@ struct ScrollViewFinder: NSViewRepresentable {
     func updateNSView(_ nsView: NSView, context: Context) {
         if scrollView == nil {
             DispatchQueue.main.async {
-                self.scrollView = nsView.enclosingScrollView
+                scrollView = nsView.enclosingScrollView
             }
         }
     }

--- a/macos/durian/Utilities/ScrollViewModifiers.swift
+++ b/macos/durian/Utilities/ScrollViewModifiers.swift
@@ -1,12 +1,12 @@
-import SwiftUI
 import AppKit
+import SwiftUI
 
 // MARK: - Overlay Scrollbars Modifier
 
 extension View {
     /// Makes ScrollView use thin overlay-style scrollbars (like modern macOS apps)
     func overlayScrollbars() -> some View {
-        self.background(ScrollViewStyleConfigurator())
+        background(ScrollViewStyleConfigurator())
     }
 }
 
@@ -22,9 +22,9 @@ private struct ScrollViewStyleConfigurator: NSViewRepresentable {
         }
         return view
     }
-    
+
     func updateNSView(_ nsView: NSView, context: Context) {}
-    
+
     /// Traverses up the view hierarchy to find the enclosing NSScrollView
     private func findScrollView(from view: NSView) -> NSScrollView? {
         var current: NSView? = view

--- a/macos/durian/Utilities/WindowCloseGuard.swift
+++ b/macos/durian/Utilities/WindowCloseGuard.swift
@@ -6,8 +6,8 @@
 //  async save before dismissal.
 //
 
-import SwiftUI
 import AppKit
+import SwiftUI
 
 struct WindowCloseGuard: NSViewRepresentable {
     @Binding var allowClose: Bool
@@ -50,15 +50,15 @@ struct WindowCloseGuard: NSViewRepresentable {
             guard let window = view.window else { return }
             self.window = window
             context.coordinator.originalDelegate = window.delegate
-            context.coordinator.allowClose = self.allowClose
-            context.coordinator.onCloseAttempt = self.onCloseAttempt
+            context.coordinator.allowClose = allowClose
+            context.coordinator.onCloseAttempt = onCloseAttempt
             window.delegate = context.coordinator
         }
         return view
     }
 
     func updateNSView(_ nsView: NSView, context: Context) {
-        context.coordinator.allowClose = self.allowClose
-        context.coordinator.onCloseAttempt = self.onCloseAttempt
+        context.coordinator.allowClose = allowClose
+        context.coordinator.onCloseAttempt = onCloseAttempt
     }
 }

--- a/macos/durian/Views/AvatarView.swift
+++ b/macos/durian/Views/AvatarView.swift
@@ -11,14 +11,14 @@ struct AvatarView: View {
     let name: String
     var email: String? = nil  // Optional email for avatar lookup
     var size: CGFloat = 36
-    
+
     @State private var loadedImage: NSImage? = nil
-    
+
     private static let avatarColors: [Color] = [
         .red, .orange, .yellow, .green, .mint, .teal,
         .cyan, .blue, .indigo, .purple, .pink, .brown
     ]
-    
+
     var body: some View {
         ZStack {
             if let image = loadedImage {
@@ -31,7 +31,7 @@ struct AvatarView: View {
                 // Fallback: Initials with hash-based color
                 Circle()
                     .fill(colorForName)
-                
+
                 Text(initials)
                     .font(.system(size: size * 0.4, weight: .semibold))
                     .foregroundColor(.white)
@@ -44,19 +44,19 @@ struct AvatarView: View {
             await loadAvatarImage()
         }
     }
-    
+
     // MARK: - Avatar Loading
-    
+
     private func loadAvatarImage() async {
         guard let email = email, !email.isEmpty else { return }
-        
+
         // Request 2x size for retina displays
         let requestSize = Int(size * 2)
         loadedImage = await AvatarManager.shared.loadAvatar(for: email, size: requestSize)
     }
-    
+
     // MARK: - Initials (Fallback)
-    
+
     /// Extract initials from name (max 2 characters)
     /// "Julian Schenker" → "JS"
     /// "Atlassian Home" → "AH"
@@ -64,7 +64,7 @@ struct AvatarView: View {
     private var initials: String {
         let cleanName = extractDisplayName(from: name)
         let words = cleanName.split(separator: " ")
-        
+
         if words.count >= 2 {
             // First letter of first two words
             let first = words[0].prefix(1).uppercased()
@@ -77,7 +77,7 @@ struct AvatarView: View {
             return "?"
         }
     }
-    
+
     /// Get consistent color based on name hash
     private var colorForName: Color {
         let cleanName = extractDisplayName(from: name).lowercased()
@@ -88,7 +88,7 @@ struct AvatarView: View {
         let index = abs(hash) % Self.avatarColors.count
         return Self.avatarColors[index]
     }
-    
+
     private func extractDisplayName(from: String) -> String {
         AddressUtils.extractName(from: from)
     }

--- a/macos/durian/Views/BannerView.swift
+++ b/macos/durian/Views/BannerView.swift
@@ -5,8 +5,8 @@
 //  Banner view for displaying user-facing messages
 //
 
-import SwiftUI
 import AppKit
+import SwiftUI
 
 struct BannerView: View {
     let banner: BannerMessage

--- a/macos/durian/Views/ComposeForm+Contacts.swift
+++ b/macos/durian/Views/ComposeForm+Contacts.swift
@@ -6,8 +6,8 @@
 //  Split out of ComposeForm.swift to keep the main form file under 800 lines.
 //
 
-import SwiftUI
 import AppKit
+import SwiftUI
 
 extension ComposeForm {
     // MARK: - Contact Suggestion Handling

--- a/macos/durian/Views/ComposeForm.swift
+++ b/macos/durian/Views/ComposeForm.swift
@@ -5,9 +5,9 @@
 //  Email composition form
 //
 
-import SwiftUI
 import AppKit
 import Combine
+import SwiftUI
 
 extension Notification.Name {
     static let vimSearchSubmit = Notification.Name("vimSearchSubmit")
@@ -16,14 +16,14 @@ import UniformTypeIdentifiers
 
 struct ComposeForm: View {
     @StateObject private var sendingManager = EmailSendingManager.shared
-    
+
     let accounts: [MailAccount]
     let existingDraft: EmailDraft?
     @Binding var triggerSend: Bool
     @Binding var showingFilePicker: Bool
     @Binding var currentDraft: EmailDraft?
     let onDismiss: () -> Void
-    
+
     @State var draft: EmailDraft
     @State private var showError = false
     @State private var errorMessage = ""
@@ -61,24 +61,24 @@ struct ComposeForm: View {
     private let maxAttachmentSize: Int64 = 25_000_000
     private let maxTotalSize: Int64 = 50_000_000
     private let maxAttachments: Int = 10
-    
+
     // MARK: - Colors
 
     private let labelColor = Color.Detail.textSecondary
     private let placeholderColor = Color.Detail.textPlaceholder
     private let textColor = Color.Detail.textPrimary
-    
+
     init(accounts: [MailAccount], existingDraft: EmailDraft? = nil, triggerSend: Binding<Bool>, showingFilePicker: Binding<Bool>, currentDraft: Binding<EmailDraft?>, onDismiss: @escaping () -> Void) {
         self.accounts = accounts
         self.existingDraft = existingDraft
-        self._triggerSend = triggerSend
-        self._showingFilePicker = showingFilePicker
-        self._currentDraft = currentDraft
+        _triggerSend = triggerSend
+        _showingFilePicker = showingFilePicker
+        _currentDraft = currentDraft
         self.onDismiss = onDismiss
-        self.signatures = ConfigManager.shared.getSignatures()
-        
+        signatures = ConfigManager.shared.getSignatures()
+
         let defaultAccount = accounts.first?.email ?? ""
-        
+
         if let existing = existingDraft {
             _draft = State(initialValue: existing)
             _selectedSignature = State(initialValue: nil)
@@ -86,18 +86,18 @@ struct ComposeForm: View {
             _showCcBcc = State(initialValue: !existing.cc.isEmpty || !existing.bcc.isEmpty)
         } else {
             _draft = State(initialValue: EmailDraft(from: defaultAccount))
-            
+
             let account = accounts.first { $0.email == defaultAccount }
             _selectedSignature = State(initialValue: account?.defaultSignature)
             _showCcBcc = State(initialValue: false)
         }
     }
-    
+
     var body: some View {
         VStack(spacing: 0) {
             // Form Area
             formSection
-            
+
             // Formatting Toolbar
             ComposeToolbar(
                 onFormat: { command in
@@ -118,15 +118,15 @@ struct ComposeForm: View {
                 currentAlignment: currentAlignment,
                 vimMode: vimMode
             )
-            
+
             // Message Editor
             messageEditor
-            
+
             // Attachments (if any)
             if !draft.attachments.isEmpty {
                 attachmentsScrollView
             }
-            
+
         }
         .navigationTitle("")
         .fileImporter(
@@ -179,42 +179,42 @@ struct ComposeForm: View {
             }
         }
     }
-    
+
     // MARK: - Form Section
-    
+
     private var formSection: some View {
         VStack(spacing: 0) {
             // To Row
             toRow
-            
+
             // Cc/Bcc Rows (expandable)
             if showCcBcc {
                 ccRow
                 bccRow
             }
-            
+
             // From Row
             fromRow
-            
+
             // Subject Row
             subjectRow
-            
+
             Divider()
                 .padding(.horizontal, 24)
         }
         .padding(.top, 16)
         .padding(.bottom, 8)
     }
-    
+
     // MARK: - To Row
-    
+
     private var toRow: some View {
         HStack(alignment: .center, spacing: 12) {
             Text("To:")
                 .font(.system(size: 14, weight: .medium))
                 .foregroundColor(labelColor)
                 .frame(width: 50, alignment: .leading)
-            
+
             TokenField(
                 tokens: $draft.to,
                 focusedField: $focusedField,
@@ -227,7 +227,7 @@ struct ComposeForm: View {
                     handleSuggestionKeyCommand(command)
                 }
             )
-            
+
             // Expand Cc/Bcc Button
             Button(action: {
                 withAnimation(.easeInOut(duration: 0.2)) {
@@ -246,16 +246,16 @@ struct ComposeForm: View {
         .padding(.horizontal, 24)
         .padding(.vertical, 10)
     }
-    
+
     // MARK: - Cc Row
-    
+
     private var ccRow: some View {
         HStack(alignment: .center, spacing: 12) {
             Text("Cc:")
                 .font(.system(size: 14, weight: .medium))
                 .foregroundColor(labelColor)
                 .frame(width: 50, alignment: .leading)
-            
+
             TokenField(
                 tokens: $draft.cc,
                 focusedField: $focusedField,
@@ -268,7 +268,7 @@ struct ComposeForm: View {
                     handleSuggestionKeyCommand(command)
                 }
             )
-            
+
             // Spacer to align with To row
             Color.clear
                 .frame(width: 24, height: 24)
@@ -277,16 +277,16 @@ struct ComposeForm: View {
         .padding(.vertical, 8)
         .transition(.opacity.combined(with: .move(edge: .top)))
     }
-    
+
     // MARK: - Bcc Row
-    
+
     private var bccRow: some View {
         HStack(alignment: .center, spacing: 12) {
             Text("Bcc:")
                 .font(.system(size: 14, weight: .medium))
                 .foregroundColor(labelColor)
                 .frame(width: 50, alignment: .leading)
-            
+
             TokenField(
                 tokens: $draft.bcc,
                 focusedField: $focusedField,
@@ -299,7 +299,7 @@ struct ComposeForm: View {
                     handleSuggestionKeyCommand(command)
                 }
             )
-            
+
             // Spacer to align with To row
             Color.clear
                 .frame(width: 24, height: 24)
@@ -308,16 +308,16 @@ struct ComposeForm: View {
         .padding(.vertical, 8)
         .transition(.opacity.combined(with: .move(edge: .top)))
     }
-    
+
     // MARK: - From Row
-    
+
     private var fromRow: some View {
         HStack(spacing: 12) {
             Text("From:")
                 .font(.system(size: 14, weight: .medium))
                 .foregroundColor(labelColor)
                 .frame(width: 50, alignment: .leading)
-            
+
             // Account Menu
             Menu {
                 ForEach(accounts, id: \.email) { account in
@@ -349,9 +349,9 @@ struct ComposeForm: View {
                 }
             }
             .buttonStyle(.plain)
-            
+
             Spacer()
-            
+
             // Signature Button
             if !signatures.isEmpty {
                 Menu {
@@ -367,9 +367,9 @@ struct ComposeForm: View {
                             }
                         }
                     }
-                    
+
                     Divider()
-                    
+
                     ForEach(signatures.keys.sorted(), id: \.self) { key in
                         Button(action: {
                             selectedSignature = key
@@ -398,11 +398,11 @@ struct ComposeForm: View {
         .padding(.horizontal, 24)
         .padding(.vertical, 10)
     }
-    
 
-    
+
+
     // MARK: - Subject Row
-    
+
     private var subjectRow: some View {
         ZStack(alignment: .leading) {
             if draft.subject.isEmpty {
@@ -410,7 +410,7 @@ struct ComposeForm: View {
                     .font(.system(size: 14, weight: .semibold))
                     .foregroundColor(placeholderColor)
             }
-            
+
             TextField("", text: $draft.subject)
                 .textFieldStyle(.plain)
                 .font(.system(size: 14, weight: .semibold))
@@ -422,9 +422,9 @@ struct ComposeForm: View {
         .padding(.horizontal, 24)
         .padding(.vertical, 12)
     }
-    
+
     // MARK: - Message Editor
-    
+
     private var messageEditor: some View {
         ScrollView {
             VStack(alignment: .leading, spacing: 0) {
@@ -494,9 +494,9 @@ struct ComposeForm: View {
         .padding(.horizontal, 24)
         .padding(.vertical, 8)
     }
-    
+
     // MARK: - Quoted Content View
-    
+
     @ViewBuilder
     private func quotedContentView(_ quoted: String) -> some View {
         VStack(alignment: .leading, spacing: 0) {
@@ -504,11 +504,11 @@ struct ComposeForm: View {
             Divider()
                 .padding(.horizontal, 12)
                 .padding(.vertical, 8)
-            
+
             // Always use NonScrollingWebView for consistent scrolling behavior
             // For plain text, wrap in basic HTML
             let htmlContent = draft.quotedIsHTML ? quoted : plainTextToHTML(quoted)
-            
+
             NonScrollingWebView(
                 html: htmlContent,
                 contentHeight: $quotedContentHeight
@@ -516,7 +516,7 @@ struct ComposeForm: View {
             .frame(height: quotedContentHeight)
         }
     }
-    
+
     /// Detect whether a signature string contains HTML tags
     private func isHTMLSignature(_ text: String) -> Bool {
         let pattern = "<\\s*(?:b|i|u|em|strong|br|div|span|p|a|img|table|tr|td|h[1-6]|ul|ol|li|hr|font|style)\\b[^>]*>"
@@ -531,12 +531,12 @@ struct ComposeForm: View {
             .replacingOccurrences(of: "<", with: "&lt;")
             .replacingOccurrences(of: ">", with: "&gt;")
             .replacingOccurrences(of: "\n", with: "<br>")
-        
+
         return "<div style=\"font-family: -apple-system, monospace; font-size: 13px; color: #666; white-space: pre-wrap;\">\(escaped)</div>"
     }
-    
+
     // MARK: - Attachments
-    
+
     private var attachmentsScrollView: some View {
         ScrollView(.horizontal, showsIndicators: false) {
             HStack(spacing: 8) {
@@ -559,25 +559,25 @@ struct ComposeForm: View {
         }
         .background(Color(NSColor.controlBackgroundColor))
     }
-    
-    
+
+
     // MARK: - Signature Handling
-    
+
     private struct BodySections {
         var userContent: String
         var signature: String?
         var quotedContent: String
     }
-    
+
     private func parseBodySections(_ body: String) -> BodySections {
         let quoteSeparators = [
             "---\nOn ",
             "---------- Forwarded message"
         ]
-        
+
         var quotedContent = ""
         var contentBeforeQuote = body
-        
+
         for separator in quoteSeparators {
             if let range = body.range(of: separator) {
                 contentBeforeQuote = String(body[..<range.lowerBound])
@@ -585,10 +585,10 @@ struct ComposeForm: View {
                 break
             }
         }
-        
+
         var userContent = contentBeforeQuote
         var existingSignature: String? = nil
-        
+
         for (_, sigText) in signatures {
             if let sigRange = contentBeforeQuote.range(of: "\n\n" + sigText, options: .backwards) {
                 userContent = String(contentBeforeQuote[..<sigRange.lowerBound])
@@ -596,14 +596,14 @@ struct ComposeForm: View {
                 break
             }
         }
-        
+
         return BodySections(
             userContent: userContent,
             signature: existingSignature,
             quotedContent: quotedContent
         )
     }
-    
+
     private func updateBodyWithSignature() {
         let sections = parseBodySections(draft.body)
 
@@ -611,7 +611,8 @@ struct ComposeForm: View {
 
         if let signatureKey = selectedSignature,
            let signatureText = signatures[signatureKey],
-           !signatureText.isEmpty {
+           !signatureText.isEmpty
+        {
             if isHTMLSignature(signatureText) {
                 // HTML signature — rendered in EditableWebView
                 draft.htmlSignature = signatureText
@@ -634,33 +635,33 @@ struct ComposeForm: View {
 
         draft.body = newBody
     }
-    
+
     // MARK: - Auto-Save
-    
+
     func scheduleAutoSave() {
         autoSaveCancellable?.cancel()
-        
+
         autoSaveCancellable = Just(())
             .delay(for: .seconds(0.5), scheduler: DispatchQueue.main)
             .sink { _ in
                 var updatedDraft = draft
                 updatedDraft.updateModifiedDate()
-                
+
                 Log.debug("DRAFTING", "Auto-saving draft locally only")
                 DraftManager.shared.saveDraft(updatedDraft)
             }
     }
-    
+
     private func saveDraftToServer() async {
         var updatedDraft = draft
         updatedDraft.updateModifiedDate()
-        
+
         Log.debug("DRAFTING", "Saving draft to local storage")
         DraftManager.shared.saveDraft(updatedDraft)
     }
-    
+
     // MARK: - File Handling
-    
+
     private func handleFileSelection(_ result: Result<[URL], Error>) {
         switch result {
         case .success(let urls):
@@ -669,96 +670,96 @@ struct ComposeForm: View {
                     Log.error("COMPOSE", "Failed to access file: \(url.lastPathComponent)")
                     continue
                 }
-                
+
                 defer {
                     url.stopAccessingSecurityScopedResource()
                 }
-                
+
                 do {
                     let data = try Data(contentsOf: url)
-                    
+
                     guard canAddAttachment(size: Int64(data.count)) else {
                         continue
                     }
-                    
+
                     let mimeType = getMimeType(for: url)
                     let attachment = EmailAttachment(
                         filename: url.lastPathComponent,
                         mimeType: mimeType,
                         data: data
                     )
-                    
+
                     draft.attachments.append(attachment)
                     scheduleAutoSave()
-                    
+
                 } catch {
                     Log.error("COMPOSE", "Failed to read file: \(error)")
                     showErrorMessage("Failed to attach: \(url.lastPathComponent)")
                 }
             }
-            
+
         case .failure(let error):
             Log.error("COMPOSE", "File picker error: \(error)")
         }
     }
-    
+
     private func canAddAttachment(size: Int64) -> Bool {
         guard draft.attachments.count < maxAttachments else {
             showErrorMessage("Maximum \(maxAttachments) attachments allowed")
             return false
         }
-        
+
         guard size <= maxAttachmentSize else {
             showErrorMessage("File too large (max 25MB)")
             return false
         }
-        
+
         guard draft.totalAttachmentSize + size <= maxTotalSize else {
             showErrorMessage("Total attachments too large (max 50MB)")
             return false
         }
-        
+
         return true
     }
-    
+
     private func getMimeType(for url: URL) -> String {
         if let uti = UTType(filenameExtension: url.pathExtension) {
             return uti.preferredMIMEType ?? "application/octet-stream"
         }
         return "application/octet-stream"
     }
-    
+
     private func removeAttachment(id: UUID) {
         draft.attachments.removeAll { $0.id == id }
         scheduleAutoSave()
     }
-    
+
     private func showErrorMessage(_ message: String) {
         errorMessage = message
         showError = true
     }
-    
+
     // MARK: - Key Monitor (for QuickLook)
-    
+
     private func setupKeyMonitor() {
         keyMonitor = NSEvent.addLocalMonitorForEvents(matching: .keyDown) { event in
             if event.keyCode == 49 {
-                if let index = self.selectedAttachmentIndex {
+                if let index = selectedAttachmentIndex {
                     Log.debug("QUICKLOOK", "Space pressed, opening preview for attachment \(index)")
-                    QuickLookManager.shared.showPreview(for: self.draft.attachments, startingAt: index)
+                    QuickLookManager.shared.showPreview(for: draft.attachments, startingAt: index)
                     return nil
                 }
             }
             return event
         }
     }
-    
+
     private func removeKeyMonitor() {
         if let monitor = keyMonitor {
             NSEvent.removeMonitor(monitor)
             keyMonitor = nil
         }
     }
-    
+
 }
 

--- a/macos/durian/Views/ComposeFormSubviews.swift
+++ b/macos/durian/Views/ComposeFormSubviews.swift
@@ -7,8 +7,8 @@
 //  itself.
 //
 
-import SwiftUI
 import AppKit
+import SwiftUI
 
 // MARK: - Attachment Chip
 
@@ -18,13 +18,13 @@ struct AttachmentChip: View {
     let isSelected: Bool
     let onClick: () -> Void
     let onRemove: () -> Void
-    
+
     var body: some View {
         HStack(spacing: 6) {
             Image(systemName: "doc.fill")
                 .font(.caption)
                 .foregroundStyle(.secondary)
-            
+
             VStack(alignment: .leading, spacing: 2) {
                 Text(filename)
                     .font(.caption)
@@ -33,7 +33,7 @@ struct AttachmentChip: View {
                     .font(.caption2)
                     .foregroundStyle(.secondary)
             }
-            
+
             Button(action: onRemove) {
                 Image(systemName: "xmark.circle.fill")
                     .font(.caption)

--- a/macos/durian/Views/ComposeToolbar.swift
+++ b/macos/durian/Views/ComposeToolbar.swift
@@ -60,25 +60,25 @@ struct ComposeToolbar: View {
 
             // Font Picker
             fontPicker
-            
+
             // Size Picker
             sizePicker
-            
+
             Divider()
                 .frame(height: 20)
-            
+
             // Bold, Italic, Underline
             textStyleButtons
-            
+
             Divider()
                 .frame(height: 20)
-            
+
             // Alignment
             alignmentButtons
-            
+
             Divider()
                 .frame(height: 20)
-            
+
             // Lists
             listButtons
 
@@ -94,9 +94,9 @@ struct ComposeToolbar: View {
         .padding(.vertical, 12)
         .background(Color(NSColor.windowBackgroundColor))
     }
-    
+
     // MARK: - Font Picker
-    
+
     private var fontPicker: some View {
         Menu {
             ForEach(availableFonts, id: \.self) { font in
@@ -127,9 +127,9 @@ struct ComposeToolbar: View {
         }
         .buttonStyle(.plain)
     }
-    
+
     // MARK: - Size Picker
-    
+
     private var sizePicker: some View {
         Menu {
             ForEach(availableSizes, id: \.self) { size in
@@ -160,9 +160,9 @@ struct ComposeToolbar: View {
         }
         .buttonStyle(.plain)
     }
-    
+
     // MARK: - Text Style Buttons (B, I, U)
-    
+
     private var textStyleButtons: some View {
         HStack(spacing: 4) {
             ToolbarIconButton(icon: "bold", action: { onFormat?("bold") }, isActive: boldActive)
@@ -171,9 +171,9 @@ struct ComposeToolbar: View {
             ToolbarIconButton(icon: "strikethrough", action: { onFormat?("strikeThrough") }, isActive: strikethroughActive)
         }
     }
-    
+
     // MARK: - Alignment Buttons
-    
+
     private var alignmentButtons: some View {
         HStack(spacing: 4) {
             ToolbarIconButton(icon: "text.alignleft", action: { onFormat?("justifyLeft") }, isActive: currentAlignment == "left")
@@ -182,7 +182,7 @@ struct ComposeToolbar: View {
             ToolbarIconButton(icon: "text.justify", action: { onFormat?("justifyFull") }, isActive: currentAlignment == "justify")
         }
     }
-    
+
     // MARK: - List Buttons
 
     private var listButtons: some View {
@@ -235,9 +235,9 @@ struct ToolbarIconButton: View {
     let icon: String
     let action: () -> Void
     var isActive: Bool = false
-    
+
     @State private var isHovered: Bool = false
-    
+
     var body: some View {
         Button(action: action) {
             Image(systemName: icon)

--- a/macos/durian/Views/ComposeWindow.swift
+++ b/macos/durian/Views/ComposeWindow.swift
@@ -10,7 +10,7 @@ import SwiftUI
 /// Wrapper view for the compose window
 struct ComposeWindow: View {
     let draftId: UUID
-    
+
     @Environment(\.dismiss) private var dismiss
     @Environment(\.openWindow) private var openWindow
     @StateObject private var draftService = DraftService.shared
@@ -44,9 +44,9 @@ struct ComposeWindow: View {
         }
         .tint(profileManager.resolvedAccentColor)
     }
-    
+
     // MARK: - Subviews
-    
+
     private var noAccountsView: some View {
         VStack(spacing: 16) {
             Image(systemName: "exclamationmark.triangle")
@@ -63,7 +63,7 @@ struct ComposeWindow: View {
         .frame(maxWidth: .infinity, maxHeight: .infinity)
         .padding()
     }
-    
+
     private func composeView(draft: EmailDraft, accounts: [MailAccount]) -> some View {
         ZStack {
         ComposeForm(
@@ -89,7 +89,7 @@ struct ComposeWindow: View {
                         .scaleEffect(0.7)
                 }
             }
-            
+
             // Action icons (right)
             ToolbarItemGroup(placement: .primaryAction) {
                 // Placeholder: AI Assist (not yet implemented)
@@ -111,7 +111,7 @@ struct ComposeWindow: View {
                 //     Image(systemName: "doc.on.doc")
                 // }
                 // .help("Templates")
-                
+
                 // More options
                 Menu {
                     Button(action: {}) {
@@ -122,7 +122,7 @@ struct ComposeWindow: View {
                     Image(systemName: "ellipsis")
                 }
                 .help("More Options")
-                
+
                 // Send
                 Button(action: {
                     triggerSend = true
@@ -210,7 +210,7 @@ struct ComposeWindow: View {
         .onAppear { KeymapHandler.shared.composeActive = true }
         .onDisappear { KeymapHandler.shared.composeActive = false }
     }
-    
+
     // MARK: - Actions
 
     /// Activate the next visible Durian window so the app doesn't appear

--- a/macos/durian/Views/ContactSuggestionController.swift
+++ b/macos/durian/Views/ContactSuggestionController.swift
@@ -6,29 +6,29 @@
 //  Design: Figma node 6:2
 //
 
-import SwiftUI
 import AppKit
+import SwiftUI
 
 // MARK: - Contact Suggestion Controller
 
 class ContactSuggestionController {
     static let shared = ContactSuggestionController()
-    
+
     private var popupPanel: NSPanel?
     private var hostingView: NSHostingView<AnyView>?
     private var clickOutsideMonitor: Any?
     private var currentOnDismiss: (() -> Void)?
     private var currentOnSelect: ((Contact) -> Void)?
-    
+
     private init() {}
-    
+
     // MARK: - Public API
-    
+
     /// Check if popup is currently visible
     var isVisible: Bool {
         popupPanel?.isVisible ?? false
     }
-    
+
     /// Show the contact suggestion popup below the cursor in the given token field
     func show(
         for tokenField: NSTokenField,
@@ -40,35 +40,35 @@ class ContactSuggestionController {
         // Store callbacks
         currentOnDismiss = onDismiss
         currentOnSelect = onSelect
-        
+
         // Create or update the popup
         if popupPanel == nil {
             createPopupPanel()
         }
-        
+
         // Update content
         updateContent(contacts: contacts, selectedIndex: selectedIndex)
-        
+
         // Position at cursor
         positionPopup(for: tokenField)
-        
+
         // Show the panel
         popupPanel?.orderFront(nil)
-        
+
         // Setup click-outside monitor
         setupClickOutsideMonitor()
     }
-    
+
     /// Update popup content without recreating the window
     func update(contacts: [Contact], selectedIndex: Int) {
         updateContent(contacts: contacts, selectedIndex: selectedIndex)
     }
-    
+
     /// Reposition the popup (call if cursor moves)
     func reposition(for tokenField: NSTokenField) {
         positionPopup(for: tokenField)
     }
-    
+
     /// Hide and cleanup the popup
     func dismiss() {
         popupPanel?.orderOut(nil)
@@ -76,9 +76,9 @@ class ContactSuggestionController {
         currentOnDismiss = nil
         currentOnSelect = nil
     }
-    
+
     // MARK: - Private: Panel Creation
-    
+
     private func createPopupPanel() {
         // Create borderless panel
         let panel = NSPanel(
@@ -87,7 +87,7 @@ class ContactSuggestionController {
             backing: .buffered,
             defer: true
         )
-        
+
         // Configure panel behavior
         panel.level = .popUpMenu
         panel.isFloatingPanel = true
@@ -96,13 +96,13 @@ class ContactSuggestionController {
         panel.backgroundColor = .clear
         panel.isOpaque = false
         panel.hasShadow = false  // SwiftUI view provides shadow
-        
+
         popupPanel = panel
     }
-    
+
     private func updateContent(contacts: [Contact], selectedIndex: Int) {
         guard let panel = popupPanel else { return }
-        
+
         // Create SwiftUI view
         let popupView = ContactSuggestionPopup(
             contacts: contacts,
@@ -116,161 +116,163 @@ class ContactSuggestionController {
                 self?.dismiss()
             }
         )
-        
+
         // Wrap in hosting view
         let hostingView = NSHostingView(rootView: AnyView(popupView))
         hostingView.frame = panel.contentView?.bounds ?? .zero
-        
+
         // Calculate intrinsic size
         let fittingSize = hostingView.fittingSize
-        
+
         // Update panel size
         var frame = panel.frame
         frame.size = fittingSize
         panel.setFrame(frame, display: true)
-        
+
         // Set content
         panel.contentView = hostingView
         self.hostingView = hostingView
     }
-    
+
     // MARK: - Private: Positioning
-    
+
     private func positionPopup(for tokenField: NSTokenField) {
         guard let panel = popupPanel,
               let window = tokenField.window else { return }
-        
+
         // Get cursor position or fall back to field position
         let cursorRect = cursorScreenRect(in: tokenField) ?? fieldScreenRect(for: tokenField)
-        
+
         // Position popup below cursor with small gap
         let gap: CGFloat = 4
         let popupSize = panel.frame.size
-        
+
         // Calculate position: align left edge with cursor, below the line
         var popupOrigin = NSPoint(
             x: cursorRect.minX,
             y: cursorRect.minY - popupSize.height - gap
         )
-        
+
         // Ensure popup stays on screen
         if let screen = window.screen ?? NSScreen.main {
             let screenFrame = screen.visibleFrame
-            
+
             // Don't go off right edge
             if popupOrigin.x + popupSize.width > screenFrame.maxX {
                 popupOrigin.x = screenFrame.maxX - popupSize.width
             }
-            
+
             // Don't go off left edge
             if popupOrigin.x < screenFrame.minX {
                 popupOrigin.x = screenFrame.minX
             }
-            
+
             // If would go off bottom, show above cursor instead
             if popupOrigin.y < screenFrame.minY {
                 popupOrigin.y = cursorRect.maxY + gap
             }
         }
-        
+
         panel.setFrameOrigin(popupOrigin)
     }
-    
+
     /// Get screen rect for the text cursor in the token field
     private func cursorScreenRect(in tokenField: NSTokenField) -> NSRect? {
         guard let editor = tokenField.currentEditor() as? NSTextView,
               let layoutManager = editor.layoutManager,
-              let textContainer = editor.textContainer else {
+              let textContainer = editor.textContainer else
+        {
             return nil
         }
-        
+
         // Get insertion point location
         let selectedRange = editor.selectedRange()
         let insertionPoint = selectedRange.location
-        
+
         // Handle empty text case
         guard insertionPoint > 0 || editor.string.isEmpty == false else {
             return nil
         }
-        
+
         // Get glyph index (use max to handle end of text)
         let glyphIndex = min(
             layoutManager.glyphIndexForCharacter(at: max(0, insertionPoint - 1)),
             layoutManager.numberOfGlyphs > 0 ? layoutManager.numberOfGlyphs - 1 : 0
         )
-        
+
         // Get bounding rect for the glyph
         var lineRect = layoutManager.boundingRect(
             forGlyphRange: NSRange(location: glyphIndex, length: 1),
             in: textContainer
         )
-        
+
         // Adjust to cursor position (right edge of character if at end)
         if insertionPoint > 0 {
             lineRect.origin.x = lineRect.maxX
         }
         lineRect.size.width = 1  // Cursor width
-        
+
         // Add text container origin offset
         lineRect.origin.x += editor.textContainerOrigin.x
         lineRect.origin.y += editor.textContainerOrigin.y
-        
+
         // Convert to window coordinates
         let windowRect = editor.convert(lineRect, to: nil)
-        
+
         // Convert to screen coordinates
         guard let window = tokenField.window else { return nil }
         let screenRect = window.convertToScreen(windowRect)
-        
+
         return screenRect
     }
-    
+
     /// Fallback: get screen rect for the entire token field
     private func fieldScreenRect(for tokenField: NSTokenField) -> NSRect {
         guard let window = tokenField.window else {
             return NSRect(x: 100, y: 100, width: 200, height: 24)
         }
-        
+
         // Get field bounds in window coordinates
         let fieldBounds = tokenField.bounds
         let windowRect = tokenField.convert(fieldBounds, to: nil)
-        
+
         // Convert to screen coordinates
         return window.convertToScreen(windowRect)
     }
-    
+
     // MARK: - Private: Click Outside Monitor
-    
+
     private func setupClickOutsideMonitor() {
         removeClickOutsideMonitor()
-        
+
         clickOutsideMonitor = NSEvent.addLocalMonitorForEvents(
             matching: [.leftMouseDown, .rightMouseDown]
         ) { [weak self] event in
             guard let self = self,
-                  let panel = self.popupPanel,
-                  panel.isVisible else {
+                  let panel = popupPanel,
+                  panel.isVisible else
+            {
                 return event
             }
-            
+
             // Check if click is outside the popup
             let clickLocation = NSEvent.mouseLocation
             if !NSPointInRect(clickLocation, panel.frame) {
-                self.currentOnDismiss?()
-                self.dismiss()
+                currentOnDismiss?()
+                dismiss()
             }
-            
+
             return event
         }
     }
-    
+
     private func removeClickOutsideMonitor() {
         if let monitor = clickOutsideMonitor {
             NSEvent.removeMonitor(monitor)
             clickOutsideMonitor = nil
         }
     }
-    
+
     deinit {
         removeClickOutsideMonitor()
     }

--- a/macos/durian/Views/ContactSuggestionPopup.swift
+++ b/macos/durian/Views/ContactSuggestionPopup.swift
@@ -13,7 +13,7 @@ import SwiftUI
 struct ContactSuggestionRow: View {
     let contact: Contact
     let isSelected: Bool
-    
+
     var body: some View {
         HStack(spacing: 8) {
             // Avatar with initials
@@ -49,7 +49,7 @@ struct ContactSuggestionPopup: View {
     let selectedIndex: Int
     let onSelect: (Contact) -> Void
     let onDismiss: () -> Void
-    
+
     private let maxHeight: CGFloat = 200  // ~5 rows visible
     private let popupWidth: CGFloat = 200
 

--- a/macos/durian/Views/EditableWebView.swift
+++ b/macos/durian/Views/EditableWebView.swift
@@ -102,7 +102,7 @@ struct EditableWebView: NSViewRepresentable {
         // Execute formatting command if requested
         if let cmd = formatCommand {
             DispatchQueue.main.async {
-                self.formatCommand = nil
+                formatCommand = nil
             }
             let js: String
             if cmd == "insertUnorderedList" || cmd == "insertOrderedList" {
@@ -159,7 +159,7 @@ struct EditableWebView: NSViewRepresentable {
         // Execute font size command if requested
         if let size = fontSizeCommand {
             DispatchQueue.main.async {
-                self.fontSizeCommand = nil
+                fontSizeCommand = nil
             }
             let js = """
             (function() {
@@ -193,7 +193,7 @@ struct EditableWebView: NSViewRepresentable {
         // Execute font family command if requested
         if let family = fontFamilyCommand {
             DispatchQueue.main.async {
-                self.fontFamilyCommand = nil
+                fontFamilyCommand = nil
             }
             let stacks: [String: String] = [
                 "Helvetica": "'Helvetica Neue', Helvetica, Arial, sans-serif",
@@ -345,7 +345,8 @@ struct EditableWebView: NSViewRepresentable {
         // Open links in browser
         func webView(_ webView: WKWebView, decidePolicyFor navigationAction: WKNavigationAction, decisionHandler: @escaping (WKNavigationActionPolicy) -> Void) {
             if navigationAction.navigationType == .linkActivated,
-               let url = navigationAction.request.url {
+               let url = navigationAction.request.url
+            {
                 NSWorkspace.shared.open(url)
                 decisionHandler(.cancel)
             } else {

--- a/macos/durian/Views/EditableWebViewHTML.swift
+++ b/macos/durian/Views/EditableWebViewHTML.swift
@@ -10,7 +10,8 @@
 import AppKit
 
 enum EditableWebViewHTML {
-        static func resolveHex(_ color: NSColor, dark: Bool) -> String {
+        static func resolveHex(_ color: NSColor, dark: Bool) -> String
+    {
         let name: NSAppearance.Name = dark ? .darkAqua : .aqua
         guard let appearance = NSAppearance(named: name) else {
             let resolved = color.usingColorSpace(.sRGB) ?? color

--- a/macos/durian/Views/EmailDetailView.swift
+++ b/macos/durian/Views/EmailDetailView.swift
@@ -6,10 +6,10 @@
 //  Uses ThreadMessage data from CLI instead of HTML parsing
 //
 
-import SwiftUI
 import AppKit
-import UniformTypeIdentifiers
 import Quartz
+import SwiftUI
+import UniformTypeIdentifiers
 
 // MARK: - Email Detail View
 
@@ -89,9 +89,9 @@ struct EmailDetailView: View {
             focusedMessageIndex = 0
         }
     }
-    
+
     // MARK: - Message Cards (Chat-Style Thread View)
-    
+
     @ViewBuilder
     private var messageCards: some View {
         switch email.bodyState {
@@ -99,10 +99,10 @@ struct EmailDetailView: View {
             loadingCard(text: "Click to load") {
                 onLoadBody()
             }
-            
+
         case .loading:
             loadingCard(text: nil, action: nil)
-            
+
         case .loaded:
             // Use thread messages from CLI if available
             if let messages = email.threadMessages, !messages.isEmpty {
@@ -132,41 +132,41 @@ struct EmailDetailView: View {
                 // Fallback: single message with body/html directly from email
                 singleMessageFallback
             }
-            
+
         case .failed(let errorMessage):
             errorCard(message: errorMessage)
         }
     }
-    
+
     @ViewBuilder
     private var singleMessageFallback: some View {
         // Use htmlBody if available, otherwise body
         let htmlContent = email.htmlBody ?? ""
         let textContent = email.body ?? ""
-        
+
         VStack(alignment: .leading, spacing: 16) {
             // Sender row
             HStack(alignment: .top, spacing: 12) {
                 AvatarView(name: email.from, email: email.from, size: 40)
-                
+
                 VStack(alignment: .leading, spacing: 2) {
                     Text(extractName(from: email.from))
                         .font(.system(size: 16, weight: .semibold))
                         .foregroundColor(Color.Detail.textPrimary)
-                    
+
                     Text("Details")
                         .font(.system(size: 14))
                         .foregroundColor(Color.Detail.textSecondary)
                 }
-                
+
                 Spacer()
-                
+
                 Text(formatDate(email.date))
                     .font(.system(size: 14))
                     .foregroundColor(Color.Detail.textTertiary)
                     .lineLimit(1)
             }
-            
+
             // Content
             if !htmlContent.isEmpty {
                 NonScrollingWebView(
@@ -183,7 +183,7 @@ struct EmailDetailView: View {
                     .foregroundColor(Color.Detail.textPrimary)
                     .textSelection(.enabled)
             }
-            
+
             // Action footer
             actionFooter
         }
@@ -197,7 +197,7 @@ struct EmailDetailView: View {
         .padding(.top, 24)
         .padding(.bottom, 32)
     }
-    
+
     private func scrollBy(_ delta: CGFloat) {
         guard let sv = detailScrollView,
               let docView = sv.documentView else { return }
@@ -214,7 +214,7 @@ struct EmailDetailView: View {
             set: { messageHeights[id] = $0 }
         )
     }
-    
+
     @ViewBuilder
     private func loadingCard(text: String?, action: (() -> Void)?) -> some View {
         VStack {
@@ -245,7 +245,7 @@ struct EmailDetailView: View {
         .padding(.top, 24)
         .padding(.bottom, 32)
     }
-    
+
     @ViewBuilder
     private func errorCard(message: String) -> some View {
         Text("Failed: \(message)")
@@ -259,9 +259,9 @@ struct EmailDetailView: View {
             .padding(.top, 24)
             .padding(.bottom, 32)
     }
-    
+
     // MARK: - Header Section
-    
+
     private var parsedTags: [String] {
         (email.tags?.split(separator: ",").map(String.init) ?? [])
             .filter { $0 != currentFolder }
@@ -289,7 +289,7 @@ struct EmailDetailView: View {
             }
         }
     }
-    
+
     // MARK: - Action Footer
 
     @ViewBuilder
@@ -339,7 +339,7 @@ struct EmailDetailView: View {
         let formatter = DateFormatter()
         formatter.locale = Locale(identifier: "en_US_POSIX")
         formatter.dateFormat = "EEE, dd MMM yyyy HH:mm:ss Z"
-        
+
         guard let date = formatter.date(from: dateString) else {
             // Fallback: try without day name
             formatter.dateFormat = "dd MMM yyyy HH:mm:ss Z"
@@ -348,15 +348,15 @@ struct EmailDetailView: View {
             }
             return formatRelativeDate(date)
         }
-        
+
         return formatRelativeDate(date)
     }
-    
+
     /// Format date as relative or absolute depending on age
     private func formatRelativeDate(_ date: Date) -> String {
         let calendar = Calendar.current
         let now = Date()
-        
+
         if calendar.isDateInToday(date) {
             // Today: show time only
             let formatter = DateFormatter()

--- a/macos/durian/Views/EmailListView.swift
+++ b/macos/durian/Views/EmailListView.swift
@@ -30,7 +30,7 @@ enum DateGrouping: Hashable, Comparable {
         case .yesterday: return 1
         case .thisWeek: return 2
         case .lastWeek: return 3
-        case .month(let year, let month): 
+        case .month(let year, let month):
             // Must be > 3 (after lastWeek), newer months = smaller value
             return 100 + (2100 - year) * 12 + (12 - month)
         }
@@ -47,7 +47,7 @@ struct EmailListView: View {
     @Binding var cursorId: String?           // Current cursor position (highlighted)
     @Binding var selection: Set<String>      // Marked emails (for batch operations)
     let onEmailAppear: (MailMessage) -> Void
-    
+
     // Context menu callbacks
     var onTogglePin: ((String) -> Void)?
     var onToggleRead: ((String) -> Void)?
@@ -87,7 +87,7 @@ struct EmailListView: View {
             }
         }
     }
-    
+
     @ViewBuilder
     private func listItemView(_ item: ListItem, groupPositions: [String: (isFirst: Bool, isLast: Bool)]) -> some View {
         switch item {
@@ -97,7 +97,7 @@ struct EmailListView: View {
             emailRow(email: email, groupPositions: groupPositions)
         }
     }
-    
+
     @ViewBuilder
     private func headerView(title: String, style: HeaderStyle) -> some View {
         Text(title)
@@ -109,17 +109,17 @@ struct EmailListView: View {
             .padding(.bottom, 4)
             .padding(.horizontal, 12)
     }
-    
+
     // MARK: - List Building
-    
+
     private enum HeaderStyle {
         case pinned, date
     }
-    
+
     private enum ListItem: Identifiable {
         case header(String, HeaderStyle)
         case email(MailMessage)
-        
+
         var id: String {
             switch self {
             case .header(let title, _): return "header-\(title)"
@@ -127,29 +127,29 @@ struct EmailListView: View {
             }
         }
     }
-    
+
     private func buildEmailList() -> [ListItem] {
         var items: [ListItem] = []
-        
+
         // Pinned emails first
         let pinnedEmails = emails.filter { $0.isPinned }.sorted { $0.timestamp > $1.timestamp }
         if !pinnedEmails.isEmpty {
             items.append(.header("Pinned", .pinned))
             items.append(contentsOf: pinnedEmails.map { .email($0) })
         }
-        
+
         // Then unpinned emails grouped by date
         let unpinnedEmails = emails.filter { !$0.isPinned }
         let grouped = groupEmails(unpinnedEmails)
-        
+
         for (group, groupEmails) in grouped {
             items.append(.header(group.displayName, .date))
             items.append(contentsOf: groupEmails.map { .email($0) })
         }
-        
+
         return items
     }
-    
+
     /// Pre-computed selection group positions — O(n) instead of O(n²)
     /// Takes pre-built items to avoid double buildEmailList() call
     private func computeGroupPositions(from items: [ListItem]) -> [String: (isFirst: Bool, isLast: Bool)] {
@@ -173,18 +173,18 @@ struct EmailListView: View {
         }
         return result
     }
-    
+
     @ViewBuilder
     private func emailRow(email: MailMessage, groupPositions: [String: (isFirst: Bool, isLast: Bool)]) -> some View {
         // Cursor position gets highlight, marked emails show selection indicator
         let isCursor = cursorId == email.id
         let isMarked = selection.contains(email.id)
         let isSelected = isCursor || isMarked
-        
+
         // Pre-computed position in selection group for corner radius
         let pos = groupPositions[email.id] ?? (true, true)
         let (isFirstInGroup, isLastInGroup) = pos
-        
+
         EquatableView(content: EmailRowView(
             email: email,
             isSelected: isSelected,

--- a/macos/durian/Views/EmailRowView.swift
+++ b/macos/durian/Views/EmailRowView.swift
@@ -47,13 +47,13 @@ struct EmailRowView: View, Equatable {
                             .fill(Color.blue)
                             .frame(width: 8, height: 8)
                     }
-                    
+
                     if email.isPinned {
                         Image(systemName: "pin.fill")
                             .font(.caption)
                             .foregroundColor(.yellow)
                     }
-                    
+
                     Text(parties.map(\.name).isEmpty ? Self.extractName(from: email.from) : parties.map(\.name).joined(separator: ", "))
                         .font(.headline)
                         .fontWeight(email.isRead ? .regular : .bold)
@@ -112,14 +112,14 @@ struct EmailRowView: View, Equatable {
             Button(action: { onTogglePin?() }) {
                 Label(email.isPinned ? "Unpin" : "Pin", systemImage: email.isPinned ? "pin.slash" : "pin")
             }
-            
+
             Button(action: { onToggleRead?() }) {
-                Label(email.isRead ? "Mark as Unread" : "Mark as Read", 
+                Label(email.isRead ? "Mark as Unread" : "Mark as Read",
                       systemImage: email.isRead ? "envelope.badge" : "envelope.open")
             }
-            
+
             Divider()
-            
+
             Button(action: { onReply?() }) {
                 Label("Reply", systemImage: "arrowshape.turn.up.left")
             }
@@ -133,9 +133,9 @@ struct EmailRowView: View, Equatable {
             Button(action: { onShowTagPicker?() }) {
                 Label("Tags...", systemImage: "tag")
             }
-            
+
             Divider()
-            
+
             Button(role: .destructive, action: { onDelete?() }) {
                 Label("Delete", systemImage: "trash")
             }
@@ -288,7 +288,8 @@ struct EmailRowView: View, Equatable {
                 if trimmed.isEmpty { continue }
                 if let pipeRange = trimmed.range(of: "|"),
                    pipeRange.lowerBound > trimmed.startIndex,
-                   trimmed[trimmed.index(before: pipeRange.lowerBound)] != " " {
+                   trimmed[trimmed.index(before: pipeRange.lowerBound)] != " "
+                {
                     let before = String(trimmed[..<pipeRange.lowerBound]).trimmingCharacters(in: .whitespaces)
                     let after = String(trimmed[trimmed.index(after: pipeRange.lowerBound)...]).trimmingCharacters(in: .whitespaces)
                     if !before.isEmpty { authors.append(before) }
@@ -366,7 +367,7 @@ private struct TruncatedTagsView: View {
                     .padding(.horizontal, hPadding)
                     .padding(.vertical, 2)
                     .background(
-                        (isSelected ? Color.white.opacity(0.15) : Color.gray.opacity(0.15)),
+                        isSelected ? Color.white.opacity(0.15) : Color.gray.opacity(0.15),
                         in: Capsule()
                     )
             }

--- a/macos/durian/Views/NonScrollingWebView.swift
+++ b/macos/durian/Views/NonScrollingWebView.swift
@@ -15,7 +15,7 @@ import WebKit
 class ScrollPassthroughWebView: WKWebView {
     override func scrollWheel(with event: NSEvent) {
         // Pass scroll events to parent instead of handling them
-        self.nextResponder?.scrollWheel(with: event)
+        nextResponder?.scrollWheel(with: event)
     }
 }
 
@@ -28,49 +28,49 @@ struct NonScrollingWebView: NSViewRepresentable {
     let loadRemoteImages: Bool     // Security: block tracking pixels by default
     let emailId: String            // Track which email this WebView belongs to (for race condition prevention)
     @Binding var contentHeight: CGFloat
-    
+
     init(html: String, theme: String = "system", loadRemoteImages: Bool = false, emailId: String = "", contentHeight: Binding<CGFloat>) {
         self.html = html
         self.theme = theme
         self.loadRemoteImages = loadRemoteImages
         self.emailId = emailId
-        self._contentHeight = contentHeight
+        _contentHeight = contentHeight
     }
-    
+
     func makeNSView(context: Context) -> WKWebView {
         let config = WKWebViewConfiguration()
-        
+
         // Enable JavaScript for height measurement only
         // Note: We need JS enabled to measure content height, but CSP blocks external scripts
         config.defaultWebpagePreferences.allowsContentJavaScript = true
-        
+
         // SECURITY: Disable auto-opening windows
         config.preferences.javaScriptCanOpenWindowsAutomatically = false
-        
+
         // Use custom WebView that passes scroll events to parent
         let webView = ScrollPassthroughWebView(frame: .zero, configuration: config)
         #if DEBUG
         webView.isInspectable = true
         #endif
         webView.navigationDelegate = context.coordinator
-        
+
         // Transparent background (let parent handle background color)
         webView.setValue(false, forKey: "drawsBackground")
         webView.wantsLayer = true
         webView.layer?.backgroundColor = NSColor.clear.cgColor
-        
+
         context.coordinator.webView = webView
         context.coordinator.parent = self
-        
+
         return webView
     }
-    
+
     func updateNSView(_ webView: WKWebView, context: Context) {
         // Update parent reference for height binding
         context.coordinator.parent = self
-        
+
         let styledHTML = buildSecureHTML(html: html, theme: theme, loadRemoteImages: loadRemoteImages)
-        
+
         // Only reload if HTML actually changed - prevents infinite loop
         // (contentHeight binding triggers re-render → updateNSView → reload → didFinish → height update → loop)
         if context.coordinator.lastLoadedHTML != styledHTML {
@@ -79,7 +79,7 @@ struct NonScrollingWebView: NSViewRepresentable {
             webView.loadHTMLString(styledHTML, baseURL: nil)
         }
     }
-    
+
     private func buildSecureHTML(html: String, theme: String, loadRemoteImages: Bool) -> String {
         // Dynamic CSP based on loadRemoteImages setting
         // Note: script-src stays 'none' — evaluateJavaScript() from Swift bypasses CSP,
@@ -90,7 +90,7 @@ struct NonScrollingWebView: NSViewRepresentable {
         } else {
             csp = "default-src 'none'; style-src 'unsafe-inline'; img-src data: cid:;"
         }
-        
+
         // Theme CSS with robust dark mode (CSS filter invert)
         let themeCSS: String
         switch theme {
@@ -111,7 +111,7 @@ struct NonScrollingWebView: NSViewRepresentable {
                 }
             """
         }
-        
+
         return """
         <!DOCTYPE html>
         <html>
@@ -140,17 +140,17 @@ struct NonScrollingWebView: NSViewRepresentable {
         </html>
         """
     }
-    
+
     func makeCoordinator() -> Coordinator {
         Coordinator()
     }
-    
+
     class Coordinator: NSObject, WKNavigationDelegate {
         weak var webView: WKWebView?
         var parent: NonScrollingWebView?
         var lastLoadedHTML: String?  // Track to prevent reload loops
         var loadedForEmailId: String?  // Track which email we loaded for (race condition prevention)
-        
+
         func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {
             // Capture email ID at callback time to detect stale callbacks
             let expectedEmailId = loadedForEmailId
@@ -183,11 +183,12 @@ struct NonScrollingWebView: NSViewRepresentable {
             }
         }
 
-        
+
         // Links open in default browser
         func webView(_ webView: WKWebView, decidePolicyFor navigationAction: WKNavigationAction, decisionHandler: @escaping (WKNavigationActionPolicy) -> Void) {
             if navigationAction.navigationType == .linkActivated,
-               let url = navigationAction.request.url {
+               let url = navigationAction.request.url
+            {
                 NSWorkspace.shared.open(url)
                 decisionHandler(.cancel)
             } else {

--- a/macos/durian/Views/SearchPopupView.swift
+++ b/macos/durian/Views/SearchPopupView.swift
@@ -95,21 +95,21 @@ struct SearchPopupView: View {
             return .handled
         }
     }
-    
+
     // MARK: - Subviews
-    
+
     private var searchInputView: some View {
         HStack(spacing: 14) {
             Image(systemName: "magnifyingglass")
                 .foregroundStyle(.secondary)
                 .font(.title2)
                 .fontWeight(.medium)
-            
+
             TextField("Search emails...", text: $query)
                 .textFieldStyle(.plain)
                 .font(.title2)
                 .focused($isTextFieldFocused)
-            
+
             if !query.isEmpty {
                 Button {
                     query = ""
@@ -121,7 +121,7 @@ struct SearchPopupView: View {
                 }
                 .buttonStyle(.plain)
             }
-            
+
             if searchManager.isSearching {
                 ProgressView()
                     .scaleEffect(0.8)
@@ -130,7 +130,7 @@ struct SearchPopupView: View {
         .padding(.horizontal, 20)
         .padding(.vertical, 18)
     }
-    
+
     private var loadingView: some View {
         HStack(spacing: 10) {
             ProgressView()
@@ -142,7 +142,7 @@ struct SearchPopupView: View {
         .frame(maxWidth: .infinity)
         .padding(.vertical, 24)
     }
-    
+
     private var noResultsView: some View {
         VStack(spacing: 6) {
             Image(systemName: "magnifyingglass")
@@ -155,7 +155,7 @@ struct SearchPopupView: View {
         .frame(maxWidth: .infinity)
         .padding(.vertical, 24)
     }
-    
+
     private var resultsListView: some View {
         VStack(spacing: 0) {
             ScrollViewReader { proxy in
@@ -206,19 +206,19 @@ struct SearchPopupView: View {
             .padding(.vertical, 8)
         }
     }
-    
+
     // MARK: - Actions
-    
+
     private func selectCurrentResult() {
         guard !searchManager.results.isEmpty,
               selectedIndex < searchManager.results.count else { return }
-        
+
         let email = searchManager.results[selectedIndex]
         selectedEmailId = email.id
         onResultsActivated(query, searchManager.results, email.id)
         close()
     }
-    
+
     private func close() {
         searchManager.clear()
         query = ""

--- a/macos/durian/Views/ThreadMessageCardView.swift
+++ b/macos/durian/Views/ThreadMessageCardView.swift
@@ -7,10 +7,10 @@
 //  thread-level layout and header/footer composition.
 //
 
-import SwiftUI
 import AppKit
-import UniformTypeIdentifiers
 import Quartz
+import SwiftUI
+import UniformTypeIdentifiers
 
 struct ThreadMessageCardView: View {
     let message: ThreadMessage
@@ -122,16 +122,16 @@ struct ThreadMessageCardView: View {
         .padding(.top, isFirst ? 24 : 0)
         .padding(.bottom, isLast ? 32 : 16)
     }
-    
+
     // MARK: - Own Message Detection
-    
+
     /// Check if message is from one of the configured accounts
     private func isOwnMessage() -> Bool {
         let fromEmail = extractEmail(from: message.from).lowercased()
         let ownEmails = ConfigManager.shared.getAccounts().map { $0.email.lowercased() }
         return ownEmails.contains(fromEmail)
     }
-    
+
     /// Extract email address from "Name <email>" format
     private func extractEmail(from: String) -> String {
         if let start = from.range(of: "<"), let end = from.range(of: ">") {
@@ -139,34 +139,34 @@ struct ThreadMessageCardView: View {
         }
         return from
     }
-    
+
     // MARK: - Sender Row
-    
+
     @ViewBuilder
     private var senderRow: some View {
         HStack(alignment: .top, spacing: 12) {
             AvatarView(name: message.from, email: message.from, size: 40)
-            
+
             VStack(alignment: .leading, spacing: 2) {
                 Text(extractName(from: message.from))
                     .font(.system(size: 16, weight: .semibold))
                     .foregroundColor(Color.Detail.textPrimary)
-                
+
                 // To/Cc line with expand chevron
                 recipientsRow
             }
-            
+
             Spacer()
-            
+
             Text(formatDate(message.date))
                 .font(.system(size: 14))
                 .foregroundColor(Color.Detail.textTertiary)
                 .lineLimit(1)
         }
     }
-    
+
     // MARK: - Recipients Row (To/Cc)
-    
+
     @ViewBuilder
     private var recipientsRow: some View {
         HStack(spacing: 4) {
@@ -187,7 +187,7 @@ struct ThreadMessageCardView: View {
                     .foregroundColor(Color.Detail.textSecondary)
                     .lineLimit(1)
             }
-            
+
             // Expand chevron
             Image(systemName: "chevron.right")
                 .font(.system(size: 12, weight: .medium))
@@ -203,28 +203,28 @@ struct ThreadMessageCardView: View {
             }
         }
     }
-    
+
     /// Extract clean names from recipient list
     /// "\"Lisa Neumayer | kmpro\" <l@x.de>, \"Max Müller\" <m@x.de>" → ["Lisa Neumayer", "Max Müller"]
     private func extractRecipientNames(_ recipients: String) -> [String] {
         // Split by comma, but be careful with commas inside quotes
         let parts = recipients.components(separatedBy: ">,")
-        
+
         return parts.compactMap { part in
             let trimmed = part.trimmingCharacters(in: .whitespaces)
             guard !trimmed.isEmpty else { return nil }
-            
+
             // Add back the ">" if it was removed by split (except for last part)
             let fullPart = trimmed.hasSuffix(">") ? trimmed : trimmed + ">"
-            
+
             // Use extractName to get clean name
             let name = extractName(from: fullPart)
-            
+
             // Remove "| domain" suffix if present
             if let pipeRange = name.range(of: " |") {
                 return String(name[..<pipeRange.lowerBound]).trimmingCharacters(in: .whitespaces)
             }
-            
+
             if !name.isEmpty { return name }
             // Fallback: show local part of email
             let email = AddressUtils.extractEmail(from: fullPart)
@@ -234,7 +234,7 @@ struct ThreadMessageCardView: View {
             return nil
         }
     }
-    
+
     // MARK: - Attachment Bar
 
     @ViewBuilder
@@ -505,7 +505,7 @@ struct ThreadMessageCardView: View {
                 guard html.contains("cid:\(cleanId)") else { continue }
 
                 group.addTask {
-                    guard let data = await self.fetchAttachmentData(attachment) else {
+                    guard let data = await fetchAttachmentData(attachment) else {
                         return (cleanId, nil)
                     }
                     let base64 = data.base64EncodedString()
@@ -552,26 +552,26 @@ struct ThreadMessageCardView: View {
             if message.from.contains("<") || message.from.contains("@") {
                 detailRow(label: "From", value: message.from)
             }
-            
+
             // To (from message if available, else from parent email)
             if let to = message.to, !to.isEmpty {
                 detailRow(label: "To", value: to)
             } else if let to = email.to, !to.isEmpty {
                 detailRow(label: "To", value: to)
             }
-            
+
             // Cc (from message if available, else from parent email)
             if let cc = message.cc, !cc.isEmpty {
                 detailRow(label: "Cc", value: cc)
             } else if let cc = email.cc, !cc.isEmpty {
                 detailRow(label: "Cc", value: cc)
             }
-            
+
             // Tags (from message)
             if let tags = message.tags, !tags.isEmpty {
                 detailRow(label: "Tags", value: tags.joined(separator: ", "))
             }
-            
+
             // Message-ID (from message)
             detailRow(label: "Message-ID", value: message.id)
         }
@@ -579,21 +579,21 @@ struct ThreadMessageCardView: View {
         .padding(.top, 8)
         .transition(.opacity.combined(with: .move(edge: .top)))
     }
-    
+
     @ViewBuilder
     private func detailRow(label: String, value: String) -> some View {
         HStack(alignment: .top, spacing: 8) {
             Text("\(label):")
                 .font(.system(size: 13))
                 .foregroundColor(Color.Detail.textTertiary)
-            
+
             Text(value)
                 .font(.system(size: 13))
                 .foregroundColor(Color.Detail.textSecondary)
                 .textSelection(.enabled)
         }
     }
-    
+
     // MARK: - Action Footer
 
     @ViewBuilder
@@ -643,7 +643,7 @@ struct ThreadMessageCardView: View {
         let formatter = DateFormatter()
         formatter.locale = Locale(identifier: "en_US_POSIX")
         formatter.dateFormat = "EEE, dd MMM yyyy HH:mm:ss Z"
-        
+
         guard let date = formatter.date(from: dateString) else {
             // Fallback: try without day name
             formatter.dateFormat = "dd MMM yyyy HH:mm:ss Z"
@@ -652,15 +652,15 @@ struct ThreadMessageCardView: View {
             }
             return formatRelativeDate(date)
         }
-        
+
         return formatRelativeDate(date)
     }
-    
+
     /// Format date as relative or absolute depending on age
     private func formatRelativeDate(_ date: Date) -> String {
         let calendar = Calendar.current
         let now = Date()
-        
+
         if calendar.isDateInToday(date) {
             // Today: show time only
             let formatter = DateFormatter()

--- a/macos/durian/Views/TokenField.swift
+++ b/macos/durian/Views/TokenField.swift
@@ -5,8 +5,8 @@
 //  Native NSTokenField wrapper for email addresses with autocomplete
 //
 
-import SwiftUI
 import AppKit
+import SwiftUI
 
 // MARK: - Compose Field Enum (Shared Focus)
 
@@ -35,13 +35,13 @@ enum TokenFieldHelper {
     /// Clear partial text and insert a complete token
     static func replacePartialTextWithToken(_ token: String, in tokenField: NSTokenField) {
         guard let editor = tokenField.currentEditor() as? NSTextView else { return }
-        
+
         let fullText = editor.string
-        
+
         // Find the start of the partial text (after last attachment character or separator)
         let attachmentChar = "\u{FFFC}"
         var partialStartIndex = fullText.startIndex
-        
+
         if let lastAttachmentIndex = fullText.lastIndex(of: Character(attachmentChar)) {
             partialStartIndex = fullText.index(after: lastAttachmentIndex)
         } else {
@@ -54,19 +54,19 @@ enum TokenFieldHelper {
                 }
             }
         }
-        
+
         // Calculate range to replace
         let partialRange = partialStartIndex..<fullText.endIndex
         let nsRange = NSRange(partialRange, in: fullText)
-        
+
         // Replace partial text with empty string
         editor.replaceCharacters(in: nsRange, with: "")
-        
+
         // Now get the current tokens and add the new one
         var currentTokens = (tokenField.objectValue as? [String]) ?? []
         currentTokens.append(token)
         tokenField.objectValue = currentTokens as NSArray
-        
+
         // Move cursor to end (after the new token) with no selection
         DispatchQueue.main.async {
             if let newEditor = tokenField.currentEditor() as? NSTextView {
@@ -84,76 +84,76 @@ struct TokenField: NSViewRepresentable {
     var focusedField: FocusState<ComposeField?>.Binding
     let fieldIdentifier: ComposeField
     var onCommit: (() -> Void)? = nil
-    
+
     // Callbacks for custom autocomplete popup
     var onPartialTextChange: ((String, NSTokenField) -> Void)? = nil
     var onKeyCommand: ((SuggestionKeyCommand) -> Bool)? = nil  // Returns true if handled
-    
+
     func makeCoordinator() -> Coordinator {
         Coordinator(self)
     }
-    
+
     func makeNSView(context: Context) -> NSTokenField {
         let tokenField = NSTokenField()
         tokenField.delegate = context.coordinator
-        
+
         // Styling
         tokenField.isBordered = false
         tokenField.backgroundColor = .clear
         tokenField.drawsBackground = false
         tokenField.focusRingType = .none
         tokenField.font = .systemFont(ofSize: 14)
-        
+
         // Token behavior
         tokenField.tokenizingCharacterSet = CharacterSet(charactersIn: ";\n")
         tokenField.tokenStyle = .rounded
-        
+
         // Layout
         tokenField.lineBreakMode = .byClipping
         tokenField.cell?.isScrollable = true
         tokenField.cell?.wraps = false
-        
+
         // Set initial value
         tokenField.objectValue = tokens as NSArray
-        
+
         context.coordinator.tokenField = tokenField
-        
+
         return tokenField
     }
-    
+
     func updateNSView(_ nsView: NSTokenField, context: Context) {
         // Update tokens if changed from outside
         let currentTokens = (nsView.objectValue as? [String]) ?? []
         if currentTokens != tokens {
             nsView.objectValue = tokens as NSArray
         }
-        
+
         // Handle focus
         let shouldBeFocused = focusedField.wrappedValue == fieldIdentifier
         let isFocused = nsView.window?.firstResponder == nsView.currentEditor()
-        
+
         if shouldBeFocused && !isFocused {
             DispatchQueue.main.async {
                 nsView.window?.makeFirstResponder(nsView)
             }
         }
     }
-    
+
     // MARK: - Coordinator
-    
+
     class Coordinator: NSObject, NSTokenFieldDelegate {
         var parent: TokenField
         weak var tokenField: NSTokenField?
-        
+
         init(_ parent: TokenField) {
             self.parent = parent
         }
-        
+
         // MARK: - Token Field Delegate
-        
+
         func controlTextDidChange(_ notification: Notification) {
             guard let tokenField = notification.object as? NSTokenField else { return }
-            
+
             // Update parent tokens
             if let newTokens = tokenField.objectValue as? [String] {
                 if newTokens != parent.tokens {
@@ -162,21 +162,21 @@ struct TokenField: NSViewRepresentable {
                     }
                 }
             }
-            
+
             // Notify about partial text for custom autocomplete
             notifyPartialTextChange(tokenField: tokenField)
         }
-        
+
         func controlTextDidBeginEditing(_ notification: Notification) {
             DispatchQueue.main.async {
                 self.parent.focusedField.wrappedValue = self.parent.fieldIdentifier
             }
         }
-        
+
         func controlTextDidEndEditing(_ notification: Notification) {
             // Commit any pending tokens
             guard let tokenField = notification.object as? NSTokenField else { return }
-            
+
             if let newTokens = tokenField.objectValue as? [String] {
                 DispatchQueue.main.async {
                     self.parent.tokens = newTokens
@@ -184,7 +184,7 @@ struct TokenField: NSViewRepresentable {
                 }
             }
         }
-        
+
         func control(_ control: NSControl, textView: NSTextView, doCommandBy commandSelector: Selector) -> Bool {
             // Map selector to suggestion command
             let command: SuggestionKeyCommand? = {
@@ -203,18 +203,20 @@ struct TokenField: NSViewRepresentable {
                     return nil
                 }
             }()
-            
+
             // Let parent handle if custom popup is showing
             if let command = command,
                let handler = parent.onKeyCommand,
-               handler(command) {
+               handler(command)
+            {
                 return true  // We handled it, don't let NSTokenField process
             }
-            
+
             // Default handling for Enter - commit tokens
             if commandSelector == #selector(NSResponder.insertNewline(_:)) {
                 if let tokenField = control as? NSTokenField,
-                   let tokens = tokenField.objectValue as? [String] {
+                   let tokens = tokenField.objectValue as? [String]
+                {
                     DispatchQueue.main.async {
                         self.parent.tokens = tokens
                         self.parent.onCommit?()
@@ -222,43 +224,43 @@ struct TokenField: NSViewRepresentable {
                 }
                 return false // Let NSTokenField handle the tokenization
             }
-            
+
             return false
         }
-        
+
         // MARK: - Partial Text Extraction
-        
+
         /// Extract the current partial input (text being typed, not yet a token)
         private func notifyPartialTextChange(tokenField: NSTokenField) {
             guard let editor = tokenField.currentEditor() as? NSTextView else { return }
-            
+
             // Get the full text in the editor
             let fullText = editor.string
-            
+
             // Get existing tokens
             let existingTokens = (tokenField.objectValue as? [String]) ?? []
-            
+
             // Extract partial input (text after the last token)
             let partialText = extractPartialInput(from: fullText, existingTokens: existingTokens)
-            
+
             // Notify parent
             DispatchQueue.main.async {
                 self.parent.onPartialTextChange?(partialText, tokenField)
             }
         }
-        
+
         /// Extract partial text from full editor string
         private func extractPartialInput(from fullText: String, existingTokens: [String]) -> String {
             // The NSTokenField editor contains tokens as special characters (attachment characters)
             // followed by any text being typed. We need to find text after the last token separator.
-            
+
             // Simple approach: find text after the last token separator or attachment
             let separators = CharacterSet(charactersIn: ",;\n")
-            
+
             // Split by separators and get the last component
             let components = fullText.components(separatedBy: separators)
             let lastComponent = components.last?.trimmingCharacters(in: .whitespaces) ?? ""
-            
+
             // Also check for attachment character (used by NSTokenField for tokens)
             // The attachment character is \u{FFFC}
             let attachmentChar = "\u{FFFC}"
@@ -267,76 +269,77 @@ struct TokenField: NSViewRepresentable {
                 let trimmed = afterAttachment.trimmingCharacters(in: .whitespaces)
                 return trimmed
             }
-            
+
             return lastComponent
         }
-        
+
         // MARK: - Token Representation
-        
+
         func tokenField(_ tokenField: NSTokenField, displayStringForRepresentedObject representedObject: Any) -> String? {
             // Display only the name part, not the full "Name <email>" format
             guard let fullString = representedObject as? String else { return nil }
             return extractDisplayName(from: fullString)
         }
-        
+
         func tokenField(_ tokenField: NSTokenField, editingStringForRepresentedObject representedObject: Any) -> String? {
             // When editing, show the full email address
-            return representedObject as? String
+            representedObject as? String
         }
-        
+
         func tokenField(_ tokenField: NSTokenField, representedObjectForEditing editingString: String) -> Any? {
             // Clean the email when creating a token
             let cleaned = EmailTokenHelper.cleanEmail(editingString)
             return cleaned.isEmpty ? nil : cleaned
         }
-        
+
         func tokenField(_ tokenField: NSTokenField, styleForRepresentedObject representedObject: Any) -> NSTokenField.TokenStyle {
             // Use rounded style for all tokens
-            return .rounded
+            .rounded
         }
-        
+
         // MARK: - Token Context Menu
-        
+
         func tokenField(_ tokenField: NSTokenField, hasMenuForRepresentedObject representedObject: Any) -> Bool {
-            return true
+            true
         }
-        
+
         func tokenField(_ tokenField: NSTokenField, menuForRepresentedObject representedObject: Any) -> NSMenu? {
             guard let fullString = representedObject as? String else { return nil }
             let email = extractEmail(from: fullString)
-            
+
             let menu = NSMenu()
-            
+
             // Display email as disabled menu item (just for display)
             let emailItem = NSMenuItem(title: email, action: nil, keyEquivalent: "")
             emailItem.isEnabled = false
             menu.addItem(emailItem)
-            
+
             menu.addItem(NSMenuItem.separator())
-            
+
             // Copy Address action
             let copyItem = NSMenuItem(title: "Copy Address", action: #selector(copyEmailAddress(_:)), keyEquivalent: "")
             copyItem.representedObject = email
             copyItem.target = self
             menu.addItem(copyItem)
-            
+
             return menu
         }
-        
+
         @objc private func copyEmailAddress(_ sender: NSMenuItem) {
             guard let email = sender.representedObject as? String else { return }
             NSPasteboard.general.clearContents()
             NSPasteboard.general.setString(email, forType: .string)
         }
-        
+
         // MARK: - Email/Name Extraction Helpers
-        
+
         /// Extract display name from "Name <email>" format, or return email if no name
         private func extractDisplayName(from fullString: String) -> String {
             let trimmed = fullString.trimmingCharacters(in: .whitespaces)
             // Check for "Name <email>" or "Name<email>" format
             if let angleBracket = trimmed.range(of: "<"),
-               trimmed.contains(">") {
+               trimmed.contains(">")
+            {
                 let namePart = String(trimmed[..<angleBracket.lowerBound])
                     .trimmingCharacters(in: .whitespaces)
                     .trimmingCharacters(in: CharacterSet(charactersIn: "\""))
@@ -347,25 +350,26 @@ struct TokenField: NSViewRepresentable {
             // No name found, return as-is (probably just email)
             return trimmed
         }
-        
+
         /// Extract email from "Name <email>" format, or return as-is if just email
         private func extractEmail(from fullString: String) -> String {
             // Check for "Name <email>" format
             if let startRange = fullString.range(of: "<"),
-               let endRange = fullString.range(of: ">") {
+               let endRange = fullString.range(of: ">")
+            {
                 let email = String(fullString[startRange.upperBound..<endRange.lowerBound])
                 return email.trimmingCharacters(in: .whitespaces)
             }
             // No angle brackets, assume it's just the email
             return fullString
         }
-        
+
         // MARK: - Autocomplete (Disabled - using custom popup)
-        
+
         func tokenField(_ tokenField: NSTokenField, completionsForSubstring substring: String, indexOfToken tokenIndex: Int, indexOfSelectedItem selectedIndex: UnsafeMutablePointer<Int>?) -> [Any]? {
             // Return nil to disable native autocomplete
             // Our custom ContactSuggestionPopup handles this instead
-            return nil
+            nil
         }
     }
 }
@@ -376,7 +380,7 @@ enum EmailTokenHelper {
     static func isValidEmail(_ email: String) -> Bool {
         EmailHelper.isValidEmail(email)
     }
-    
+
     static func cleanEmail(_ input: String) -> String {
         EmailHelper.cleanEmail(input)
     }

--- a/macos/tests/AccountManagerTests.swift
+++ b/macos/tests/AccountManagerTests.swift
@@ -1,5 +1,5 @@
-import XCTest
 @testable import durian_lib
+import XCTest
 
 @MainActor
 final class AccountManagerTests: XCTestCase {

--- a/macos/tests/AttachmentCacheManagerTests.swift
+++ b/macos/tests/AttachmentCacheManagerTests.swift
@@ -1,5 +1,5 @@
-import XCTest
 @testable import durian_lib
+import XCTest
 
 @MainActor
 final class AttachmentCacheManagerTests: XCTestCase {

--- a/macos/tests/BannerManagerTests.swift
+++ b/macos/tests/BannerManagerTests.swift
@@ -1,5 +1,5 @@
-import XCTest
 @testable import durian_lib
+import XCTest
 
 @MainActor
 final class BannerManagerTests: XCTestCase {

--- a/macos/tests/ConfigTests.swift
+++ b/macos/tests/ConfigTests.swift
@@ -1,5 +1,5 @@
-import XCTest
 @testable import durian_lib
+import XCTest
 
 final class ConfigTests: XCTestCase {
 

--- a/macos/tests/ContactsManagerTests.swift
+++ b/macos/tests/ContactsManagerTests.swift
@@ -1,5 +1,5 @@
-import XCTest
 @testable import durian_lib
+import XCTest
 
 @MainActor
 final class ContactsManagerTests: XCTestCase {

--- a/macos/tests/EmailSendingManagerTests.swift
+++ b/macos/tests/EmailSendingManagerTests.swift
@@ -1,5 +1,5 @@
-import XCTest
 @testable import durian_lib
+import XCTest
 
 final class EmailSendingManagerTests: XCTestCase {
 

--- a/macos/tests/EmailSendingTests.swift
+++ b/macos/tests/EmailSendingTests.swift
@@ -1,5 +1,5 @@
-import XCTest
 @testable import durian_lib
+import XCTest
 
 @MainActor
 final class EmailSendingTests: XCTestCase {

--- a/macos/tests/IntegrationTests.swift
+++ b/macos/tests/IntegrationTests.swift
@@ -1,5 +1,5 @@
-import XCTest
 @testable import durian_lib
+import XCTest
 
 /// Integration tests that hit a real durian server.
 /// The server URL is passed via DURIAN_TEST_URL environment variable.

--- a/macos/tests/KeyBufferTests.swift
+++ b/macos/tests/KeyBufferTests.swift
@@ -1,5 +1,5 @@
-import XCTest
 @testable import durian_lib
+import XCTest
 
 @MainActor
 final class KeyBufferTests: XCTestCase {

--- a/macos/tests/KeymapsMergeTests.swift
+++ b/macos/tests/KeymapsMergeTests.swift
@@ -1,5 +1,5 @@
-import XCTest
 @testable import durian_lib
+import XCTest
 
 @MainActor
 final class KeymapsMergeTests: XCTestCase {

--- a/macos/tests/ModelTests.swift
+++ b/macos/tests/ModelTests.swift
@@ -1,5 +1,5 @@
-import XCTest
 @testable import durian_lib
+import XCTest
 
 final class ModelTests: XCTestCase {
 

--- a/macos/tests/OutboxManagerTests.swift
+++ b/macos/tests/OutboxManagerTests.swift
@@ -1,12 +1,12 @@
-import XCTest
 @testable import durian_lib
+import XCTest
 
 @MainActor
 private class MockOutboxBackend: OutboxBackend {
     var outboxItems: [OutboxEntry] = []
 
     func listOutbox() async -> [OutboxEntry] {
-        return outboxItems
+        outboxItems
     }
 }
 

--- a/macos/tests/ProfileTests.swift
+++ b/macos/tests/ProfileTests.swift
@@ -1,6 +1,6 @@
-import XCTest
-import SwiftUI
 @testable import durian_lib
+import SwiftUI
+import XCTest
 
 final class ProfileTests: XCTestCase {
 

--- a/macos/tests/SearchManagerTests.swift
+++ b/macos/tests/SearchManagerTests.swift
@@ -1,5 +1,5 @@
-import XCTest
 @testable import durian_lib
+import XCTest
 
 @MainActor
 private class MockSearchBackend: SearchBackend {

--- a/macos/tests/SequenceMatcherTests.swift
+++ b/macos/tests/SequenceMatcherTests.swift
@@ -1,5 +1,5 @@
-import XCTest
 @testable import durian_lib
+import XCTest
 
 @MainActor
 final class SequenceMatcherTests: XCTestCase {

--- a/macos/tests/SyncManagerTests.swift
+++ b/macos/tests/SyncManagerTests.swift
@@ -1,6 +1,6 @@
-import XCTest
-import SwiftUI
 @testable import durian_lib
+import SwiftUI
+import XCTest
 
 @MainActor
 final class SyncManagerTests: XCTestCase {


### PR DESCRIPTION
Closes #260.

## Why

\`.swiftformat\` was added in [\`3059815c\`](https://github.com/julion2/durian/commit/3059815c) with \`--enable\` syntax, which **adds** rules on top of SwiftFormat's ~50 default rule set rather than replacing it. The defaults include semantic style migrations like \`andOperator\` (\`a && b\` → \`a, b\` in \`if\`/\`guard\`) and \`hoistPatternLet\` that would have churned the codebase without distinguishing real improvements from cosmetic shuffles. The CI gate was deferred at the time because \`--lint\` reported 78/81 files failing under that broader set.

## Config tightening

Switched to \`--rules\` (explicit allowlist) of six narrow rules:

| Rule | Effect |
|---|---|
| trailingSpace | Drop end-of-line whitespace |
| sortImports | Alphabetize import blocks |
| redundantSelf | Remove unambiguous \`self.\` |
| redundantParens | Drop unneeded condition/return parens |
| redundantReturn | Drop \`return\` from single-expression closures |
| wrapMultilineStatementBraces | Opening brace on its own line for long ifs |

## Sweep

\`swiftformat macos/\` against the new config touched 69 of 81 \`.swift\` files. Hit breakdown:

- 762 trailingSpace
- 108 redundantSelf
- 87 sortImports
- 47 wrapMultilineStatementBraces
- 26 redundantReturn
- 1 redundantParens

No semantic changes.

## CI gate

GUI job in \`.github/workflows/test.yml\` now runs:

\`\`\`yaml
- name: Check SwiftFormat
  run: |
    brew install swiftformat
    swiftformat --lint macos/
\`\`\`

before the existing \`bazel test\` step.

## Test plan

- [x] \`swiftformat --lint macos/\` exits clean against the new config.
- [x] \`bazel build //macos:Durian\` succeeds locally.
- [x] CI's new SwiftFormat step runs and stays green.
- [x] \`bazel test //macos:all\` green in CI.