### PR TITLE
feat(go-show): --raw-headers fetches full header set from IMAP

### DIFF
--- a/cli/cmd/durian/show.go
+++ b/cli/cmd/durian/show.go
@@ -1,22 +1,28 @@
 package main
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
+	stdmail "net/mail"
+	"net/textproto"
 	"os"
 	"sort"
 	"strings"
 
+	"github.com/julion2/durian/cli/internal/config"
 	"github.com/julion2/durian/cli/internal/handler"
+	imapclient "github.com/julion2/durian/cli/internal/imap"
 	"github.com/julion2/durian/cli/internal/mail"
 	"github.com/julion2/durian/cli/internal/store"
 	"github.com/spf13/cobra"
 )
 
 var (
-	showHTML    bool
-	showHeaders bool
-	showHeader  string
+	showHTML       bool
+	showHeaders    bool
+	showHeader     string
+	showRawHeaders bool
 )
 
 var showCmd = &cobra.Command{
@@ -27,6 +33,8 @@ var showCmd = &cobra.Command{
   durian show 00000000000022ca --html
   durian show 00000000000022ca --headers
   durian show 00000000000022ca --header list-id
+  durian show 00000000000022ca --raw-headers
+  durian show 00000000000022ca --raw-headers --header x-gitlab-notificationreason
   durian show 00000000000022ca --json`,
 	Args: cobra.ExactArgs(1),
 	RunE: runShow,
@@ -35,7 +43,8 @@ var showCmd = &cobra.Command{
 func init() {
 	showCmd.Flags().BoolVar(&showHTML, "html", false, "show HTML body instead of plain text")
 	showCmd.Flags().BoolVar(&showHeaders, "headers", false, "print all stored headers per message instead of the body (useful for writing rules)")
-	showCmd.Flags().StringVar(&showHeader, "header", "", "print only this header (case-insensitive); implies --headers")
+	showCmd.Flags().StringVar(&showHeader, "header", "", "print only this header (case-insensitive); implies --headers unless --raw-headers is set")
+	showCmd.Flags().BoolVar(&showRawHeaders, "raw-headers", false, "fetch the full header block for each message from IMAP on demand (bypasses the indexed allowlist; requires network)")
 	rootCmd.AddCommand(showCmd)
 }
 
@@ -48,6 +57,9 @@ func runShow(cmd *cobra.Command, args []string) error {
 	}
 	defer emailDB.Close()
 
+	if showRawHeaders {
+		return runShowRawHeaders(emailDB, threadID, showHeader)
+	}
 	if showHeaders || showHeader != "" {
 		return runShowHeaders(emailDB, threadID, showHeader)
 	}
@@ -97,7 +109,114 @@ func runShowHeaders(emailDB *store.DB, threadID, filterName string) error {
 	if err != nil {
 		return fmt.Errorf("load headers: %w", err)
 	}
+	return printHeadersResult(msgs, headersByID, filterName, "no headers stored")
+}
 
+// runShowRawHeaders is the on-demand IMAP-fetch counterpart to
+// runShowHeaders. It groups the thread's messages by (account, mailbox)
+// to batch FETCH BODY.PEEK[HEADER], parses every header per message, and
+// prints via the same formatter. Bypasses the indexed allowlist entirely
+// — useful for "what does $provider actually send?" debugging.
+func runShowRawHeaders(emailDB *store.DB, threadID, filterName string) error {
+	msgs, err := emailDB.GetByThread(threadID)
+	if err != nil {
+		return fmt.Errorf("get thread: %w", err)
+	}
+	if len(msgs) == 0 {
+		return fmt.Errorf("no messages found for thread %s", threadID)
+	}
+
+	cfg := GetConfig()
+	if cfg == nil {
+		return fmt.Errorf("no configuration loaded")
+	}
+
+	// Group messages by (account, mailbox) so we open one IMAP connection
+	// per account and one SELECT per mailbox. UIDs within the same
+	// (account, mailbox) batch into a single FETCH.
+	type groupKey struct{ account, mailbox string }
+	type groupEntry struct {
+		msgs []*store.Message
+		uids []uint32
+	}
+	groups := make(map[groupKey]*groupEntry)
+	for _, m := range msgs {
+		if m.UID == 0 {
+			fmt.Fprintf(os.Stderr, "warning: message %s has no IMAP UID (synced before UID backfill?), skipping\n", m.MessageID)
+			continue
+		}
+		if m.Account == "" || m.Mailbox == "" {
+			fmt.Fprintf(os.Stderr, "warning: message %s has no account/mailbox (%q/%q), skipping\n", m.MessageID, m.Account, m.Mailbox)
+			continue
+		}
+		k := groupKey{m.Account, m.Mailbox}
+		g, ok := groups[k]
+		if !ok {
+			g = &groupEntry{}
+			groups[k] = g
+		}
+		g.msgs = append(g.msgs, m)
+		g.uids = append(g.uids, m.UID)
+	}
+
+	headersByID := make(map[int64]map[string][]string)
+	for k, g := range groups {
+		account, err := cfg.GetAccountByIdentifier(k.account)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "warning: no account config for %q, skipping %d message(s) in %s\n", k.account, len(g.msgs), k.mailbox)
+			continue
+		}
+		raw, err := fetchRawHeaders(account, k.mailbox, g.uids)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "warning: IMAP fetch failed for %s/%s: %v\n", k.account, k.mailbox, err)
+			continue
+		}
+		for _, m := range g.msgs {
+			rawBytes, ok := raw[m.UID]
+			if !ok {
+				continue
+			}
+			parsed, err := stdmail.ReadMessage(bytes.NewReader(append(rawBytes, '\r', '\n')))
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "warning: header parse failed for uid=%d in %s: %v\n", m.UID, k.mailbox, err)
+				continue
+			}
+			out := make(map[string][]string, len(parsed.Header))
+			for name, values := range parsed.Header {
+				out[textproto.CanonicalMIMEHeaderKey(name)] = values
+			}
+			headersByID[m.ID] = out
+		}
+	}
+
+	return printHeadersResult(msgs, headersByID, filterName, "no headers fetched (see warnings above)")
+}
+
+// fetchRawHeaders connects to the account's IMAP server, selects the
+// given mailbox, and BODY.PEEK[HEADER]-fetches the supplied UIDs.
+// Returns map[uid]rawHeaderBytes. Caller closes nothing — the IMAP
+// connection is created and closed inside this function.
+func fetchRawHeaders(account *config.AccountConfig, mailbox string, uids []uint32) (map[uint32][]byte, error) {
+	c := imapclient.NewClient(account)
+	if err := c.Connect(); err != nil {
+		return nil, fmt.Errorf("connect: %w", err)
+	}
+	defer c.Close()
+	if err := c.Authenticate(); err != nil {
+		return nil, fmt.Errorf("authenticate: %w", err)
+	}
+	if _, err := c.SelectMailbox(mailbox); err != nil {
+		return nil, fmt.Errorf("select %s: %w", mailbox, err)
+	}
+	return c.FetchHeadersOnly(uids)
+}
+
+// printHeadersResult is the shared text/JSON formatter for both
+// runShowHeaders (DB-indexed) and runShowRawHeaders (IMAP-fetched).
+// emptyMsg is shown per-message when the headers map for that message
+// is empty after filtering — differs between "no headers stored" and
+// "no headers fetched".
+func printHeadersResult(msgs []*store.Message, headersByID map[int64]map[string][]string, filterName, emptyMsg string) error {
 	// JSON: nested by message_id (RFC-5322), preserving order.
 	if jsonOutput {
 		type messageHeaders struct {
@@ -132,11 +251,10 @@ func runShowHeaders(emailDB *store.DB, threadID, filterName string) error {
 			if filterName != "" {
 				fmt.Printf("  (no %s header)\n", filterName)
 			} else {
-				fmt.Println("  (no headers stored)")
+				fmt.Printf("  (%s)\n", emptyMsg)
 			}
 			continue
 		}
-		// Sort header names for stable output.
 		names := make([]string, 0, len(h))
 		for name := range h {
 			names = append(names, name)


### PR DESCRIPTION
Closes #269.

## Why

\`durian show --headers\` (PR #266) only sees what was indexed at sync time — the builtin allowlist plus the user's \`sync.indexed_headers\` (PR #270). That's useless as a diagnostic when the question is "what does \$provider actually send?" — because if a header wasn't on the list, it was never stored, and a search returns empty whether the header is missing OR just not on the allowlist.

Concrete trigger: I ran \`durian show <gitlab-thread> --headers | grep -i gitlab\` to verify GitLab habric ships \`X-GitLab-NotificationReason\`. Got nothing — but I can't tell whether GitLab habric routes through SES strip the headers or my \`indexed_headers\` config has the wrong name.

## What

\`\`\`
durian show <thread> --raw-headers
durian show <thread> --raw-headers --header x-gitlab-notificationreason
durian show <thread> --raw-headers --json
\`\`\`

Fetches every header from IMAP on demand via \`BODY.PEEK[HEADER]\`, parses with \`net/mail\`, prints via the same formatter as \`--headers\`. Bypasses the indexed allowlist entirely.

## Implementation

- Reuses \`(*imap.Client).FetchHeadersOnly\` (already exists, used by \`sync --backfill-headers\`).
- Reuses the IMAP connect/auth pattern from \`send.go\`'s Sent-folder copy.
- Messages grouped by \`(account, mailbox)\` — one IMAP connection per account, one \`SELECT\` per mailbox, UIDs within a group batch into a single \`FETCH\`. Threads with messages across multiple mailboxes (e.g., one in INBOX, one in Sent) handle gracefully.
- Shared formatter \`printHeadersResult\` so \`--headers\` and \`--raw-headers\` produce identical text + JSON shapes. Scripts that consume one work on the other.
- Partial-success error handling: per-message failures (missing UID, no account config, IMAP failure, parse failure) print warnings to stderr and continue. Better than failing the whole thread on one bad message.

## Trade-off vs. \`--headers\`

| Flag | Source | Offline | Performance | Use case |
|---|---|---|---|---|
| \`--headers\` | local DB | yes | instant (decrypt only) | check what's indexed (rule-writing) |
| \`--raw-headers\` | IMAP fetch | no | one round-trip per (account, mailbox) | discover what provider sends |

Complementary, not redundant. Typical workflow:

1. \`--raw-headers\` to discover the actual header set
2. Add the names to \`sync.indexed_headers\` in \`config.pkl\`
3. \`durian sync --backfill-headers\`
4. \`--headers\` to verify they're now indexed
5. Write the \`rules.pkl\` entry

## Test plan

- [x] \`bazel build //cli/cmd/durian\` clean
- [x] CI green
- [ ] Manual on a real GitLab/GitHub thread: \`durian show <thread> --raw-headers --header x-gitlab-notificationreason\` returns the value (or proves it's not sent at all)
- [x] \`--json\` output round-trips through \`jq\`
- [x] Multi-mailbox thread (message in INBOX + reply in Sent) works without spurious warnings