### PR TITLE
fix(go-sync): --force for backfill-headers (re-fetch after indexed_headers change)

### DIFF
--- a/cli/cmd/durian/sync.go
+++ b/cli/cmd/durian/sync.go
@@ -18,7 +18,8 @@ var (
 	syncNoFlags         bool
 	syncDownloadOnly    bool
 	syncUploadOnly      bool
-	syncBackfillHeaders bool
+	syncBackfillHeaders      bool
+	syncBackfillHeadersForce bool
 )
 
 var syncCmd = &cobra.Command{
@@ -48,7 +49,8 @@ func init() {
 	syncCmd.Flags().BoolVar(&syncNoFlags, "no-flags", false, "skip flag synchronization")
 	syncCmd.Flags().BoolVar(&syncDownloadOnly, "download-only", false, "only download from server (no flag upload)")
 	syncCmd.Flags().BoolVar(&syncUploadOnly, "upload-only", false, "only upload local changes to server")
-	syncCmd.Flags().BoolVar(&syncBackfillHeaders, "backfill-headers", false, "fetch and store headers for existing messages")
+	syncCmd.Flags().BoolVar(&syncBackfillHeaders, "backfill-headers", false, "fetch and store headers for messages that don't have any yet")
+	syncCmd.Flags().BoolVar(&syncBackfillHeadersForce, "force", false, "with --backfill-headers, re-fetch headers for ALL messages even if they already have some (needed after changing sync.indexed_headers in config.pkl)")
 
 	rootCmd.AddCommand(syncCmd)
 }
@@ -89,8 +91,9 @@ func runSync(cmd *cobra.Command, args []string) error {
 		Mode:            mode,
 		Store:           emailDB,
 		FilterRules:     rules,
-		BackfillHeaders: syncBackfillHeaders,
-		IndexedHeaders:  GetConfig().Sync.IndexedHeaders,
+		BackfillHeaders:      syncBackfillHeaders,
+		BackfillHeadersForce: syncBackfillHeadersForce,
+		IndexedHeaders:       GetConfig().Sync.IndexedHeaders,
 		Groups:          func() map[string]config.GroupEntry { g, _ := config.LoadGroups(""); return g }(),
 	}
 

--- a/cli/internal/imap/sync.go
+++ b/cli/internal/imap/sync.go
@@ -56,8 +56,9 @@ type SyncOptions struct {
 	Store           *store.DB                    // SQLite store (required)
 	FilterRules     []config.RuleConfig          // User-defined filter rules applied at insert time
 	Groups          map[string]config.GroupEntry // Contact groups for group: expansion in rules
-	BackfillHeaders bool                         // Fetch and store headers for existing messages
-	IndexedHeaders  []string                     // User-added MIME header names to index on top of builtinSelectedHeaders (see sync_mailbox.go)
+	BackfillHeaders      bool     // Fetch and store headers for existing messages
+	BackfillHeadersForce bool     // With BackfillHeaders, re-fetch every message even if it already has rows in message_headers — needed after sync.indexed_headers changes
+	IndexedHeaders       []string // User-added MIME header names to index on top of builtinSelectedHeaders (see sync_mailbox.go)
 }
 
 // SyncResult contains the results of a sync operation

--- a/cli/internal/imap/sync_mailbox.go
+++ b/cli/internal/imap/sync_mailbox.go
@@ -109,8 +109,14 @@ func (s *Syncer) uidsNeedingHeaderBackfill(mboxState *MailboxState) []uint32 {
 		if err != nil || dbID == 0 {
 			continue
 		}
-		if has, _ := s.store.HasHeaders(dbID); has {
-			continue
+		// Without --force, skip messages that already have at least one
+		// header row — incremental backfill. With --force, refetch
+		// everything; needed after the user changes sync.indexed_headers
+		// because the existing rows reflect the old configured set.
+		if !s.options.BackfillHeadersForce {
+			if has, _ := s.store.HasHeaders(dbID); has {
+				continue
+			}
 		}
 		uids = append(uids, uid)
 	}


### PR DESCRIPTION
## Bug

The skip in \`uidsNeedingHeaderBackfill\` (\`cli/internal/imap/sync_mailbox.go:112\`) treats "has any \`message_headers\` row" as "done":

\`\`\`go
if has, _ := s.store.HasHeaders(dbID); has {
    continue
}
\`\`\`

That's incremental-backfill optimization. But when the user extends \`sync.indexed_headers\` in \`config.pkl\` (PR #270 feature), re-running \`durian sync --backfill-headers\` does **nothing** for the existing 2k+ messages — they all have \`List-Id\` from the first run, so they get skipped. The newly-configured headers (e.g. \`X-Gitlab-Pipeline-Status\`) are never fetched. Discovered by Julian after live-testing PR #270 + #271 against a GitLab/Microsoft account.

## Fix

New \`--force\` flag bypasses the skip:

\`\`\`bash
durian sync --backfill-headers --force h
\`\`\`

Used exactly when the configured set changes. Without \`--force\`, incremental behaviour unchanged (no regression for the common case).

\`InsertHeader\` is \`INSERT OR REPLACE\` on \`(message_id, name)\` so re-running on populated rows is idempotent — headers that haven't changed get the same ciphertext back, headers that now match the new set get fresh rows.

## Test plan

- [x] \`bazel test //cli/internal/imap:imap_test\` green
- [x] \`bazel build //cli/cmd/durian\` clean
- [ ] CI green
- [ ] Manual: extend \`indexed_headers\` with \`X-Gitlab-Pipeline-Status\`, run \`durian sync --backfill-headers --force h\`, verify \`durian show <gitlab-thread> --headers | grep -i gitlab\` returns the new headers

## Related

- PR #270 (\`indexed_headers\` config) — the feature whose extension this fix unblocks
- PR #271 (\`--raw-headers\`) — the diagnostic that surfaced the bug
- Future: smart-detect via config-hash version stamp in metadata table — eliminates the need for explicit \`--force\`. Tracked separately.