### PR TITLE
perf(swift-webview): pool WebContent processes across email cards

### DIFF
--- a/macos/durian/Views/EditableWebView.swift
+++ b/macos/durian/Views/EditableWebView.swift
@@ -27,7 +27,14 @@ struct EditableWebView: NSViewRepresentable {
     var vimInsertExitKeys: [String] = []
 
     func makeNSView(context: Context) -> WKWebView {
+        // Per-instance config (userContentController + message handlers must
+        // belong to this single editor), but share the SharedWebKit.composePool
+        // so successive open-and-close compose windows reuse one WebContent
+        // process instead of spawning fresh. Distinct from the read-only pool
+        // — editor message handlers shouldn't share a process with rendered
+        // mail content.
         let config = WKWebViewConfiguration()
+        config.processPool = SharedWebKit.composePool
         config.defaultWebpagePreferences.allowsContentJavaScript = true
         config.preferences.javaScriptCanOpenWindowsAutomatically = false
 
@@ -43,6 +50,7 @@ struct EditableWebView: NSViewRepresentable {
         config.userContentController.add(handler, name: "vimSearch")
 
         let webView = ScrollPassthroughWebView(frame: .zero, configuration: config)
+        SharedWebKit.applyEnergyDefaults(to: webView)
         #if DEBUG
         webView.isInspectable = true
         #endif
@@ -235,6 +243,12 @@ struct EditableWebView: NSViewRepresentable {
 
     func makeCoordinator() -> Coordinator {
         Coordinator()
+    }
+
+    static func dismantleNSView(_ nsView: WKWebView, coordinator: Coordinator) {
+        // Stop in-flight loads on compose-window close so the editor's
+        // WebContent process doesn't keep doing work after dismissal.
+        nsView.stopLoading()
     }
 
     class Coordinator: NSObject, WKNavigationDelegate, WKScriptMessageHandler {

--- a/macos/durian/Views/NonScrollingWebView.swift
+++ b/macos/durian/Views/NonScrollingWebView.swift
@@ -9,6 +9,61 @@
 import SwiftUI
 import WebKit
 
+// MARK: - Shared WebKit infrastructure
+
+/// Pooled WebKit resources reused across every email-card WebView in the
+/// app. Without these, each NonScrollingWebView+EditableWebView creates its
+/// own WKWebViewConfiguration → its own WKProcessPool → its own WebContent
+/// process. A 20-message thread becomes 20+ WebContent processes, all
+/// independently suspended/resumed by macOS on every window-occlusion
+/// transition.
+///
+/// Activity Monitor pre-pooling: ~16k `WebKit:ProcessSuspension` events / 12h.
+/// Expected post-pooling: cuts to one process per pool, throttled by
+/// `suspendsActivityWhenWindowIsOccluded` when the window goes background.
+enum SharedWebKit {
+    /// Process pool shared by every read-only email-rendering WebView
+    /// (NonScrollingWebView). Lifetime = app process.
+    static let readOnlyPool = WKProcessPool()
+
+    /// Separate pool for the compose editor — keeps a stale editor renderer
+    /// from sharing a process with the reader fleet. The editor has its own
+    /// userContentController + message handlers, isolation is desirable.
+    static let composePool = WKProcessPool()
+
+    /// Ephemeral, in-memory data store shared across read-only WebViews.
+    /// Email HTML is CSP'd (`script-src 'none'`) so cookies/localStorage can
+    /// never be written. Sharing the HTTP cache means the same tracking
+    /// pixel / remote image across N cards is fetched once, not N times.
+    static let readOnlyDataStore: WKWebsiteDataStore = .nonPersistent()
+
+    /// Build a WKWebViewConfiguration pre-wired with the shared read-only
+    /// pool + data store + the read-only JS/window prefs. Returns a fresh
+    /// instance per call — the SHARED state is the inner pool, not the
+    /// config object.
+    static func makeReadOnlyConfig() -> WKWebViewConfiguration {
+        let config = WKWebViewConfiguration()
+        config.processPool = readOnlyPool
+        config.websiteDataStore = readOnlyDataStore
+        // JS is needed for one-shot height measurement; CSP blocks all
+        // inline + external scripts anyway.
+        config.defaultWebpagePreferences.allowsContentJavaScript = true
+        config.preferences.javaScriptCanOpenWindowsAutomatically = false
+        return config
+    }
+
+    /// Apply the runtime-only knobs that aren't part of WKWebViewConfiguration:
+    /// occlusion throttling, scroll passthrough flags, etc.
+    static func applyEnergyDefaults(to webView: WKWebView) {
+        // Throttle JS timers + CSS animations when the window is occluded
+        // (background, behind another window, etc.). Default is `false` —
+        // WebViews keep ticking layout/timer work even when invisible.
+        if webView.responds(to: NSSelectorFromString("setSuspendsActivityWhenWindowIsOccluded:")) {
+            webView.setValue(true, forKey: "suspendsActivityWhenWindowIsOccluded")
+        }
+    }
+}
+
 // MARK: - Custom WebView that passes scroll events to parent
 
 /// A WKWebView subclass that passes scroll wheel events to its parent ScrollView
@@ -38,31 +93,31 @@ struct NonScrollingWebView: NSViewRepresentable {
     }
     
     func makeNSView(context: Context) -> WKWebView {
-        let config = WKWebViewConfiguration()
-        
-        // Enable JavaScript for height measurement only
-        // Note: We need JS enabled to measure content height, but CSP blocks external scripts
-        config.defaultWebpagePreferences.allowsContentJavaScript = true
-        
-        // SECURITY: Disable auto-opening windows
-        config.preferences.javaScriptCanOpenWindowsAutomatically = false
-        
-        // Use custom WebView that passes scroll events to parent
-        let webView = ScrollPassthroughWebView(frame: .zero, configuration: config)
+        // Use the shared read-only config — same WKProcessPool and
+        // WKWebsiteDataStore across every email card in the app.
+        let webView = ScrollPassthroughWebView(frame: .zero, configuration: SharedWebKit.makeReadOnlyConfig())
+        SharedWebKit.applyEnergyDefaults(to: webView)
         #if DEBUG
         webView.isInspectable = true
         #endif
         webView.navigationDelegate = context.coordinator
-        
+
         // Transparent background (let parent handle background color)
         webView.setValue(false, forKey: "drawsBackground")
         webView.wantsLayer = true
         webView.layer?.backgroundColor = NSColor.clear.cgColor
-        
+
         context.coordinator.webView = webView
         context.coordinator.parent = self
-        
+
         return webView
+    }
+
+    static func dismantleNSView(_ nsView: WKWebView, coordinator: Coordinator) {
+        // Stop any in-flight HTML/image load on teardown so we don't keep
+        // the WebContent process awake doing work whose result no view
+        // will ever consume.
+        nsView.stopLoading()
     }
     
     func updateNSView(_ webView: WKWebView, context: Context) {


### PR DESCRIPTION
## Why

Each `NonScrollingWebView` previously created its own `WKWebViewConfiguration` — which means its own implicit `WKProcessPool` — which means a separate **WebContent process per email card**. A 20-message thread with signatures spawned 40 WebContent processes; macOS suspended/resumed each independently on every window-occlusion transition.

Activity Monitor showed Durian's GUI burning ~2.7% lifetime CPU avg with a high Energy Impact bar. `log show --last 12h --predicate 'process CONTAINS "urian"' --style compact | awk '{print $5}' | sort | uniq -c | sort -rn` surfaced the root cause:

| Subsystem | Events / 12h |
|---|---|
| `com.apple.network:connection` | 32k |
| `com.apple.CFNetwork:Default` | 18.5k |
| **`com.apple.WebKit:ProcessSuspension`** | **16.3k** |
| `com.apple.WebKit:PerformanceLogging` | 7.8k |
| `com.apple.WebKit:Process` | 7.7k |

This PR targets the three WebKit lines (~32k events / 12h). The network/CFNetwork lines are addressed separately in the IMAP watcher backoff work (PR2, sibling).

## What

New `SharedWebKit` namespace at the top of `NonScrollingWebView.swift`:

- `readOnlyPool: WKProcessPool` — shared by every email-render WebView
- `composePool: WKProcessPool` — separate, for the compose editor (distinct security and lifecycle profile)
- `readOnlyDataStore: WKWebsiteDataStore` — `.nonPersistent()`, shared. HTTP cache for remote images now reused across cards instead of N-times-refetched. Cookies / localStorage cannot be written because email HTML is CSP'd (`script-src 'none'`).
- `makeReadOnlyConfig()` — factory returning a fresh `WKWebViewConfiguration` pre-wired with the shared pool + data store.

`NonScrollingWebView.makeNSView` uses the factory instead of building per-instance config. `EditableWebView` keeps its per-instance `userContentController` and message handlers (those must be per-editor) but joins `SharedWebKit.composePool` so successive open-close-open compose windows reuse one WebContent process.

`dismantleNSView` on both representables calls `stopLoading()` — a closed thread or dismissed compose window doesn't keep the WebContent process awake fetching resources whose result no view will ever consume.

## Out of scope

`suspendsActivityWhenWindowIsOccluded` was an early candidate but turns out to be iOS-only — there is no public macOS WKWebView property for occlusion throttling. The selector doesn't even exist via `responds(to:)` on macOS 14+. Throttling on occlusion would have to listen for `NSWindow.didChangeOcclusionStateNotification` and pause manually; tracked as a follow-up. The shared process pool is the dominant win on its own.

## Tests

`macos/tests/SharedWebKitTests.swift` — 11 tests pin the contract:

- pool identity (`readOnlyPool` and `composePool` are stable singletons, distinct from each other)
- data store identity (`.nonPersistent()`, shared instance)
- config factory: returns fresh `WKWebViewConfiguration` per call, but the **inner** pool + data store references are the same shared instances; JS allowed (height measurement), auto-window-open blocked

```bash
bazel test //macos:shared_webkit_test  # 11 tests pass
bazel build //macos:Durian             # clean
```

Manual UI smoke-test on a real config (12 accounts incl. GitLab/M365): inbox scroll, multi-message thread render, compose editor — all visually identical to pre-PR. No content cut off, no missing images, no broken styling.

## Soak measurement

Energy Impact reduction isn't conclusively measurable in a 5-minute window. The honest comparison needs 12h of mixed active+idle usage against the historical 16k `WebKit:ProcessSuspension` baseline. Will follow up in this PR's comments once I have 12h on the new build.

## Related

- PR2 (sibling, IMAP watcher IDLE-failure backoff): addresses the `com.apple.network:connection` 32k events
- Future: NSWindow occlusion-state pause as a separate change
- #275 (silent Pkl-parse failure → "No accounts" — surfaced today during this work, separate)