### PR TITLE
doc: document headers workflow (--headers / --raw-headers / --force)

### DIFF
--- a/cli/cmd/durian/sync.go
+++ b/cli/cmd/durian/sync.go
@@ -13,11 +13,11 @@ import (
 )
 
 var (
-	syncDryRun          bool
-	syncQuiet           bool
-	syncNoFlags         bool
-	syncDownloadOnly    bool
-	syncUploadOnly      bool
+	syncDryRun               bool
+	syncQuiet                bool
+	syncNoFlags              bool
+	syncDownloadOnly         bool
+	syncUploadOnly           bool
 	syncBackfillHeaders      bool
 	syncBackfillHeadersForce bool
 )
@@ -85,16 +85,16 @@ func runSync(cmd *cobra.Command, args []string) error {
 
 	// Build sync options
 	options := &imap.SyncOptions{
-		DryRun:          syncDryRun,
-		Quiet:           syncQuiet,
-		NoFlags:         syncNoFlags,
-		Mode:            mode,
-		Store:           emailDB,
-		FilterRules:     rules,
+		DryRun:               syncDryRun,
+		Quiet:                syncQuiet,
+		NoFlags:              syncNoFlags,
+		Mode:                 mode,
+		Store:                emailDB,
+		FilterRules:          rules,
 		BackfillHeaders:      syncBackfillHeaders,
 		BackfillHeadersForce: syncBackfillHeadersForce,
 		IndexedHeaders:       GetConfig().Sync.IndexedHeaders,
-		Groups:          func() map[string]config.GroupEntry { g, _ := config.LoadGroups(""); return g }(),
+		Groups:               func() map[string]config.GroupEntry { g, _ := config.LoadGroups(""); return g }(),
 	}
 
 	// Determine which accounts to sync

--- a/cli/internal/imap/sync.go
+++ b/cli/internal/imap/sync.go
@@ -48,17 +48,17 @@ var specialUseFolderTags = map[string]FolderTagMapping{
 
 // SyncOptions configures the sync behavior
 type SyncOptions struct {
-	DryRun          bool
-	Quiet           bool
-	NoFlags         bool                         // Skip flag synchronization
-	Mode            SyncMode                     // Sync direction
-	Mailboxes       []string                     // Specific mailboxes to sync (empty = all)
-	Store           *store.DB                    // SQLite store (required)
-	FilterRules     []config.RuleConfig          // User-defined filter rules applied at insert time
-	Groups          map[string]config.GroupEntry // Contact groups for group: expansion in rules
-	BackfillHeaders      bool     // Fetch and store headers for existing messages
-	BackfillHeadersForce bool     // With BackfillHeaders, re-fetch every message even if it already has rows in message_headers — needed after sync.indexed_headers changes
-	IndexedHeaders       []string // User-added MIME header names to index on top of builtinSelectedHeaders (see sync_mailbox.go)
+	DryRun               bool
+	Quiet                bool
+	NoFlags              bool                         // Skip flag synchronization
+	Mode                 SyncMode                     // Sync direction
+	Mailboxes            []string                     // Specific mailboxes to sync (empty = all)
+	Store                *store.DB                    // SQLite store (required)
+	FilterRules          []config.RuleConfig          // User-defined filter rules applied at insert time
+	Groups               map[string]config.GroupEntry // Contact groups for group: expansion in rules
+	BackfillHeaders      bool                         // Fetch and store headers for existing messages
+	BackfillHeadersForce bool                         // With BackfillHeaders, re-fetch every message even if it already has rows in message_headers — needed after sync.indexed_headers changes
+	IndexedHeaders       []string                     // User-added MIME header names to index on top of builtinSelectedHeaders (see sync_mailbox.go)
 }
 
 // SyncResult contains the results of a sync operation

--- a/docs/content/docs/cli/encryption-at-rest.md
+++ b/docs/content/docs/cli/encryption-at-rest.md
@@ -79,6 +79,19 @@ IMAP-sourced mail is recoverable — re-sync from the server with a fresh keyrin
 
 So: export the master at least once, soon. The `durian master-key export` command is the entire disaster-recovery story.
 
+## Inspecting headers
+
+Because `message_headers.value` is encrypted at rest, raw `sqlite3` access doesn't work for inspecting individual mail headers anymore. Two CLI flags are the canonical replacement:
+
+```bash
+durian show <thread-id> --headers                    # what's in the local DB right now
+durian show <thread-id> --header list-id             # filter to one header (case-insensitive)
+durian show <thread-id> --raw-headers                # bypass the indexed allowlist, fetch from IMAP
+durian show <thread-id> --raw-headers --header x-spam-status
+```
+
+`--headers` reads from `message_headers` and decrypts via the meta sub-key. `--raw-headers` does a `BODY.PEEK[HEADER]` IMAP fetch — useful when you want to see headers that aren't on the indexed allowlist (the built-in seven plus your `sync.indexed_headers`). See the [rules-writing walkthrough](../../configuration/rules/#finding-the-header-value-for-a-rule).
+
 ## Performance
 
 On Apple M2: ~290 ns per AES-GCM decrypt on the hot path with the cached AEAD (PR #258, [#254.1](https://github.com/julion2/durian/pull/258)). A full-mailbox scan of 50,000 messages costs ~15 ms of crypto work — dwarfed by SQLite row I/O and IMAP latency.

--- a/docs/content/docs/cli/reference.md
+++ b/docs/content/docs/cli/reference.md
@@ -24,7 +24,8 @@ durian sync --debug                  # verbose logging to stderr
 durian sync --upload-only            # only push local tag/flag changes
 durian sync --download-only          # only fetch from server
 durian sync --no-flags               # skip flag sync (bodies only)
-durian sync --backfill-headers       # refetch headers for existing rows
+durian sync --backfill-headers       # fetch headers for messages that don't have any yet
+durian sync --backfill-headers --force  # re-fetch headers for ALL messages (after editing sync.indexed_headers)
 durian sync --dry-run                # report what would happen, write nothing
 ```
 
@@ -56,11 +57,17 @@ Tags must be prefixed with `+` (add) or `-` (remove). Both can be mixed in one c
 ## show — display a thread
 
 ```bash
-durian show <thread-id>
-durian show <thread-id> --html
+durian show <thread-id>                                   # plain-text body
+durian show <thread-id> --html                            # HTML body
+durian show <thread-id> --headers                         # indexed MIME headers per message (local, fast)
+durian show <thread-id> --header list-id                  # single header by name (implies --headers)
+durian show <thread-id> --raw-headers                     # full header block from IMAP (network, slow)
+durian show <thread-id> --raw-headers --header x-spam-status
 ```
 
 Renders the thread to stdout — useful for piping into `less` or grepping a specific thread.
+
+`--headers` shows what Durian indexed at sync time (`sync.indexed_headers` plus the built-in seven). `--raw-headers` does an on-demand IMAP `BODY.PEEK[HEADER]` fetch — useful for discovering what a provider actually sends before deciding what to add to `indexed_headers`. See [Encryption at rest](encryption-at-rest/#inspecting-headers) and the [Writing rules](../configuration/rules/#finding-the-header-value-for-a-rule) walkthrough.
 
 ## attachment — list or download
 

--- a/docs/content/docs/configuration/rules.md
+++ b/docs/content/docs/configuration/rules.md
@@ -29,6 +29,28 @@ rules {
 | `remove_tags` | `Listing<String>?` | Tags to remove on match |
 | `accounts` | `Listing<String>?` | Restrict rule to certain account aliases |
 
+## Finding the header value for a rule
+
+Before writing a `header:Name:value` rule, you usually want to know what the provider actually sends. Two CLI flags help:
+
+```bash
+durian show <thread-id> --headers                    # what's in the local DB right now
+durian show <thread-id> --raw-headers                # full set from IMAP, on demand
+durian show <thread-id> --raw-headers --header x-gitlab-pipeline-status
+```
+
+`--headers` shows the indexed subset (the built-in seven plus your `sync.indexed_headers` from `config.pkl`). `--raw-headers` bypasses the allowlist and fetches the whole header block from the server — use it to discover headers you didn't know about yet.
+
+Typical workflow when a new provider shows up:
+
+1. `durian show <thread> --raw-headers | grep -iE 'gitlab|spam|list'` — find the candidate.
+2. Add the names to `sync.indexed_headers` in `config.pkl` and run `durian validate`.
+3. `durian sync --backfill-headers --force <account>` — re-indexes the existing messages against the new set. `--force` is required because the incremental skip otherwise treats "has any header" as "done".
+4. `durian show <thread> --headers` — confirm the values are now in the local DB.
+5. Write the `header:Name:value` rule and `durian rules apply --dry-run`.
+
+See [Encryption at rest § Inspecting headers](../../cli/encryption-at-rest/#inspecting-headers).
+
 ## Match syntax
 
 The same operators as `durian search`, with extra header/attachment matchers:

--- a/docs/content/docs/gui/search.md
+++ b/docs/content/docs/gui/search.md
@@ -16,8 +16,8 @@ Durian uses notmuch-style queries — terms are ANDed by default; `OR` and `NOT`
 | `from:alice@example.com` | Sender contains substring |
 | `to:me@you.com` | Recipient contains substring |
 | `subject:invoice` | Subject contains substring |
-| `header:list-id:` | Header present (any value) |
-| `header:x-spam-score:5` | Header value contains substring |
+| `header:list-id:` | Header present (any value). **Note:** only available in `rules.pkl` match clauses, not in search queries yet — tracked in [#265](https://github.com/julion2/durian/issues/265). |
+| `header:x-spam-score:5` | Header value contains substring. Same restriction as above. |
 | `has:attachment` | Has any attachment |
 | `has:attachment:pdf` | Has a PDF attachment |
 | `path:Work/Projects` | IMAP folder path |


### PR DESCRIPTION
Closes #267.

End-to-end docs for the headers → rule workflow that landed across PRs #266, #270, #271, #272.

## Touched

| File | What |
|---|---|
| \`docs/content/docs/cli/reference.md\` | \`show\` section lists \`--headers\`, \`--header\`, \`--raw-headers\` with examples + cross-links. \`sync\` section gains the \`--force\` note. |
| \`docs/content/docs/configuration/rules.md\` | New "Finding the header value for a rule" section above Match syntax. Walks the discover → backfill → write → apply loop with concrete commands (the workflow Julian just live-tested against GitLab habric). |
| \`docs/content/docs/cli/encryption-at-rest.md\` | New "Inspecting headers" section explains the \`sqlite3\`-vs-CLI split now that values are encrypted. |
| \`docs/content/docs/gui/search.md\` | Clarifies \`header:\` works only in \`rules.pkl\` match clauses (not search queries yet) — link to #265. |

## Verified

- [x] \`cd docs && hugo --quiet\` clean
- [x] All four new anchor cross-links resolve in the rendered HTML (\`#finding-the-header-value-for-a-rule\`, \`#inspecting-headers\` on both consuming pages)
- [x] CI green

## Related

- PR #266 (\`--headers\` flag)
- PR #270 (\`indexed_headers\` config)
- PR #271 (\`--raw-headers\` IMAP fetch)
- PR #272 (\`--force\` for backfill after config change)
- #265 (shared parser — would allow \`header:\` in search queries)
- #273 (auto-detect indexed_headers change — eliminate need for \`--force\`)