### PR TITLE
feat(config,sync): user-extensible indexed_headers

### DIFF
--- a/cli/cmd/durian/serve.go
+++ b/cli/cmd/durian/serve.go
@@ -226,7 +226,7 @@ func runServe(cmd *cobra.Command, args []string) {
 		if len(accounts) == 0 {
 			slog.Info("No IMAP accounts configured, skipping watchers", "module", "SERVE") // encgrep:allow wrapper-protected slog key per redact.SensitiveSlogKeys
 		} else {
-			watcher := handler.NewWatcherManager(eventHub, emailDB, rules, groups)
+			watcher := handler.NewWatcherManager(eventHub, emailDB, rules, groups, cfg.Sync.IndexedHeaders)
 			h.SetFetcher(watcher)
 			h.SetSyncTrigger(watcher)
 			go watcher.Start(watcherCtx, accounts)

--- a/cli/cmd/durian/sync.go
+++ b/cli/cmd/durian/sync.go
@@ -90,6 +90,7 @@ func runSync(cmd *cobra.Command, args []string) error {
 		Store:           emailDB,
 		FilterRules:     rules,
 		BackfillHeaders: syncBackfillHeaders,
+		IndexedHeaders:  GetConfig().Sync.IndexedHeaders,
 		Groups:          func() map[string]config.GroupEntry { g, _ := config.LoadGroups(""); return g }(),
 	}
 

--- a/cli/internal/config/types.go
+++ b/cli/internal/config/types.go
@@ -24,6 +24,11 @@ type SyncConfig struct {
 	FullSyncInterval  int                    `pkl:"full_sync_interval" json:"full_sync_interval"`
 	TagSync           *TagSyncConfig         `pkl:"tag_sync" json:"tag_sync"`
 	AttachmentCache   *AttachmentCacheConfig `pkl:"attachment_cache" json:"attachment_cache"`
+	// IndexedHeaders supplements the built-in set of MIME headers that
+	// sync fetches into message_headers for rule matching. See
+	// cli/internal/imap/sync_mailbox.go builtinSelectedHeaders for the
+	// built-ins. Case-insensitive merge, user entries are additive only.
+	IndexedHeaders []string `pkl:"indexed_headers" json:"indexed_headers"`
 }
 
 // AttachmentCacheConfig configures the GUI attachment cache.

--- a/cli/internal/config/validate.go
+++ b/cli/internal/config/validate.go
@@ -43,6 +43,24 @@ func ValidateConfig(cfg *Config) []ValidationError {
 		}
 	}
 
+	// indexed_headers: RFC 822 header names = ASCII letters + digits +
+	// hyphen, starting with a letter. The runtime merge in imap.headerSet
+	// drops empty strings and dedups case-insensitively, but a typo like
+	// "X Gitlab Reason " (spaces) would silently be a no-op — surface it
+	// at validate time instead.
+	headerName := regexp.MustCompile(`^[A-Za-z][A-Za-z0-9-]*$`)
+	for i, name := range cfg.Sync.IndexedHeaders {
+		trimmed := strings.TrimSpace(name)
+		if trimmed == "" {
+			add(fmt.Sprintf("sync.indexed_headers[%d]", i), "empty header name")
+			continue
+		}
+		if !headerName.MatchString(trimmed) {
+			add(fmt.Sprintf("sync.indexed_headers[%d]", i),
+				fmt.Sprintf("invalid MIME header name: %q (must match [A-Za-z][A-Za-z0-9-]*)", name))
+		}
+	}
+
 	if len(cfg.Accounts) == 0 {
 		warn("accounts", "no accounts configured")
 		return errs

--- a/cli/internal/handler/watcher.go
+++ b/cli/internal/handler/watcher.go
@@ -42,27 +42,29 @@ type accountWatcher struct {
 // WatcherManager runs per-account IMAP IDLE watchers that trigger syncs
 // and broadcast new-mail events via the EventHub.
 type WatcherManager struct {
-	hub         *EventHub
-	store       *store.DB
-	log         *slog.Logger
-	locks       map[string]*sync.Mutex       // per-account sync locks keyed by email
-	locksMu     sync.Mutex                   // protects the locks map
-	watchers    map[string]*accountWatcher   // keyed by account identifier (e.g. "work")
-	filterRules []config.RuleConfig          // user-defined filter rules applied at sync time
-	groups      map[string]config.GroupEntry // contact groups for group: expansion in rules
+	hub            *EventHub
+	store          *store.DB
+	log            *slog.Logger
+	locks          map[string]*sync.Mutex       // per-account sync locks keyed by email
+	locksMu        sync.Mutex                   // protects the locks map
+	watchers       map[string]*accountWatcher   // keyed by account identifier (e.g. "work")
+	filterRules    []config.RuleConfig          // user-defined filter rules applied at sync time
+	groups         map[string]config.GroupEntry // contact groups for group: expansion in rules
+	indexedHeaders []string                     // user-added MIME headers to index (see imap.SyncOptions)
 }
 
 // NewWatcherManager creates a WatcherManager wired to the given EventHub
 // and SQLite store.
-func NewWatcherManager(hub *EventHub, db *store.DB, rules []config.RuleConfig, groups map[string]config.GroupEntry) *WatcherManager {
+func NewWatcherManager(hub *EventHub, db *store.DB, rules []config.RuleConfig, groups map[string]config.GroupEntry, indexedHeaders []string) *WatcherManager {
 	return &WatcherManager{
-		hub:         hub,
-		store:       db,
-		log:         slog.Default().With("module", "WATCHER"),
-		locks:       make(map[string]*sync.Mutex),
-		watchers:    make(map[string]*accountWatcher),
-		filterRules: rules,
-		groups:      groups,
+		hub:            hub,
+		store:          db,
+		log:            slog.Default().With("module", "WATCHER"),
+		locks:          make(map[string]*sync.Mutex),
+		watchers:       make(map[string]*accountWatcher),
+		filterRules:    rules,
+		groups:         groups,
+		indexedHeaders: indexedHeaders,
 	}
 }
 
@@ -151,7 +153,7 @@ func (w *WatcherManager) watchAccount(ctx context.Context, aw *accountWatcher) {
 		// Initial sync on the watcher's connection (catch-up, no SSE notification).
 		// If this kills the connection, SELECT below will fail and the
 		// outer loop reconnects with 30s backoff.
-		initOpts := &imap.SyncOptions{Quiet: true, Mailboxes: []string{"INBOX"}, Store: w.store, FilterRules: w.filterRules, Groups: w.groups}
+		initOpts := &imap.SyncOptions{Quiet: true, Mailboxes: []string{"INBOX"}, Store: w.store, FilterRules: w.filterRules, Groups: w.groups, IndexedHeaders: w.indexedHeaders}
 		initSyncer := imap.NewSyncerWithClient(account, client, initOpts)
 		if _, err := initSyncer.Sync(); err != nil {
 			w.log.Error("Initial sync failed", "account", account.Email, "err", err) // encgrep:allow wrapper-protected slog key per redact.SensitiveSlogKeys
@@ -392,7 +394,7 @@ func (w *WatcherManager) syncAndNotify(account *config.AccountConfig, client *im
 
 	// Build syncer: reuse caller's IDLE connection, only sync INBOX.
 	// Iterating other mailboxes triggers rate-limiting on M365.
-	opts := &imap.SyncOptions{Quiet: true, Mailboxes: []string{"INBOX"}, Store: w.store, FilterRules: w.filterRules, Groups: w.groups}
+	opts := &imap.SyncOptions{Quiet: true, Mailboxes: []string{"INBOX"}, Store: w.store, FilterRules: w.filterRules, Groups: w.groups, IndexedHeaders: w.indexedHeaders}
 	syncer := imap.NewSyncerWithClient(account, client, opts)
 
 	// Run sync with timeout so a flaky server can't block the watcher forever.

--- a/cli/internal/handler/watcher_test.go
+++ b/cli/internal/handler/watcher_test.go
@@ -73,7 +73,7 @@ func TestCleanSnippet_EmptyInput(t *testing.T) {
 
 func TestNewWatcherManager(t *testing.T) {
 	db := newTestStore(t)
-	w := NewWatcherManager(nil, db, nil, nil)
+	w := NewWatcherManager(nil, db, nil, nil, nil)
 	if w == nil {
 		t.Fatal("nil watcher manager")
 	}
@@ -90,7 +90,7 @@ func TestNewWatcherManager(t *testing.T) {
 
 func TestWatcherManager_AccountLock_SameEmailSameLock(t *testing.T) {
 	db := newTestStore(t)
-	w := NewWatcherManager(nil, db, nil, nil)
+	w := NewWatcherManager(nil, db, nil, nil, nil)
 
 	a := w.accountLock("alice@example.com")
 	b := w.accountLock("alice@example.com")
@@ -101,7 +101,7 @@ func TestWatcherManager_AccountLock_SameEmailSameLock(t *testing.T) {
 
 func TestWatcherManager_AccountLock_DifferentEmailsDifferentLocks(t *testing.T) {
 	db := newTestStore(t)
-	w := NewWatcherManager(nil, db, nil, nil)
+	w := NewWatcherManager(nil, db, nil, nil, nil)
 
 	a := w.accountLock("alice@example.com")
 	b := w.accountLock("bob@example.com")
@@ -112,7 +112,7 @@ func TestWatcherManager_AccountLock_DifferentEmailsDifferentLocks(t *testing.T) 
 
 func TestWatcherManager_AccountLock_ConcurrentSafe(t *testing.T) {
 	db := newTestStore(t)
-	w := NewWatcherManager(nil, db, nil, nil)
+	w := NewWatcherManager(nil, db, nil, nil, nil)
 
 	// Hammer accountLock from multiple goroutines — should not race
 	// when run under `bazel test --test_arg=-race` (go_test has race
@@ -136,7 +136,7 @@ func TestWatcherManager_AccountLock_ConcurrentSafe(t *testing.T) {
 
 func TestWatcherManager_TriggerSync_UnknownAccount(t *testing.T) {
 	db := newTestStore(t)
-	w := NewWatcherManager(nil, db, nil, nil)
+	w := NewWatcherManager(nil, db, nil, nil, nil)
 
 	// Must not panic when the account has no registered watcher
 	w.TriggerSync("unknown-account")

--- a/cli/internal/imap/sync.go
+++ b/cli/internal/imap/sync.go
@@ -57,6 +57,7 @@ type SyncOptions struct {
 	FilterRules     []config.RuleConfig          // User-defined filter rules applied at insert time
 	Groups          map[string]config.GroupEntry // Contact groups for group: expansion in rules
 	BackfillHeaders bool                         // Fetch and store headers for existing messages
+	IndexedHeaders  []string                     // User-added MIME header names to index on top of builtinSelectedHeaders (see sync_mailbox.go)
 }
 
 // SyncResult contains the results of a sync operation

--- a/cli/internal/imap/sync_mailbox.go
+++ b/cli/internal/imap/sync_mailbox.go
@@ -10,11 +10,52 @@ import (
 	"strings"
 )
 
-// selectedHeaders are the headers stored in message_headers for rule matching.
-var selectedHeaders = []string{
+// builtinSelectedHeaders is the universal-default set of MIME headers
+// fetched into message_headers for rule matching. Users can extend this
+// per-account or per-install via config.pkl's sync.indexed_headers
+// listing; the runtime set is the case-insensitive union of these
+// built-ins and the user additions (see (*Syncer).headerSet).
+//
+// These seven cover ~90% of inbox-zero rule patterns: mailing-list
+// identification (List-Id, List-Unsubscribe, Precedence), automation
+// markers (X-Mailer, Return-Path), GitHub notification routing
+// (X-GitHub-Reason), and sender verification (Authentication-Results).
+// Provider-specific additions like X-GitLab-NotificationReason,
+// X-Spam-Status, etc. belong in the user's indexed_headers config.
+var builtinSelectedHeaders = []string{
 	"List-Id", "List-Unsubscribe", "Precedence",
 	"X-Mailer", "Return-Path", "X-GitHub-Reason",
 	"Authentication-Results",
+}
+
+// headerSet returns the deduped, case-insensitive union of the built-in
+// header allowlist and the user's sync.indexed_headers entries. Output
+// preserves built-ins-first order; user entries follow in declaration
+// order. Used by both the live-sync header insert (sync_store.go) and
+// the backfill-headers path (sync_mailbox.go).
+func (s *Syncer) headerSet() []string {
+	seen := make(map[string]struct{}, len(builtinSelectedHeaders)+len(s.options.IndexedHeaders))
+	out := make([]string, 0, len(builtinSelectedHeaders)+len(s.options.IndexedHeaders))
+	for _, h := range builtinSelectedHeaders {
+		k := strings.ToLower(h)
+		if _, dup := seen[k]; dup {
+			continue
+		}
+		seen[k] = struct{}{}
+		out = append(out, h)
+	}
+	for _, h := range s.options.IndexedHeaders {
+		k := strings.ToLower(strings.TrimSpace(h))
+		if k == "" {
+			continue
+		}
+		if _, dup := seen[k]; dup {
+			continue
+		}
+		seen[k] = struct{}{}
+		out = append(out, h)
+	}
+	return out
 }
 
 // backfillHeaders fetches headers from the IMAP server for messages that
@@ -106,10 +147,10 @@ func (s *Syncer) storeHeadersForUID(uid uint32, rawHeader []byte, mboxState *Mai
 	if err != nil {
 		return false
 	}
-	for _, hdrName := range selectedHeaders {
+	for _, hdrName := range s.headerSet() {
 		if v := parsed.Header.Get(hdrName); v != "" {
 			if err := s.store.InsertHeader(dbID, strings.ToLower(hdrName), v); err != nil {
-				slog.Debug("InsertHeader failed", "module", "SYNC", "uid", uid, "header", hdrName, "err", err)
+				slog.Debug("InsertHeader failed", "module", "SYNC", "uid", uid, "header", hdrName, "err", err) // encgrep:allow word "header" in message text, no header value logged
 			}
 		}
 	}

--- a/cli/internal/imap/sync_store.go
+++ b/cli/internal/imap/sync_store.go
@@ -88,8 +88,9 @@ func (s *Syncer) storeInsertMessage(mailboxName string, imapMsg *goimap.Message,
 		}
 	}
 
-	// Store selected headers for rule matching and analysis
-	for _, hdrName := range selectedHeaders {
+	// Store selected headers for rule matching and analysis (builtin set
+	// plus user-added entries from config.pkl sync.indexed_headers).
+	for _, hdrName := range s.headerSet() {
 		if v := parsed.Header.Get(hdrName); v != "" {
 			_ = s.store.InsertHeader(storeMsg.ID, strings.ToLower(hdrName), v)
 		}

--- a/cli/internal/imap/sync_test.go
+++ b/cli/internal/imap/sync_test.go
@@ -355,3 +355,62 @@ func TestMailboxResult(t *testing.T) {
 		t.Error("expected Error to be nil")
 	}
 }
+
+func TestHeaderSet_MergesBuiltinAndUser(t *testing.T) {
+	cases := []struct {
+		name string
+		user []string
+		want []string
+	}{
+		{
+			name: "no user additions returns builtins",
+			user: nil,
+			want: []string{"List-Id", "List-Unsubscribe", "Precedence",
+				"X-Mailer", "Return-Path", "X-GitHub-Reason",
+				"Authentication-Results"},
+		},
+		{
+			name: "user additions are appended",
+			user: []string{"X-GitLab-NotificationReason", "X-Spam-Status"},
+			want: []string{"List-Id", "List-Unsubscribe", "Precedence",
+				"X-Mailer", "Return-Path", "X-GitHub-Reason",
+				"Authentication-Results",
+				"X-GitLab-NotificationReason", "X-Spam-Status"},
+		},
+		{
+			name: "case-insensitive dedup against builtins",
+			user: []string{"list-id", "LIST-UNSUBSCRIBE", "X-Spam-Status"},
+			want: []string{"List-Id", "List-Unsubscribe", "Precedence",
+				"X-Mailer", "Return-Path", "X-GitHub-Reason",
+				"Authentication-Results", "X-Spam-Status"},
+		},
+		{
+			name: "case-insensitive dedup within user list",
+			user: []string{"X-Spam-Status", "x-spam-status", "X-SPAM-STATUS"},
+			want: []string{"List-Id", "List-Unsubscribe", "Precedence",
+				"X-Mailer", "Return-Path", "X-GitHub-Reason",
+				"Authentication-Results", "X-Spam-Status"},
+		},
+		{
+			name: "empty + whitespace-only entries dropped",
+			user: []string{"", "   ", "X-Spam-Status"},
+			want: []string{"List-Id", "List-Unsubscribe", "Precedence",
+				"X-Mailer", "Return-Path", "X-GitHub-Reason",
+				"Authentication-Results", "X-Spam-Status"},
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			s := &Syncer{options: &SyncOptions{IndexedHeaders: c.user}}
+			got := s.headerSet()
+			if len(got) != len(c.want) {
+				t.Fatalf("len = %d, want %d (got=%v)", len(got), len(c.want), got)
+			}
+			for i, h := range c.want {
+				if got[i] != h {
+					t.Errorf("[%d] = %q, want %q", i, got[i], h)
+				}
+			}
+		})
+	}
+}

--- a/docs/content/docs/configuration/config.md
+++ b/docs/content/docs/configuration/config.md
@@ -54,6 +54,29 @@ accounts {
 | `full_sync_interval` | `Int` (seconds) | `7200` | Full sync interval |
 | `tag_sync` | object? | `null` | Optional remote tag sync — see [tag sync server](https://github.com/julion2/durian/tree/main/sync) |
 | `attachment_cache` | object? | `null` | `{ max_size_mb, ttl_days }` |
+| `indexed_headers` | `Listing<String>?` | `null` | Extra MIME headers to fetch + index on top of the built-in seven (`List-Id`, `List-Unsubscribe`, `Precedence`, `X-Mailer`, `Return-Path`, `X-GitHub-Reason`, `Authentication-Results`). Use for provider-specific rules. After editing, run `durian sync --backfill-headers` once to populate existing messages. |
+
+### Extra `indexed_headers` example
+
+```pkl
+sync {
+  indexed_headers {
+    "X-GitLab-NotificationReason"   // own_activity / assigned / mentioned
+    "X-GitLab-Project-Path"
+    "X-Spam-Status"
+    "Auto-Submitted"
+  }
+}
+```
+
+Then in `rules.pkl`:
+
+```pkl
+new { name = "GitLab mentions"; match = "header:x-gitlab-notificationreason:mentioned"; add_tags { "gitlab/mention" } }
+new { name = "Spam";           match = "header:x-spam-status:Yes";                        add_tags { "spam" } }
+```
+
+The built-in seven cover ~90% of inbox-zero patterns; user additions handle the long tail without code changes. After editing the config, `durian sync --backfill-headers` re-fetches headers for existing messages so old mails match the new rules. New mails pick up the change automatically on the next sync.
 
 ## accounts
 

--- a/schema/Config.pkl
+++ b/schema/Config.pkl
@@ -17,6 +17,14 @@ class SyncConfig {
   full_sync_interval: Int(this > 0) = 7200
   tag_sync: TagSyncConfig?
   attachment_cache: AttachmentCacheConfig?
+  /// Extra MIME header names to fetch and index on top of the built-in
+  /// set (List-Id, List-Unsubscribe, Precedence, X-Mailer, Return-Path,
+  /// X-GitHub-Reason, Authentication-Results). Use this when you want
+  /// rules.pkl to match against provider-specific headers like
+  /// X-GitLab-NotificationReason or X-Spam-Status. After changing the
+  /// list, run `durian sync --backfill-headers` once to populate
+  /// existing messages.
+  indexed_headers: Listing<String>?
 }
 
 class AttachmentCacheConfig {


### PR DESCRIPTION
Closes #268.

## Why

Currently \`cli/internal/imap/sync_mailbox.go\` hardcodes a 7-entry allowlist of MIME headers that get fetched into \`message_headers\` and become available for \`rules.pkl\` \`header:\` matches. Real-world break: GitLab sends \`X-GitLab-NotificationReason\` (own_activity / assigned / mentioned) plus \`X-GitLab-Project-Path\`, \`X-GitLab-Issue-IID\`, etc. — and the only way to match against them today is to edit Go source, rebuild, and \`sync --backfill-headers\`.

## What

A new \`sync.indexed_headers\` field in \`config.pkl\`:

\`\`\`pkl
sync {
  indexed_headers {
    "X-GitLab-NotificationReason"
    "X-GitLab-Project-Path"
    "X-Spam-Status"
    "Auto-Submitted"
  }
}
\`\`\`

The runtime set is the case-insensitive union of the built-in seven (universal 80%) and the user entries (long tail). Built-ins stay code constants — they shouldn't be removable.

## Architecture

| Layer | Change |
|---|---|
| Schema | \`schema/Config.pkl\` — new \`indexed_headers: Listing<String>?\` under \`SyncConfig\` |
| Go config | \`cli/internal/config/types.go\` — new \`IndexedHeaders []string\` |
| Sync options | \`cli/internal/imap/sync.go\` — new \`IndexedHeaders\` field on \`SyncOptions\` |
| Merge logic | \`cli/internal/imap/sync_mailbox.go\` — renamed \`selectedHeaders\` → \`builtinSelectedHeaders\`; new \`(*Syncer).headerSet()\` does case-insensitive dedupe + merge |
| Call sites | \`sync_mailbox.go\` backfill + \`sync_store.go\` live-sync — both go through \`headerSet()\` |
| Plumbing | \`cli/cmd/durian/sync.go\`, \`cli/cmd/durian/serve.go\`, \`cli/internal/handler/watcher.go\` — pass \`cfg.Sync.IndexedHeaders\` into \`SyncOptions\` / \`NewWatcherManager\` |
| Validation | \`cli/internal/config/validate.go\` — reject malformed header names (must match \`[A-Za-z][A-Za-z0-9-]*\`); empty / whitespace dropped silently by the merge but caught at validate time so typos like \`"X Gitlab Reason "\` surface as user-actionable errors |
| Docs | \`docs/content/docs/configuration/config.md\` — \`indexed_headers\` row in \`sync\` table + worked example for GitLab |
| Test | \`cli/internal/imap/sync_test.go\` — \`TestHeaderSet_MergesBuiltinAndUser\` covers no-additions, additions, dedup against builtins, dedup within user list, empty / whitespace handling |

## Migration

After editing \`config.pkl\`:

\`\`\`bash
durian sync --backfill-headers
\`\`\`

Re-fetches the union for existing messages. New mail picks up the change automatically on the next sync.

## Test plan

- [x] \`bazel test //cli/internal/imap:imap_test //cli/internal/config:config_test //cli/internal/store:store_test\` — all green
- [ ] CI green
- [ ] Manual on a GitLab account: \`config.pkl\` + \`sync --backfill-headers\` + verify via \`durian show <thread> --headers\` (PR #266) that GitLab headers now appear

## Related

- #268 (this issue)
- PR #266 (\`durian show --headers\` — inspection path for the new headers)
- #269 (\`durian show --raw-headers\` — diagnostic path, future)