### PR TITLE
feat(go-show): add --headers / --header flag to durian show

### DIFF
--- a/cli/cmd/durian/show.go
+++ b/cli/cmd/durian/show.go
@@ -4,14 +4,20 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"sort"
 	"strings"
 
 	"github.com/julion2/durian/cli/internal/handler"
 	"github.com/julion2/durian/cli/internal/mail"
+	"github.com/julion2/durian/cli/internal/store"
 	"github.com/spf13/cobra"
 )
 
-var showHTML bool
+var (
+	showHTML    bool
+	showHeaders bool
+	showHeader  string
+)
 
 var showCmd = &cobra.Command{
 	Use:   "show <thread-id>",
@@ -19,6 +25,8 @@ var showCmd = &cobra.Command{
 	Long:  "Display the content of an email thread by its thread ID.",
 	Example: `  durian show 00000000000022ca
   durian show 00000000000022ca --html
+  durian show 00000000000022ca --headers
+  durian show 00000000000022ca --header list-id
   durian show 00000000000022ca --json`,
 	Args: cobra.ExactArgs(1),
 	RunE: runShow,
@@ -26,6 +34,8 @@ var showCmd = &cobra.Command{
 
 func init() {
 	showCmd.Flags().BoolVar(&showHTML, "html", false, "show HTML body instead of plain text")
+	showCmd.Flags().BoolVar(&showHeaders, "headers", false, "print all stored headers per message instead of the body (useful for writing rules)")
+	showCmd.Flags().StringVar(&showHeader, "header", "", "print only this header (case-insensitive); implies --headers")
 	rootCmd.AddCommand(showCmd)
 }
 
@@ -37,6 +47,10 @@ func runShow(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("email store unavailable: %w", err)
 	}
 	defer emailDB.Close()
+
+	if showHeaders || showHeader != "" {
+		return runShowHeaders(emailDB, threadID, showHeader)
+	}
 
 	h := handler.New(emailDB, nil)
 
@@ -60,6 +74,93 @@ func runShow(cmd *cobra.Command, args []string) error {
 	}
 
 	return outputThreadFormatted(resp.Thread)
+}
+
+// runShowHeaders prints stored headers for every message in the thread.
+// When filterName is non-empty, only headers whose canonical name matches
+// (case-insensitive) are printed — handy for writing rules.pkl entries
+// against things like List-Id or X-GitHub-Reason.
+func runShowHeaders(emailDB *store.DB, threadID, filterName string) error {
+	msgs, err := emailDB.GetByThread(threadID)
+	if err != nil {
+		return fmt.Errorf("get thread: %w", err)
+	}
+	if len(msgs) == 0 {
+		return fmt.Errorf("no messages found for thread %s", threadID)
+	}
+
+	ids := make([]int64, len(msgs))
+	for i, m := range msgs {
+		ids[i] = m.ID
+	}
+	headersByID, err := emailDB.HeadersByMessageDBIDs(ids)
+	if err != nil {
+		return fmt.Errorf("load headers: %w", err)
+	}
+
+	// JSON: nested by message_id (RFC-5322), preserving order.
+	if jsonOutput {
+		type messageHeaders struct {
+			MessageID string              `json:"message_id"`
+			Headers   map[string][]string `json:"headers"`
+		}
+		out := make([]messageHeaders, 0, len(msgs))
+		for _, m := range msgs {
+			h := headersByID[m.ID]
+			if filterName != "" {
+				h = filterHeaders(h, filterName)
+			}
+			out = append(out, messageHeaders{MessageID: m.MessageID, Headers: h})
+		}
+		enc := json.NewEncoder(os.Stdout)
+		enc.SetIndent("", "  ")
+		return enc.Encode(out)
+	}
+
+	// Text: mailx-style. Per message: "[i/n] <message-id>", then "Name: value"
+	// lines, blank line between messages.
+	for i, m := range msgs {
+		h := headersByID[m.ID]
+		if filterName != "" {
+			h = filterHeaders(h, filterName)
+		}
+		if i > 0 {
+			fmt.Println()
+		}
+		fmt.Printf("[%d/%d] %s\n", i+1, len(msgs), m.MessageID)
+		if len(h) == 0 {
+			if filterName != "" {
+				fmt.Printf("  (no %s header)\n", filterName)
+			} else {
+				fmt.Println("  (no headers stored)")
+			}
+			continue
+		}
+		// Sort header names for stable output.
+		names := make([]string, 0, len(h))
+		for name := range h {
+			names = append(names, name)
+		}
+		sort.Strings(names)
+		for _, name := range names {
+			for _, v := range h[name] {
+				fmt.Printf("%s: %s\n", name, v)
+			}
+		}
+	}
+	return nil
+}
+
+// filterHeaders keeps only entries whose canonical name equals filterName
+// case-insensitively. Returns a fresh map; the input is not mutated.
+func filterHeaders(h map[string][]string, filterName string) map[string][]string {
+	out := make(map[string][]string)
+	for name, values := range h {
+		if strings.EqualFold(name, filterName) {
+			out[name] = values
+		}
+	}
+	return out
 }
 
 func outputThreadFormatted(t *mail.ThreadContent) error {

--- a/cli/internal/store/headers.go
+++ b/cli/internal/store/headers.go
@@ -3,6 +3,7 @@ package store
 import (
 	"fmt"
 	"net/textproto"
+	"strings"
 )
 
 // InsertHeader stores a message header. Overwrites if it already exists.
@@ -118,6 +119,49 @@ func (d *DB) AllMessages() ([]*Message, error) {
 // Header names are returned in canonical MIME form (e.g. "List-Unsubscribe").
 func (d *DB) AllHeadersByMessage() (map[int64]map[string][]string, error) {
 	rows, err := d.db.Query("SELECT message_id, name, value_ct FROM message_headers")
+	if err != nil {
+		return nil, fmt.Errorf("query headers: %w", err)
+	}
+	defer rows.Close()
+
+	result := make(map[int64]map[string][]string)
+	for rows.Next() {
+		var msgID int64
+		var name string
+		var valueCT []byte
+		if err := rows.Scan(&msgID, &name, &valueCT); err != nil {
+			return nil, fmt.Errorf("scan header: %w", err)
+		}
+		plain, err := d.decryptHeaderValue("", valueCT)
+		if err != nil {
+			return nil, err
+		}
+		if result[msgID] == nil {
+			result[msgID] = make(map[string][]string)
+		}
+		canonical := textproto.CanonicalMIMEHeaderKey(name)
+		result[msgID][canonical] = append(result[msgID][canonical], plain)
+	}
+	return result, rows.Err()
+}
+
+// HeadersByMessageDBIDs loads headers scoped to the given message DB IDs.
+// Same decrypt path as AllHeadersByMessage but parameterised — useful for
+// `durian show --headers` where we already know the thread's message set
+// and don't want to scan the entire message_headers table.
+func (d *DB) HeadersByMessageDBIDs(ids []int64) (map[int64]map[string][]string, error) {
+	if len(ids) == 0 {
+		return map[int64]map[string][]string{}, nil
+	}
+	placeholders := make([]string, len(ids))
+	params := make([]any, len(ids))
+	for i, id := range ids {
+		placeholders[i] = "?"
+		params[i] = id
+	}
+	q := "SELECT message_id, name, value_ct FROM message_headers WHERE message_id IN (" +
+		strings.Join(placeholders, ",") + ")"
+	rows, err := d.db.Query(q, params...)
 	if err != nil {
 		return nil, fmt.Errorf("query headers: %w", err)
 	}


### PR DESCRIPTION
## Why

Before ADR-0001, headers were directly grep-able via \`sqlite3 ~/.local/share/durian/email.db\` — useful for writing rules.pkl entries against things like \`List-Id\`, \`X-GitHub-Reason\`, \`List-Unsubscribe\`. After the encryption rollout, \`message_headers.value\` is an AES-GCM-sealed BLOB and the only existing read path was inside the rules engine itself, which made the "let me peek what headers this thread has" workflow inaccessible from the CLI.

## What

Two new flags on \`durian show\`:

\`\`\`
--headers           print every stored header per message in the thread
--header <name>     print only that header (case-insensitive, implies --headers)
\`\`\`

Output is mailx-style, one header per line, sorted by header name, blank line between messages. JSON output is supported via the existing \`--json\` global flag.

Examples:

\`\`\`bash
durian show 00000000000022ca --headers
# [1/3] <msg-id@example.com>
# Authentication-Results: ...
# List-Id: ...
# Received: ...
# X-GitHub-Reason: mention
# ...

durian show 00000000000022ca --header list-id
# [1/3] <msg-id@example.com>
# List-Id: <gitlab-issues.gitlab.habric.org>

durian show 00000000000022ca --header x-github-reason --json
# [{"message_id":"...","headers":{"X-Github-Reason":["mention"]}}, ...]
\`\`\`

## Implementation

- New \`(*DB).HeadersByMessageDBIDs(ids []int64)\` in \`cli/internal/store/headers.go\` — thread-scoped variant of the existing \`AllHeadersByMessage\` helper used by the rules engine. Same decrypt path, just an \`IN (?, ?, ...)\` filter so we don't scan every header in the DB for one thread.
- \`runShowHeaders\` in \`cli/cmd/durian/show.go\` — calls \`GetByThread\` for the message IDs, \`HeadersByMessageDBIDs\` for their headers, prints either mailx-style or JSON.
- No handler / HTTP-API change: this is a CLI-only read path. The GUI never asks for raw headers.

## Test plan

- [x] \`bazel test //cli/internal/store/...\` green
- [x] \`bazel build //cli/cmd/durian\` clean
- [ ] Manual: \`./cli/install.sh && durian show <thread-id> --header list-id\` returns the expected value on a real DB
- [ ] CI green